### PR TITLE
fix: check `InferDecodeHooks` return in flagcustom fallback path

### DIFF
--- a/define.go
+++ b/define.go
@@ -385,7 +385,11 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				// The users set `flagcustom:"true"` but they didn't define a custom define hook
 				// We fallback to look up the hooks registries to avoid erroring out
 				if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
-					internalhooks.InferDecodeHooks(c, name, f.Type.String())
+					// Defensive: registries are always populated in pairs, so this
+					// should never fail — but surface the error instead of hiding it.
+					if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
+						return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
+					}
 
 					if err := finalizeFieldDefinition(); err != nil {
 						return err


### PR DESCRIPTION
## Description

The `flagcustom:"true"` fallback path in `define.go` silently discarded the return value of `InferDecodeHooks`. If a define hook existed in the registry without a matching decode hook, the flag would be defined without one — leading to silent decode failures at unmarshal time.

This adds the missing return-value check, matching the pattern already used in the non-custom path (line ~404).

The error path is a defensive guard — registries are always populated in pairs and `init()` panics on mismatches — but surfacing the error is better than hiding it.

Part of the TODO.md "Finish the remaining swallowed-error cleanup" item.

## How to test

```
go test -race ./...
```