### PR TITLE
chore: add devcontainer Dockerfile and config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/go:1.24-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        jq \
+    && rm -rf /var/lib/apt/lists/*
+# golangci-lint for linting
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// The Dev Container format allows you to configure your environment. At the heart of it
+// is a Docker image or Dockerfile which controls the tools available in your environment.
+//
+// See https://aka.ms/devcontainer.json for more information.
+{
+	"name": "Ona",
+	// Use "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+	// instead of the build to use a pre-built image.
+	"build": {
+        "context": ".",
+        "dockerfile": "Dockerfile"
+    }
+	// Features add additional features to your environment. See https://containers.dev/features
+	// Beware: features are not supported on all platforms and may have unintended side-effects.
+	// "features": {
+    //   "ghcr.io/devcontainers/features/docker-in-docker": {
+    //     "moby": false
+    //   }
+    // }
+}


### PR DESCRIPTION
## Description

Add a proper Dockerfile for the devcontainer instead of the placeholder base image.

- Go 1.24 base image (`mcr.microsoft.com/devcontainers/go:1.24-bookworm`), matching `go.mod` and CI
- `golangci-lint` for local linting
- `jq` for JSON inspection

Also tracks the existing `devcontainer.json` which was previously untracked.

## How to test

Rebuild the devcontainer and verify:
```
go version        # should be 1.24.x
golangci-lint --version
jq --version
go test ./...     # all tests pass
```