### PR TITLE
refactor: replace `unsafe.Pointer` with safe reflect in define path

### DIFF
--- a/define.go
+++ b/define.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	internalenv "github.com/leodido/structcli/internal/env"
 	internalhooks "github.com/leodido/structcli/internal/hooks"
@@ -128,7 +127,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			if f.Anonymous && f.Type.Kind() == reflect.Struct && field.CanAddr() {
 				// Use reflect.NewAt to obtain an interfaceable pointer to the
 				// unexported embedded struct so we can pass it to the recursive call.
-				ptr := reflect.NewAt(f.Type, unsafe.Pointer(field.UnsafeAddr()))
+				ptr := reflect.NewAt(f.Type, field.Addr().UnsafePointer())
 				if err := define(c, ptr.Interface(), startingGroup, structPath, exclusions, defineEnv, mandatory, validateTagName, modTagName); err != nil {
 					return err
 				}
@@ -448,42 +447,42 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 		case reflect.Bool:
 			val := field.Interface().(bool)
-			ref := (*bool)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*bool)
 			c.Flags().BoolVarP(ref, name, short, val, descr)
 
 		case reflect.String:
 			val := field.Interface().(string)
-			ref := (*string)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*string)
 			c.Flags().StringVarP(ref, name, short, val, descr)
 
 		case reflect.Uint:
 			val := field.Interface().(uint)
-			ref := (*uint)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*uint)
 			c.Flags().UintVarP(ref, name, short, val, descr)
 
 		case reflect.Uint8:
 			val := field.Interface().(uint8)
-			ref := (*uint8)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*uint8)
 			c.Flags().Uint8VarP(ref, name, short, val, descr)
 
 		case reflect.Uint16:
 			val := field.Interface().(uint16)
-			ref := (*uint16)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*uint16)
 			c.Flags().Uint16VarP(ref, name, short, val, descr)
 
 		case reflect.Uint32:
 			val := field.Interface().(uint32)
-			ref := (*uint32)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*uint32)
 			c.Flags().Uint32VarP(ref, name, short, val, descr)
 
 		case reflect.Uint64:
 			val := field.Interface().(uint64)
-			ref := (*uint64)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*uint64)
 			c.Flags().Uint64VarP(ref, name, short, val, descr)
 
 		case reflect.Int:
 			val := field.Interface().(int)
-			ref := (*int)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*int)
 			if f.Tag.Get("flagtype") == "count" {
 				c.Flags().CountVarP(ref, name, short, descr)
 
@@ -497,43 +496,43 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 		case reflect.Int8:
 			val := field.Interface().(int8)
-			ref := (*int8)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*int8)
 			c.Flags().Int8VarP(ref, name, short, val, descr)
 
 		case reflect.Int16:
 			val := field.Interface().(int16)
-			ref := (*int16)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*int16)
 			c.Flags().Int16VarP(ref, name, short, val, descr)
 
 		case reflect.Int32:
 			val := field.Interface().(int32)
-			ref := (*int32)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*int32)
 			c.Flags().Int32VarP(ref, name, short, val, descr)
 
 		case reflect.Int64:
 			val := field.Interface().(int64)
-			ref := (*int64)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*int64)
 			c.Flags().Int64VarP(ref, name, short, val, descr)
 
 		case reflect.Float32:
 			val := field.Interface().(float32)
-			ref := (*float32)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*float32)
 			c.Flags().Float32VarP(ref, name, short, val, descr)
 
 		case reflect.Float64:
 			val := field.Interface().(float64)
-			ref := (*float64)(unsafe.Pointer(field.UnsafeAddr()))
+			ref := field.Addr().Interface().(*float64)
 			c.Flags().Float64VarP(ref, name, short, val, descr)
 
 		case reflect.Slice:
 			switch f.Type.Elem().Kind() {
 			case reflect.String:
 				val := field.Interface().([]string)
-				ref := (*[]string)(unsafe.Pointer(field.UnsafeAddr()))
+				ref := field.Addr().Interface().(*[]string)
 				c.Flags().StringSliceVarP(ref, name, short, val, descr)
 			case reflect.Int:
 				val := field.Interface().([]int)
-				ref := (*[]int)(unsafe.Pointer(field.UnsafeAddr()))
+				ref := field.Addr().Interface().(*[]int)
 				c.Flags().IntSliceVarP(ref, name, short, val, descr)
 			}
 			found, err := internalhooks.InferDecodeHooks(c, name, f.Type.String())

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 	"time"
-	"unsafe"
 
 	structclivalues "github.com/leodido/structcli/values"
 	"github.com/spf13/cobra"
@@ -51,7 +50,10 @@ var byteSliceType = reflect.TypeOf([]byte(nil))
 func defineByteSliceValueHookFunc(newValue func(val []byte, ref *[]byte) pflag.Value) DefineHookFunc {
 	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Convert(byteSliceType).Interface().([]byte)
-		ref := (*[]byte)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		// The field may be a named type (e.g. structcli.Hex) so Addr().Interface()
+		// would yield *Hex, not *[]byte. Use reflect.NewAt to reinterpret the
+		// pointer as *[]byte, which is safe because the underlying type is []byte.
+		ref := reflect.NewAt(byteSliceType, fieldValue.Addr().UnsafePointer()).Interface().(*[]byte)
 
 		return newValue(val, ref), descr
 	}
@@ -60,7 +62,7 @@ func defineByteSliceValueHookFunc(newValue func(val []byte, ref *[]byte) pflag.V
 func defineFlagSetValueHookFunc[T any](register func(fs *pflag.FlagSet, ref *T, name, short string, val T, usage string)) DefineHookFunc {
 	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(T)
-		ref := (*T)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		ref := fieldValue.Addr().Interface().(*T)
 		fs := pflag.NewFlagSet(name, pflag.ContinueOnError)
 		register(fs, ref, name, short, val, descr)
 
@@ -125,7 +127,7 @@ func DefineBase64BytesHookFunc() DefineHookFunc {
 func DefineIPHookFunc() DefineHookFunc {
 	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(net.IP)
-		ref := (*net.IP)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		ref := fieldValue.Addr().Interface().(*net.IP)
 
 		return structclivalues.NewIP(val, ref), descr
 	}
@@ -134,7 +136,7 @@ func DefineIPHookFunc() DefineHookFunc {
 func DefineIPMaskHookFunc() DefineHookFunc {
 	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(net.IPMask)
-		ref := (*net.IPMask)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		ref := fieldValue.Addr().Interface().(*net.IPMask)
 
 		return structclivalues.NewIPMask(val, ref), descr
 	}
@@ -143,7 +145,7 @@ func DefineIPMaskHookFunc() DefineHookFunc {
 func DefineIPNetHookFunc() DefineHookFunc {
 	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(net.IPNet)
-		ref := (*net.IPNet)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		ref := fieldValue.Addr().Interface().(*net.IPNet)
 
 		return structclivalues.NewIPNet(val, ref), descr
 	}
@@ -152,7 +154,7 @@ func DefineIPNetHookFunc() DefineHookFunc {
 func DefineIPSliceHookFunc() DefineHookFunc {
 	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().([]net.IP)
-		ref := (*[]net.IP)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		ref := fieldValue.Addr().Interface().(*[]net.IP)
 
 		return structclivalues.NewIPSlice(val, ref), descr
 	}
@@ -161,7 +163,7 @@ func DefineIPSliceHookFunc() DefineHookFunc {
 func DefineTimeDurationHookFunc() DefineHookFunc {
 	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(time.Duration)
-		ref := (*time.Duration)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		ref := fieldValue.Addr().Interface().(*time.Duration)
 
 		return structclivalues.NewDuration(val, ref), descr
 	}
@@ -202,7 +204,7 @@ func DefineZapcoreLevelHookFunc() DefineHookFunc {
 
 		values, enhancedDescr := enumHelpText(logLevels, descr)
 
-		fieldPtr := (*zapcore.Level)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		fieldPtr := fieldValue.Addr().Interface().(*zapcore.Level)
 		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), logLevels, enumflag.EnumCaseInsensitive)
 
 		return WrapWithEnumValues(enumFlag, values), enhancedDescr
@@ -223,7 +225,7 @@ func DefineSlogLevelHookFunc() DefineHookFunc {
 
 		values, enhancedDescr := enumHelpText(logLevels, descr)
 
-		fieldPtr := (*slog.Level)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+		fieldPtr := fieldValue.Addr().Interface().(*slog.Level)
 		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), logLevels, enumflag.EnumCaseInsensitive)
 
 		return WrapWithEnumValues(enumFlag, values), enhancedDescr


### PR DESCRIPTION
## Description

Drops the `unsafe` import from both `define.go` and `internal/hooks/define.go` by replacing direct `unsafe.Pointer` casts with safe reflect alternatives.

23 of 25 call sites now use pure safe reflect (`field.Addr().Interface().(*T)`). Two sites still use `reflect.Value.UnsafePointer()` — a reflect API method that doesn't require importing `unsafe` but has the same safety implications. These two cases genuinely require unsafe pointer manipulation:

| Pattern | Count | Before | After |
|---|---|---|---|
| Exported addressable fields | 23 | `(*T)(unsafe.Pointer(field.UnsafeAddr()))` | `field.Addr().Interface().(*T)` |
| Unexported embedded struct | 1 | `reflect.NewAt(typ, unsafe.Pointer(field.UnsafeAddr()))` | `reflect.NewAt(typ, field.Addr().UnsafePointer())` |
| Named byte-slice types (Hex, Base64) | 1 | `(*[]byte)(unsafe.Pointer(fieldValue.UnsafeAddr()))` | `reflect.NewAt(byteSliceType, fieldValue.Addr().UnsafePointer()).Interface().(*[]byte)` |

No coverage change. No allocation change (identical B/op and allocs/op). Wall-clock benchmarks show no meaningful difference (~3% within noise on ±6–8% variance).

## How to test

```
go test ./...
go test -race ./...
```