### PR TITLE
fix: apply defaults when unmarshal runs on leaf command

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2672,7 +2672,7 @@ func TestUnmarshal_KeyRemapping_Characterization(t *testing.T) {
 		assert.Equal(t, "postgres://leaf-level", opts.Database.URL)
 	})
 
-	t.Run("root_defined_default_is_not_applied_when_unmarshal_runs_on_leaf_command", func(t *testing.T) {
+	t.Run("root_defined_default_is_applied_when_unmarshal_runs_on_leaf_command", func(t *testing.T) {
 		setup()
 
 		rootCmd := &cobra.Command{Use: "app"}
@@ -2683,7 +2683,7 @@ func TestUnmarshal_KeyRemapping_Characterization(t *testing.T) {
 		require.NoError(t, opts.Attach(rootCmd))
 
 		require.NoError(t, structcli.Unmarshal(leafCmd, opts))
-		assert.Equal(t, "", opts.Database.URL)
+		assert.Equal(t, "postgres://default", opts.Database.URL)
 	})
 
 	t.Run("separate_command_trees_keep_remapping_independent_for_distinct_aliases", func(t *testing.T) {

--- a/viper.go
+++ b/viper.go
@@ -51,6 +51,16 @@ func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookF
 		return true
 	})
 
+	// Re-apply explicit struct tag defaults to the command-scoped viper.
+	// Defaults are initially set during Define on that command's scope; when Unmarshal
+	// is executed on a leaf command, we must set them again on the leaf scope.
+	for alias, defval := range defaultsMap {
+		vip.SetDefault(alias, defval)
+		if path, ok := aliasToPathMap[alias]; ok {
+			vip.SetDefault(path, defval)
+		}
+	}
+
 	// Use `KeyRemappingHook` for smart config keys
 	hooks = append([]mapstructure.DecodeHookFunc{internalconfig.KeyRemappingHook(aliasToPathMap, defaultsMap)}, hooks...)
 


### PR DESCRIPTION
## Summary
- re-apply explicit struct tag defaults into the current command-scoped viper during Unmarshal
- ensure defaults are set for both alias keys and remapped nested paths
- update characterization to assert root-defined defaults are applied when Unmarshal runs on a leaf command

## Why stacked
- this PR is based on #36 and should be reviewed/merged after #36

## Testing
- go test -run TestUnmarshal_KeyRemapping_Characterization ./...
- go test ./...
- go test -race ./...