### PR TITLE
test: increase internal coverage and fix config remapping typo

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,0 +1,104 @@
+package internalcmd
+
+import (
+	"testing"
+
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecursivelyWrapRun_SkipsRunWhenDebugActive(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	runCalled := false
+	run := &cobra.Command{
+		Use: "run",
+		Run: func(_ *cobra.Command, _ []string) {
+			runCalled = true
+		},
+	}
+	root.AddCommand(run)
+	internalscope.Get(root).Viper().Set("debug-options", true)
+
+	RecursivelyWrapRun(root)
+	root.SetArgs([]string{"run"})
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.False(t, runCalled)
+}
+
+func TestRecursivelyWrapRun_SkipsRunEWhenDebugActive(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	runECalled := false
+	run := &cobra.Command{
+		Use: "run",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			runECalled = true
+			return nil
+		},
+	}
+	root.AddCommand(run)
+	internalscope.Get(root).Viper().Set("debug-options", true)
+
+	RecursivelyWrapRun(root)
+	root.SetArgs([]string{"run"})
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.False(t, runECalled)
+}
+
+func TestRecursivelyWrapRun_ExecutesWhenDebugInactive(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	runCalled := false
+	runECalled := false
+	run := &cobra.Command{
+		Use: "run",
+		Run: func(_ *cobra.Command, _ []string) {
+			runCalled = true
+		},
+	}
+	runE := &cobra.Command{
+		Use: "rune",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			runECalled = true
+			return nil
+		},
+	}
+	root.AddCommand(run, runE)
+
+	RecursivelyWrapRun(root)
+
+	root.SetArgs([]string{"run"})
+	require.NoError(t, root.Execute())
+	assert.True(t, runCalled)
+
+	root.SetArgs([]string{"rune"})
+	require.NoError(t, root.Execute())
+	assert.True(t, runECalled)
+}
+
+func TestRecursivelyWrapRun_IsIdempotentAndRecursive(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	mid := &cobra.Command{Use: "mid"}
+	leafCalls := 0
+	leaf := &cobra.Command{
+		Use: "leaf",
+		Run: func(_ *cobra.Command, _ []string) {
+			leafCalls++
+		},
+	}
+	root.AddCommand(mid)
+	mid.AddCommand(leaf)
+
+	RecursivelyWrapRun(root)
+	RecursivelyWrapRun(root)
+
+	assert.Equal(t, "true", root.Annotations[wrappedRunAnnotation])
+	assert.Equal(t, "true", mid.Annotations[wrappedRunAnnotation])
+	assert.Equal(t, "true", leaf.Annotations[wrappedRunAnnotation])
+
+	root.SetArgs([]string{"mid", "leaf"})
+	require.NoError(t, root.Execute())
+	assert.Equal(t, 1, leafCalls)
+}

--- a/internal/config/viper.go
+++ b/internal/config/viper.go
@@ -117,7 +117,7 @@ func KeyRemappingHook(aliasToPathMap map[string]string, defaultsMap map[string]s
 			return data, nil
 		}
 
-		// Hande flattened keys for nested structs
+		// Handle flattened keys for nested structs
 		for alias, path := range aliasToPathMap {
 			// Find nested paths like "database.url"
 			if strings.Contains(path, ".") {

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,0 +1,50 @@
+package internaldebug
+
+import (
+	"testing"
+
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDebugActive_DefaultFlag(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	run := &cobra.Command{Use: "run"}
+	root.AddCommand(run)
+	root.PersistentFlags().Bool("debug-options", false, "")
+
+	require.NoError(t, root.PersistentFlags().Set("debug-options", "true"))
+	assert.True(t, IsDebugActive(run))
+}
+
+func TestIsDebugActive_CustomFlagAnnotation(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	run := &cobra.Command{
+		Use:         "run",
+		Annotations: map[string]string{FlagAnnotation: "debug-mode"},
+	}
+	root.AddCommand(run)
+	root.PersistentFlags().Bool("debug-mode", false, "")
+
+	require.NoError(t, root.PersistentFlags().Set("debug-mode", "true"))
+	assert.True(t, IsDebugActive(run))
+}
+
+func TestIsDebugActive_FromScopedViper(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	run := &cobra.Command{Use: "run"}
+	root.AddCommand(run)
+
+	internalscope.Get(root).Viper().Set("debug-options", true)
+	assert.True(t, IsDebugActive(run))
+}
+
+func TestIsDebugActive_FalseWhenUnset(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	run := &cobra.Command{Use: "run"}
+	root.AddCommand(run)
+
+	assert.False(t, IsDebugActive(run))
+}

--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -1,0 +1,33 @@
+package internalpath
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type pathSample struct {
+	Value string
+}
+
+func TestGetName(t *testing.T) {
+	assert.Equal(t, "value", GetName("value", ""))
+	assert.Equal(t, "alias", GetName("value", "alias"))
+}
+
+func TestGetFieldName(t *testing.T) {
+	sf, ok := reflect.TypeOf(pathSample{}).FieldByName("Value")
+	assert.True(t, ok)
+
+	assert.Equal(t, "Value", GetFieldName("", sf))
+	assert.Equal(t, "Root.Value", GetFieldName("Root", sf))
+}
+
+func TestGetFieldPath(t *testing.T) {
+	sf, ok := reflect.TypeOf(pathSample{}).FieldByName("Value")
+	assert.True(t, ok)
+
+	assert.Equal(t, "value", GetFieldPath("", sf))
+	assert.Equal(t, "root.value", GetFieldPath("root", sf))
+}

--- a/internal/reflect/reflect_test.go
+++ b/internal/reflect/reflect_test.go
@@ -1,0 +1,85 @@
+package internalreflect
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	structclierrors "github.com/leodido/structcli/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type reflectSample struct {
+	Name string
+}
+
+func TestGetValue(t *testing.T) {
+	val := GetValue(reflectSample{Name: "x"})
+	require.True(t, val.IsValid())
+	assert.Equal(t, reflect.Struct, val.Kind())
+	assert.Equal(t, "x", val.FieldByName("Name").String())
+
+	ptrVal := GetValue(&reflectSample{Name: "y"})
+	require.True(t, ptrVal.IsValid())
+	assert.Equal(t, reflect.Struct, ptrVal.Kind())
+	assert.Equal(t, "y", ptrVal.FieldByName("Name").String())
+
+	invalid := GetValue(nil)
+	assert.False(t, invalid.IsValid())
+}
+
+func TestGetValuePtr(t *testing.T) {
+	val := GetValuePtr(reflectSample{Name: "x"})
+	require.True(t, val.IsValid())
+	assert.Equal(t, reflect.Ptr, val.Kind())
+	assert.Equal(t, reflect.TypeOf(reflectSample{}), val.Elem().Type())
+
+	var nilPtr *reflectSample
+	got := GetValuePtr(nilPtr)
+	require.True(t, got.IsValid())
+	assert.Equal(t, reflect.Ptr, got.Kind())
+	assert.False(t, got.IsNil())
+	assert.Equal(t, reflect.TypeOf(reflectSample{}), got.Elem().Type())
+}
+
+func TestGetStructPtr(t *testing.T) {
+	nonAddr := reflect.ValueOf(reflectSample{Name: "x"})
+	ptr := GetStructPtr(nonAddr)
+	require.True(t, ptr.IsValid())
+	assert.Equal(t, reflect.Ptr, ptr.Kind())
+	assert.Equal(t, "x", ptr.Elem().FieldByName("Name").String())
+
+	addr := reflect.ValueOf(&reflectSample{Name: "y"}).Elem()
+	addrPtr := GetStructPtr(addr)
+	require.True(t, addrPtr.IsValid())
+	assert.Equal(t, reflect.Ptr, addrPtr.Kind())
+	assert.Equal(t, "y", addrPtr.Elem().FieldByName("Name").String())
+
+	var nilPtr *reflectSample
+	nilPtrVal := GetStructPtr(reflect.ValueOf(nilPtr))
+	require.True(t, nilPtrVal.IsValid())
+	assert.Equal(t, reflect.Ptr, nilPtrVal.Kind())
+	assert.False(t, nilPtrVal.IsNil())
+
+	assert.False(t, GetStructPtr(reflect.Value{}).IsValid())
+}
+
+func TestGetValidValue(t *testing.T) {
+	_, err := GetValidValue(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, structclierrors.ErrInputValue))
+
+	var nilPtr *reflectSample
+	val, err := GetValidValue(nilPtr)
+	require.NoError(t, err)
+	require.True(t, val.IsValid())
+	assert.Equal(t, reflect.Struct, val.Kind())
+	assert.Equal(t, "", val.FieldByName("Name").String())
+}
+
+func TestSignature(t *testing.T) {
+	fx := func(string, int) (bool, error) { return true, nil }
+	assert.Equal(t, "func(string, int) (bool, error)", Signature(fx))
+	assert.Equal(t, "<not a function>", Signature(123))
+}

--- a/internal/tag/tag_test.go
+++ b/internal/tag/tag_test.go
@@ -1,0 +1,51 @@
+package internaltag
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type customInt int
+
+type mandatorySample struct {
+	Required string `flagrequired:"true"`
+	Optional string
+	Invalid  string `flagrequired:"not-a-bool"`
+}
+
+func TestIsValidFlagName(t *testing.T) {
+	valid := []string{"port", "log-level", "db.url", "a1", "A.B-c"}
+	for _, name := range valid {
+		assert.True(t, IsValidFlagName(name), name)
+	}
+
+	invalid := []string{"", "-lead", "trail-", "two--dashes", "with space", "with_underscore"}
+	for _, name := range invalid {
+		assert.False(t, IsValidFlagName(name), name)
+	}
+}
+
+func TestIsStandardType(t *testing.T) {
+	assert.True(t, IsStandardType(reflect.TypeOf(int(0))))
+	assert.True(t, IsStandardType(reflect.TypeOf(float64(0))))
+	assert.False(t, IsStandardType(reflect.TypeOf(customInt(0))))
+	assert.False(t, IsStandardType(reflect.TypeOf([]string{})))
+}
+
+func TestIsMandatory(t *testing.T) {
+	T := reflect.TypeOf(mandatorySample{})
+
+	required, ok := T.FieldByName("Required")
+	assert.True(t, ok)
+	assert.True(t, IsMandatory(required))
+
+	optional, ok := T.FieldByName("Optional")
+	assert.True(t, ok)
+	assert.False(t, IsMandatory(optional))
+
+	invalid, ok := T.FieldByName("Invalid")
+	assert.True(t, ok)
+	assert.False(t, IsMandatory(invalid))
+}

--- a/internal/testing/race_off_test.go
+++ b/internal/testing/race_off_test.go
@@ -1,0 +1,12 @@
+//go:build !race
+// +build !race
+
+package testing
+
+import gotesting "testing"
+
+func TestIsRaceOn_Off(got *gotesting.T) {
+	if IsRaceOn() {
+		got.Fatalf("expected race detector to be off")
+	}
+}

--- a/internal/testing/race_on_test.go
+++ b/internal/testing/race_on_test.go
@@ -1,0 +1,12 @@
+//go:build race
+// +build race
+
+package testing
+
+import gotesting "testing"
+
+func TestIsRaceOn_On(got *gotesting.T) {
+	if !IsRaceOn() {
+		got.Fatalf("expected race detector to be on")
+	}
+}

--- a/internal/usage/groups_test.go
+++ b/internal/usage/groups_test.go
@@ -1,0 +1,33 @@
+package internalusage
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroups(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().String("plain", "", "plain flag")
+	cmd.Flags().String("grouped", "", "grouped flag")
+	cmd.Flags().String("annotated-no-group", "", "annotated without group")
+	cmd.PersistentFlags().Bool("config", false, "config flag")
+
+	err := cmd.Flags().SetAnnotation("grouped", FlagGroupAnnotation, []string{"Alpha"})
+	require.NoError(t, err)
+	err = cmd.Flags().SetAnnotation("annotated-no-group", "other", []string{"x"})
+	require.NoError(t, err)
+
+	groups := Groups(cmd)
+
+	require.Contains(t, groups, localGroupID)
+	require.Contains(t, groups, "Alpha")
+	require.Contains(t, groups, globalGroupID)
+
+	assert.NotNil(t, groups[localGroupID].Lookup("plain"))
+	assert.NotNil(t, groups[localGroupID].Lookup("annotated-no-group"))
+	assert.NotNil(t, groups["Alpha"].Lookup("grouped"))
+	assert.NotNil(t, groups[globalGroupID].Lookup("config"))
+}

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -1,0 +1,78 @@
+package internalusage
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type errWriter struct{}
+
+func (errWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestHelpers(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("name", "", "name")
+	usage := flagUsages(flags)
+	assert.Contains(t, usage, "--name")
+	assert.True(t, strings.HasSuffix(usage, "\n"))
+
+	assert.Equal(t, "x   ", rpad("x", 4))
+
+	var b bytes.Buffer
+	require.NoError(t, tmpl(&b, "hello"))
+	assert.Equal(t, "hello", b.String())
+	assert.Error(t, tmpl(errWriter{}, "x"))
+}
+
+func TestSetupUsage(t *testing.T) {
+	root := &cobra.Command{
+		Use:     "app",
+		Aliases: []string{"a"},
+		Example: "app child",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return nil
+		},
+	}
+
+	root.Flags().String("plain", "", "plain flag")
+	root.Flags().String("grouped", "", "grouped flag")
+	root.PersistentFlags().Bool("config", false, "config")
+	require.NoError(t, root.Flags().SetAnnotation("grouped", FlagGroupAnnotation, []string{"Alpha"}))
+
+	child := &cobra.Command{
+		Use:   "child",
+		Short: "child cmd",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return nil
+		},
+	}
+	topic := &cobra.Command{
+		Use:   "topic",
+		Short: "topic help",
+	}
+	root.AddCommand(child, topic)
+
+	Setup(root)
+	usage := root.UsageString()
+
+	assert.Contains(t, usage, "Usage:")
+	assert.Contains(t, usage, "Aliases:")
+	assert.Contains(t, usage, "Examples:")
+	assert.Contains(t, usage, "Available Commands:")
+	assert.Contains(t, usage, "Flags:")
+	assert.Contains(t, usage, "Alpha Flags:")
+	assert.Contains(t, usage, "Global Flags:")
+	assert.Contains(t, usage, "Additional help topics:")
+	assert.Contains(t, usage, "Use \"app [command] --help\"")
+	assert.Contains(t, usage, "child")
+	assert.Contains(t, usage, "topic")
+}


### PR DESCRIPTION
## Summary
- add focused unit tests for low-covered internal packages (`cmd`, `debug`, `path`, `reflect`, `tag`, `testing`, `usage`, `validation`)
- include typo fix in `internal/config/viper.go` (`Hande` -> `Handle`)
- improve confidence on helper/edge-path behavior without changing production logic

## Validation
- `GOCACHE=/tmp/go-build go test ./...`
- `GOCACHE=/tmp/go-build go test -race ./...`

## Coverage check (workflow-style locally)
- replicated CI coverage aggregation (lib + examples with `-coverpkg`)
- total: `94.9%`