### PR TITLE
ci: auto-label PRs from conventional commit prefixes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - no-releasenotes
+      - chore
   categories:
     - title: Breaking Changes 🛠
       labels:
@@ -12,6 +13,9 @@ changelog:
     - title: Bug Fixes 🪤
       labels:
         - bug
+    - title: Documentation 📖
+      labels:
+        - documentation
     - title: Other Changes 🫶
       labels:
         # Catch-all for pull requests that didn't match any of the previous categories

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,57 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR from conventional commit prefix
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const prefixMap = {
+              'feat':     'enhancement',
+              'fix':      'bug',
+              'docs':     'documentation',
+              'chore':    'chore',
+              'refactor': 'enhancement',
+              'test':     'chore',
+              'ci':       'chore',
+              'build':    'chore',
+              'perf':     'enhancement',
+            };
+
+            // Match "type:" or "type(scope):"
+            const match = title.match(/^(\w+)(?:\([^)]*\))?!?:/);
+            if (!match) {
+              core.info('No conventional commit prefix found, skipping');
+              return;
+            }
+
+            const prefix = match[1].toLowerCase();
+            const label = prefixMap[prefix];
+            if (!label) {
+              core.info(`Unknown prefix "${prefix}", skipping`);
+              return;
+            }
+
+            // Check for breaking change indicator
+            const labels = [label];
+            if (title.includes('!:') || title.toLowerCase().includes('breaking')) {
+              labels.push('breaking-change');
+            }
+
+            core.info(`Prefix "${prefix}" → labels: ${labels.join(', ')}`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: labels,
+            });


### PR DESCRIPTION
## Description

Adds a workflow that auto-labels PRs based on conventional commit prefixes in the title:

| Prefix | Label |
|--------|-------|
| `feat`, `refactor`, `perf` | `enhancement` |
| `fix` | `bug` |
| `docs` | `documentation` |
| `chore`, `test`, `ci`, `build` | `chore` |
| `type!:` (bang) | also adds `breaking-change` |

Also updates `.github/release.yml`:
- Adds `documentation` category
- Excludes `chore`-labeled PRs from release notes

This ensures future releases get properly categorized notes without manual label management.

## How to test

Open a PR with a `feat:` or `fix:` prefix and verify the label is applied automatically.