### PR TITLE
refactor: deduplicate enum help-text building logic

### DIFF
--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 	"unsafe"
@@ -175,7 +175,7 @@ func enumHelpText[L ~int8 | ~int](levels map[L][]string, descr string) ([]string
 	for k := range levels {
 		keys = append(keys, int(k))
 	}
-	sort.Ints(keys)
+	slices.Sort(keys)
 
 	values := make([]string, 0, len(keys))
 	for _, k := range keys {

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -167,6 +167,24 @@ func DefineTimeDurationHookFunc() DefineHookFunc {
 	}
 }
 
+// enumHelpText builds a sorted "{val1,val2,...}" addendum from an enum map
+// keyed by integer-typed levels. It returns the sorted value names and the
+// description with the addendum appended.
+func enumHelpText[L ~int8 | ~int](levels map[L][]string, descr string) ([]string, string) {
+	keys := make([]int, 0, len(levels))
+	for k := range levels {
+		keys = append(keys, int(k))
+	}
+	sort.Ints(keys)
+
+	values := make([]string, 0, len(keys))
+	for _, k := range keys {
+		values = append(values, levels[L(k)][0])
+	}
+
+	return values, descr + fmt.Sprintf(" {%s}", strings.Join(values, ","))
+}
+
 // DefineZapcoreLevelHookFunc creates a flag definition function for zapcore.Level.
 //
 // It returns an enum flag that implements pflag.Value.
@@ -182,19 +200,8 @@ func DefineZapcoreLevelHookFunc() DefineHookFunc {
 			zapcore.FatalLevel:  {"fatal"},
 		}
 
-		keys := []int{}
-		for k := range logLevels {
-			keys = append(keys, int(k))
-		}
-		sort.Ints(keys)
-		values := []string{}
-		for _, k := range keys {
-			values = append(values, logLevels[zapcore.Level(k)][0])
-		}
-		addendum := fmt.Sprintf(" {%s}", strings.Join(values, ","))
-		enhancedDescr := descr + addendum
+		values, enhancedDescr := enumHelpText(logLevels, descr)
 
-		// Get pointer to the field for the enum flag
 		fieldPtr := (*zapcore.Level)(unsafe.Pointer(fieldValue.UnsafeAddr()))
 		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), logLevels, enumflag.EnumCaseInsensitive)
 
@@ -214,19 +221,8 @@ func DefineSlogLevelHookFunc() DefineHookFunc {
 			slog.LevelError: {"error"},
 		}
 
-		keys := []int{}
-		for k := range logLevels {
-			keys = append(keys, int(k))
-		}
-		sort.Ints(keys)
-		values := []string{}
-		for _, k := range keys {
-			values = append(values, logLevels[slog.Level(k)][0])
-		}
-		addendum := fmt.Sprintf(" {%s}", strings.Join(values, ","))
-		enhancedDescr := descr + addendum
+		values, enhancedDescr := enumHelpText(logLevels, descr)
 
-		// Get pointer to the field for the enum flag
 		fieldPtr := (*slog.Level)(unsafe.Pointer(fieldValue.UnsafeAddr()))
 		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), logLevels, enumflag.EnumCaseInsensitive)
 

--- a/internal/hooks/define_internal_test.go
+++ b/internal/hooks/define_internal_test.go
@@ -1,0 +1,41 @@
+package internalhooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnumHelpText_SortsAndFormats(t *testing.T) {
+	levels := map[int8][]string{
+		2:  {"warn"},
+		-1: {"debug"},
+		0:  {"info"},
+		4:  {"error"},
+	}
+
+	values, descr := enumHelpText(levels, "log level")
+
+	assert.Equal(t, []string{"debug", "info", "warn", "error"}, values)
+	assert.Equal(t, "log level {debug,info,warn,error}", descr)
+}
+
+func TestEnumHelpText_EmptyMap(t *testing.T) {
+	levels := map[int][]string{}
+
+	values, descr := enumHelpText(levels, "empty")
+
+	assert.Empty(t, values)
+	assert.Equal(t, "empty {}", descr)
+}
+
+func TestEnumHelpText_SingleEntry(t *testing.T) {
+	levels := map[int][]string{
+		0: {"only"},
+	}
+
+	values, descr := enumHelpText(levels, "one")
+
+	assert.Equal(t, []string{"only"}, values)
+	assert.Equal(t, "one {only}", descr)
+}


### PR DESCRIPTION
## Description

`DefineZapcoreLevelHookFunc` and `DefineSlogLevelHookFunc` had identical logic for sorting enum levels and building the `{val1,val2,...}` help-text addendum.

Extracts a generic `enumHelpText[L]` helper constrained to `~int8 | ~int` (covering both `zapcore.Level` and `slog.Level`). Net result: -24 lines, +20 lines, no behavioral change.

## How to test

```
go test -race ./...
```