### PR TITLE
feat: add `Unwrap()` to `ValidationError` for `errors.Is`/`errors.As` support

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -89,7 +89,16 @@ func (e *ValidationError) Details() []ValidationDetail {
 	return details
 }
 
-// UnderlyingErrors returns the slice of individual validation errors (immutable).
+// Unwrap returns the inner errors so that errors.Is and errors.As
+// traverse into individual validation failures.
+//
+// The returned slice is the live internal slice — callers that need
+// mutation-safe access should use [ValidationError.UnderlyingErrors] instead.
+func (e *ValidationError) Unwrap() []error {
+	return e.Errors
+}
+
+// UnderlyingErrors returns a defensive copy of the individual validation errors.
 func (e *ValidationError) UnderlyingErrors() []error {
 	if e.Errors == nil {
 		return nil

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -622,6 +622,78 @@ func TestValidationError_UnderlyingErrors_Immutability(t *testing.T) {
 	require.Equal(t, err1, validationErr.Errors[0])
 }
 
+func TestValidationError_Unwrap_ErrorsIs(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	ve := &ValidationError{
+		ContextName: "cmd",
+		Errors:      []error{fmt.Errorf("wrap: %w", sentinel)},
+	}
+
+	// errors.Is should traverse through Unwrap() into the inner errors
+	assert.True(t, errors.Is(ve, sentinel))
+	// Unrelated sentinel should not match
+	assert.False(t, errors.Is(ve, errors.New("other")))
+}
+
+func TestValidationError_Unwrap_ErrorsAs(t *testing.T) {
+	inner := &InvalidBooleanTagError{
+		FieldName: "Field1",
+		TagName:   "flagcustom",
+		TagValue:  "bad",
+	}
+	ve := &ValidationError{
+		Errors: []error{inner},
+	}
+
+	// errors.As should find the typed error through Unwrap()
+	var target *InvalidBooleanTagError
+	require.True(t, errors.As(ve, &target))
+	assert.Equal(t, "Field1", target.FieldName)
+}
+
+func TestValidationError_Unwrap_MultipleSentinels(t *testing.T) {
+	s1 := errors.New("first")
+	s2 := errors.New("second")
+	ve := &ValidationError{
+		Errors: []error{s1, fmt.Errorf("wrapped: %w", s2)},
+	}
+
+	assert.True(t, errors.Is(ve, s1))
+	assert.True(t, errors.Is(ve, s2))
+}
+
+func TestValidationError_Unwrap_NilErrors(t *testing.T) {
+	ve := &ValidationError{Errors: nil}
+	assert.Nil(t, ve.Unwrap())
+}
+
+func TestValidationError_Unwrap_EmptyErrors(t *testing.T) {
+	ve := &ValidationError{Errors: []error{}}
+	assert.Empty(t, ve.Unwrap())
+}
+
+func TestValidationError_Unwrap_NilElementSkipped(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	ve := &ValidationError{
+		Errors: []error{nil, sentinel},
+	}
+
+	// errors.Is skips nil elements gracefully
+	assert.True(t, errors.Is(ve, sentinel))
+}
+
+func TestValidationError_Unwrap_ErrorsAsStillMatchesSelf(t *testing.T) {
+	ve := &ValidationError{
+		ContextName: "test",
+		Errors:      []error{errors.New("inner")},
+	}
+
+	// errors.As for *ValidationError itself must still work
+	var target *ValidationError
+	require.True(t, errors.As(ve, &target))
+	assert.Equal(t, "test", target.ContextName)
+}
+
 func TestInvalidDecodeHookSignatureError_ErrorMessage(t *testing.T) {
 	err := &InvalidDecodeHookSignatureError{
 		FieldName: "ServerMode",


### PR DESCRIPTION
## Description

`ValidationError` wraps multiple inner errors but previously had no `Unwrap` method, so `errors.Is` and `errors.As` could not traverse into the individual validation failures.

This adds `Unwrap() []error` (the multi-error convention from Go 1.20) returning the inner `Errors` slice directly. The existing `Error()` message format is unchanged.

## How to test

```
go test ./errors/ -run TestValidationError_Unwrap -v
```