### PR TITLE
feat(config): add opt-in config key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ Easily set up configuration file discovery (flag, environment variable, and fall
 structcli.SetupConfig(rootCmd, config.Options{AppName: "full"})
 ```
 
+Enable strict config-key validation with:
+
+```go
+structcli.SetupConfig(rootCmd, config.Options{
+  AppName:      "full",
+  ValidateKeys: true, // opt-in
+})
+```
+
+When enabled, `Unmarshal` fails if command-relevant config contains unknown keys.
+
 Call `SetupConfig` before attaching/defining options when you rely on app-prefixed environment variables, so the env prefix is initialized before env annotations are generated.
 
 The line above:

--- a/config/types.go
+++ b/config/types.go
@@ -18,10 +18,11 @@ const (
 
 // Options defines configuration file behavior and search paths.
 type Options struct {
-	AppName     string
-	FlagName    string           // Name of config flag (defaults to "config")
-	ConfigName  string           // Config file name without extension (defaults to "config")
-	EnvVar      string           // Environment variable (defaults to {APP}_CONFIG)
-	SearchPaths []SearchPathType // Search path strategies (defaults to common paths)
-	CustomPaths []string         // Custom search paths (when SearchPaths contains SearchPathCustom)
+	AppName      string
+	FlagName     string           // Name of config flag (defaults to "config")
+	ConfigName   string           // Config file name without extension (defaults to "config")
+	EnvVar       string           // Environment variable (defaults to {APP}_CONFIG)
+	SearchPaths  []SearchPathType // Search path strategies (defaults to common paths)
+	CustomPaths  []string         // Custom search paths (when SearchPaths contains SearchPathCustom)
+	ValidateKeys bool             // Opt-in strict key validation during Unmarshal (default: false)
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,137 @@
+package internalconfig
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// ValidateKeys decodes command-relevant config values into opts' shape and fails
+// when unknown keys are present.
+func ValidateKeys(configValues map[string]any, opts any, hooks ...mapstructure.DecodeHookFunc) error {
+	if len(configValues) == 0 {
+		return nil
+	}
+
+	target, err := decodeTarget(opts)
+	if err != nil {
+		return err
+	}
+
+	metadata := &mapstructure.Metadata{}
+	cfg := &mapstructure.DecoderConfig{
+		Result:           target,
+		Metadata:         metadata,
+		WeaklyTypedInput: true,
+	}
+	if len(hooks) > 0 {
+		cfg.DecodeHook = mapstructure.ComposeDecodeHookFunc(hooks...)
+	}
+
+	decoder, err := mapstructure.NewDecoder(cfg)
+	if err != nil {
+		return fmt.Errorf("couldn't create config validator: %w", err)
+	}
+	if err := decoder.Decode(configValues); err != nil {
+		return err
+	}
+
+	if len(metadata.Unused) == 0 {
+		return nil
+	}
+
+	knownKeys := knownConfigKeys(reflect.TypeOf(opts))
+	unknown := make([]string, 0, len(metadata.Unused))
+	for _, key := range metadata.Unused {
+		norm := strings.ToLower(key)
+		if _, ok := knownKeys[norm]; ok {
+			continue
+		}
+		unknown = append(unknown, norm)
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	unique := dedupe(unknown)
+	sort.Strings(unique)
+
+	return fmt.Errorf("unknown config keys: %s", strings.Join(unique, ", "))
+}
+
+func decodeTarget(opts any) (any, error) {
+	T := reflect.TypeOf(opts)
+	if T == nil {
+		return nil, fmt.Errorf("couldn't validate config: nil options target")
+	}
+	if T.Kind() == reflect.Ptr {
+		T = T.Elem()
+	}
+	if T.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("couldn't validate config: options target must be a struct")
+	}
+
+	return reflect.New(T).Interface(), nil
+}
+
+func dedupe(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+
+	return out
+}
+
+func knownConfigKeys(T reflect.Type) map[string]struct{} {
+	out := make(map[string]struct{})
+	collectKnownConfigKeys(T, "", out)
+
+	return out
+}
+
+func collectKnownConfigKeys(T reflect.Type, prefix string, out map[string]struct{}) {
+	if T == nil {
+		return
+	}
+	if T.Kind() == reflect.Ptr {
+		T = T.Elem()
+	}
+	if T.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := range T.NumField() {
+		f := T.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+
+		fieldName := strings.ToLower(f.Name)
+		out[prefix+fieldName] = struct{}{}
+
+		alias := strings.ToLower(f.Tag.Get("flag"))
+		if alias != "" {
+			out[prefix+alias] = struct{}{}
+		}
+
+		nestedType := f.Type
+		if nestedType.Kind() == reflect.Ptr {
+			nestedType = nestedType.Elem()
+		}
+		if nestedType.Kind() == reflect.Struct {
+			collectKnownConfigKeys(nestedType, prefix+fieldName+".", out)
+			if alias != "" && alias != fieldName {
+				collectKnownConfigKeys(nestedType, prefix+alias+".", out)
+			}
+		}
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,77 @@
+package internalconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type validateDatabaseOptions struct {
+	URL string `flag:"db-url"`
+}
+
+type validateServiceOptions struct {
+	Port     int `flag:"port"`
+	Database validateDatabaseOptions
+}
+
+func TestValidateKeys_EmptyMap(t *testing.T) {
+	err := ValidateKeys(map[string]any{}, &validateServiceOptions{})
+	require.NoError(t, err)
+}
+
+func TestValidateKeys_NilTarget(t *testing.T) {
+	err := ValidateKeys(map[string]any{"port": 8080}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil options target")
+}
+
+func TestValidateKeys_NonStructTarget(t *testing.T) {
+	var target string
+	err := ValidateKeys(map[string]any{"port": 8080}, &target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a struct")
+}
+
+func TestValidateKeys_UnknownTopLevelKey(t *testing.T) {
+	err := ValidateKeys(map[string]any{
+		"port":  8080,
+		"extra": "nope",
+	}, &validateServiceOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config keys")
+	assert.Contains(t, err.Error(), "extra")
+}
+
+func TestValidateKeys_UnknownNestedKey(t *testing.T) {
+	err := ValidateKeys(map[string]any{
+		"database": map[string]any{
+			"url":   "postgres://localhost/db",
+			"extra": "nope",
+		},
+	}, &validateServiceOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config keys")
+	assert.Contains(t, err.Error(), "database.extra")
+}
+
+func TestValidateKeys_FlattenedAliasKey(t *testing.T) {
+	err := ValidateKeys(
+		map[string]any{
+			"db-url": "postgres://localhost/db",
+		},
+		&validateServiceOptions{},
+		KeyRemappingHook(map[string]string{"db-url": "database.url"}, map[string]string{}),
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateKeys_AcceptsNestedFieldNameKey(t *testing.T) {
+	err := ValidateKeys(map[string]any{
+		"database": map[string]any{
+			"url": "postgres://localhost/db",
+		},
+	}, &validateServiceOptions{})
+	require.NoError(t, err)
+}

--- a/internal/config/viper.go
+++ b/internal/config/viper.go
@@ -103,6 +103,10 @@ func SyncMandatoryFlags(c *cobra.Command, T reflect.Type, vip *viper.Viper, stru
 // It correctly handles flattened keys that point to nested struct fields.
 func KeyRemappingHook(aliasToPathMap map[string]string, defaultsMap map[string]string) mapstructure.DecodeHookFunc {
 	return func(_ reflect.Type, t reflect.Type, data any) (any, error) {
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+
 		// Only when decoding into a struct...
 		if t.Kind() != reflect.Struct {
 			return data, nil

--- a/viper.go
+++ b/viper.go
@@ -127,6 +127,12 @@ func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookF
 		}
 	})
 
+	if validateConfigKeysEnabled(c) {
+		if err := internalconfig.ValidateKeys(scopedConfigToMerge, opts, hooks...); err != nil {
+			return fmt.Errorf("invalid config file values: %w", err)
+		}
+	}
+
 	decodeHook := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		hooks...,
 	))


### PR DESCRIPTION
## Summary
- add opt-in strict config-key validation via `config.Options.ValidateKeys`
- validate command-relevant config keys during `Unmarshal` and fail on unknown keys when enabled
- keep default behavior unchanged when validation is disabled
- add unit tests for validator behavior and integration tests for end-to-end SetupConfig/UseConfig/Unmarshal flows
- document strict validation usage in README

## Validation
- `GOCACHE=/tmp/go-build go test ./...`
- `GOCACHE=/tmp/go-build go test -race ./...`
- `GOCACHE=/tmp/go-build go test -coverprofile=/tmp/structcli.cover.out ./...`

## Coverage
- project total statements covered: `62.1%`