### PR TITLE
fix(env): eliminate SetEnvPrefix data races

### DIFF
--- a/env.go
+++ b/env.go
@@ -60,15 +60,15 @@ func GetOrSetAppName(name, cName string) string {
 // The prefix is automatically appended with an underscore when generating environment variable names.
 func SetEnvPrefix(str string) {
 	if str == "" {
-		internalenv.Prefix = ""
+		internalenv.SetPrefix("")
 
 		return
 	}
 
-	internalenv.Prefix = fmt.Sprintf("%s%s", strings.TrimSuffix(internalenv.NormEnv(str), internalenv.EnvSep), internalenv.EnvSep)
+	internalenv.SetPrefix(fmt.Sprintf("%s%s", strings.TrimSuffix(internalenv.NormEnv(str), internalenv.EnvSep), internalenv.EnvSep))
 }
 
 // EnvPrefix returns the current global environment variable prefix without the trailing underscore.
 func EnvPrefix() string {
-	return strings.TrimSuffix(internalenv.Prefix, internalenv.EnvSep)
+	return strings.TrimSuffix(internalenv.GetPrefix(), internalenv.EnvSep)
 }


### PR DESCRIPTION
## Summary
- add a concurrent prefix test (TestEnvPrefix_ConcurrentSetAndGet) to reproduce data races under go test -race
- make env prefix storage thread-safe in internal/env via atomic accessors
- route SetEnvPrefix and EnvPrefix through thread-safe internal accessors
- make GetEnv read a single prefix snapshot per invocation

## Verification
- go test -race ./internal/env (before fix: race detected, after fix: pass)
- go test ./...