### PR TITLE
chore: bump `Version` constant to 0.15.0

### DIFF
--- a/examples/mcp-command-factory/go.mod
+++ b/examples/mcp-command-factory/go.mod
@@ -3,7 +3,7 @@ module github.com/leodido/structcli/examples/mcp-command-factory
 go 1.24.0
 
 require (
-	github.com/leodido/structcli v0.14.0
+	github.com/leodido/structcli v0.15.0
 	github.com/spf13/cobra v1.9.1
 )
 

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@ package structcli
 // Version is the current release version of structcli.
 // It MUST match the git tag (without the "v" prefix) at release time.
 // The release CI workflow verifies this.
-const Version = "0.14.0"
+const Version = "0.15.0"


### PR DESCRIPTION
## Description

Bump `version.go` from `0.14.0` to `0.15.0` so the release workflow's `version-check` job passes when the `v0.15.0` tag is pushed.

Also bumps `examples/mcp-command-factory/go.mod` require to `v0.15.0` since the example depends on `CommandFactory` which ships in this release.

## Related Issue(s)

Fixes the failed release run: https://github.com/leodido/structcli/actions/runs/24413223903

## How to test

```
grep 'Version' version.go
grep 'structcli' examples/mcp-command-factory/go.mod
go test -race ./...
```