### PR TITLE
fix: propagate `SetAnnotation` error from `InferDecodeHooks`

### DIFF
--- a/define.go
+++ b/define.go
@@ -385,9 +385,11 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				// The users set `flagcustom:"true"` but they didn't define a custom define hook
 				// We fallback to look up the hooks registries to avoid erroring out
 				if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
-					// Defensive: registries are always populated in pairs, so this
-					// should never fail — but surface the error instead of hiding it.
-					if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
+				found, err := internalhooks.InferDecodeHooks(c, name, f.Type.String())
+					if err != nil {
+						return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
+					}
+					if !found {
 						return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
 					}
 
@@ -405,7 +407,11 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 		// Check registry for known custom types
 		if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
-			if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
+			found, err := internalhooks.InferDecodeHooks(c, name, f.Type.String())
+			if err != nil {
+				return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
+			}
+			if !found {
 				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
 			}
 
@@ -531,7 +537,11 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				ref := (*[]int)(unsafe.Pointer(field.UnsafeAddr()))
 				c.Flags().IntSliceVarP(ref, name, short, val, descr)
 			}
-			if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
+			found, err := internalhooks.InferDecodeHooks(c, name, f.Type.String())
+			if err != nil {
+				return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
+			}
+			if !found {
 				return fmt.Errorf("internal error: missing decode hook for built-in slice type %s", f.Type.String())
 			}
 

--- a/define.go
+++ b/define.go
@@ -542,7 +542,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
 			}
 			if !found {
-				return fmt.Errorf("internal error: missing decode hook for built-in slice type %s", f.Type.String())
+				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
 			}
 
 		default:

--- a/define.go
+++ b/define.go
@@ -385,12 +385,11 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				// The users set `flagcustom:"true"` but they didn't define a custom define hook
 				// We fallback to look up the hooks registries to avoid erroring out
 				if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
-				found, err := internalhooks.InferDecodeHooks(c, name, f.Type.String())
-					if err != nil {
+				// Best-effort: attach a decode hook if one exists, but don't
+					// hard-error when missing — this is a fallback path, not a
+					// mandatory one like the other two call sites.
+					if _, err := internalhooks.InferDecodeHooks(c, name, f.Type.String()); err != nil {
 						return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
-					}
-					if !found {
-						return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
 					}
 
 					if err := finalizeFieldDefinition(); err != nil {

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -124,7 +124,7 @@ func init() {
 func InferDecodeHooks(c *cobra.Command, name, typename string) (bool, error) {
 	if data, ok := DecodeHookRegistry[typename]; ok {
 		if err := c.Flags().SetAnnotation(name, FlagDecodeHookAnnotation, []string{data.ann}); err != nil {
-			return false, fmt.Errorf("couldn't set decode hook annotation for flag %s: %w", name, err)
+			return false, fmt.Errorf("set decode hook annotation: %w", err)
 		}
 
 		return true, nil

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -121,14 +121,16 @@ func init() {
 	}
 }
 
-func InferDecodeHooks(c *cobra.Command, name, typename string) bool {
+func InferDecodeHooks(c *cobra.Command, name, typename string) (bool, error) {
 	if data, ok := DecodeHookRegistry[typename]; ok {
-		_ = c.Flags().SetAnnotation(name, FlagDecodeHookAnnotation, []string{data.ann})
+		if err := c.Flags().SetAnnotation(name, FlagDecodeHookAnnotation, []string{data.ann}); err != nil {
+			return false, fmt.Errorf("couldn't set decode hook annotation for flag %s: %w", name, err)
+		}
 
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, nil
 }
 
 // StringToZapcoreLevelHookFunc creates a decode hook that converts string values

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -24,14 +24,26 @@ func TestInferDecodeHooks(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("durations", "", "durations")
 
-	ok := InferDecodeHooks(cmd, "durations", "[]time.Duration")
+	ok, err := InferDecodeHooks(cmd, "durations", "[]time.Duration")
+	require.NoError(t, err)
 	require.True(t, ok)
 
 	flag := cmd.Flags().Lookup("durations")
 	require.NotNil(t, flag)
 	assert.Equal(t, []string{"StringToDurationSliceHookFunc"}, flag.Annotations[FlagDecodeHookAnnotation])
 
-	assert.False(t, InferDecodeHooks(cmd, "durations", "missing.Type"))
+	found, err := InferDecodeHooks(cmd, "durations", "missing.Type")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestInferDecodeHooks_ErrorOnUnknownFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	// Don't define a "durations" flag — SetAnnotation will fail on unknown flag
+
+	_, err := InferDecodeHooks(cmd, "durations", "[]time.Duration")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "durations")
 }
 
 func TestConvertMapInputErrors(t *testing.T) {

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -41,9 +41,10 @@ func TestInferDecodeHooks_ErrorOnUnknownFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	// Don't define a "durations" flag — SetAnnotation will fail on unknown flag
 
-	_, err := InferDecodeHooks(cmd, "durations", "[]time.Duration")
+	found, err := InferDecodeHooks(cmd, "durations", "[]time.Duration")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "durations")
+	assert.False(t, found)
+	assert.Contains(t, err.Error(), "decode hook annotation")
 }
 
 func TestConvertMapInputErrors(t *testing.T) {


### PR DESCRIPTION
## Description

`InferDecodeHooks` silently discarded the `SetAnnotation` error with `_ =`. If `SetAnnotation` failed, the function returned `true` (success) even though the annotation wasn't stored — downstream unmarshal would silently skip the decode hook.

Changes:
- `InferDecodeHooks` signature: `bool` → `(bool, error)`
- `SetAnnotation` error is now propagated
- All 3 call sites in `define.go` handle the new error return
- New test `TestInferDecodeHooks_ErrorOnUnknownFlag` exercises the error path
- Error messages unified across all call sites (`"built-in type"` everywhere)

**Call site 1 semantics:** The `flagcustom:"true"` fallback path is best-effort — it attaches a decode hook if one exists but does not hard-error when missing. This differs from the other two call sites where the define/decode hook pairing is mandatory. This PR reverts the `!found` hard-error that #94 introduced at this site, keeping only the `SetAnnotation` error propagation.

Completes the TODO.md "Finish the remaining swallowed-error cleanup" item together with #94.

## How to test

```
go test -race ./...
```