### PR TITLE
fix: remove throwaway "<origin>" map entry in `Groups()`

### DIFF
--- a/internal/usage/groups.go
+++ b/internal/usage/groups.go
@@ -18,10 +18,7 @@ const (
 //
 // It organizes flags by their group annotation, with ungrouped flags placed in a default local group.
 func Groups(c *cobra.Command) map[string]*pflag.FlagSet {
-	groups := map[string]*pflag.FlagSet{
-		"<origin>": c.LocalFlags(),
-	}
-	delete(groups, "<origin>")
+	groups := map[string]*pflag.FlagSet{}
 
 	addTo := func(f *pflag.Flag, groupID string) {
 		if groups[groupID] == nil {


### PR DESCRIPTION
## Description

The `"<origin>"` map entry in `Groups()` was created and immediately deleted — a no-op. Safe to remove because `LocalNonPersistentFlags()` (called on the next line) already calls `LocalFlags()` internally, which triggers the same `mergePersistentFlags()` side effect.

## How to test

```
go test ./internal/usage/ -v
```