### PR TITLE
fix: signal truncation in config description when paths exceed 3

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,7 +122,7 @@ func Description(appName string, opts config.Options) string {
 	// Limit to first 3 examples to keep description reasonable
 	if len(templatePaths) > 3 {
 		templatePaths = templatePaths[:3]
-		return fmt.Sprintf("config file (fallbacks to: {%s}/%s.{yaml,json,toml})", strings.Join(templatePaths, ","), opts.ConfigName)
+		return fmt.Sprintf("config file (fallbacks to: {%s,...}/%s.{yaml,json,toml})", strings.Join(templatePaths, ","), opts.ConfigName)
 	}
 
 	return fmt.Sprintf("config file (fallbacks to: {%s}/%s.{yaml,json,toml})", strings.Join(templatePaths, ","), opts.ConfigName)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -152,7 +152,7 @@ func TestDescription_LimitsToFirstThreePaths(t *testing.T) {
 	require.Greater(t, len(templatePaths), 3)
 
 	expected := fmt.Sprintf(
-		"config file (fallbacks to: {%s}/%s.{yaml,json,toml})",
+		"config file (fallbacks to: {%s,...}/%s.{yaml,json,toml})",
 		strings.Join(templatePaths[:3], ","),
 		opts.ConfigName,
 	)


### PR DESCRIPTION
## Description

The `>3` branch in `Description()` produced the same format string as the `≤3` branch, so truncation was invisible to the user. Append `,...` inside the brace group to signal omitted paths.

Before: `{path1,path2,path3}/cfg.{yaml,json,toml}`
After:  `{path1,path2,path3,...}/cfg.{yaml,json,toml}`

## How to test

```
go test ./internal/config/ -run TestDescription -v
```