### PR TITLE
test: add rapid property tests for validation hooks

### DIFF
--- a/internal/proptest/gen/generators.go
+++ b/internal/proptest/gen/generators.go
@@ -46,7 +46,7 @@ func ValidFlagName() *rapid.Generator[string] {
 	sep := rapid.SampledFrom([]string{".", "-"})
 
 	return rapid.Custom(func(t *rapid.T) string {
-		n := rapid.IntRange(1, 3).Draw(t, "segments")
+		n := rapid.IntRange(1, 4).Draw(t, "segments")
 		parts := make([]string, n)
 		for i := range n {
 			parts[i] = segment.Draw(t, "segment")
@@ -62,11 +62,6 @@ func ValidFlagName() *rapid.Generator[string] {
 		}
 		return b.String()
 	})
-}
-
-// BoolTagValue draws a value suitable for boolean struct tags.
-func BoolTagValue() *rapid.Generator[string] {
-	return rapid.SampledFrom([]string{"true", "false", "1", "0", "TRUE", "FALSE"})
 }
 
 // InvalidBoolTagValue draws a string that is NOT a valid boolean.
@@ -90,6 +85,8 @@ type TagSet struct {
 }
 
 // ToStructTag converts a TagSet to a reflect.StructTag string.
+// Values must not contain '"' or '\\' — these break struct tag encoding
+// and cause Tag.Get to return truncated or empty results.
 func (ts TagSet) ToStructTag() reflect.StructTag {
 	var parts []string
 	add := func(key, val string) {
@@ -139,7 +136,7 @@ func ValidTagSet(flagName string) *rapid.Generator[TagSet] {
 		useIgnore := rapid.Bool().Draw(t, "useIgnore")
 		if useIgnore {
 			ts.FlagIgnore = "true"
-			// No hidden, required, or preset when ignored
+			ts.Flag = "" // ignored fields don't need a flag name
 		} else {
 			if rapid.Bool().Draw(t, "hidden") {
 				ts.FlagHidden = "true"
@@ -149,35 +146,6 @@ func ValidTagSet(flagName string) *rapid.Generator[TagSet] {
 			}
 		}
 
-		return ts
-	})
-}
-
-// ArbitraryTagSet generates a tag set with arbitrary (possibly invalid) values.
-func ArbitraryTagSet() *rapid.Generator[TagSet] {
-	return rapid.Custom(func(t *rapid.T) TagSet {
-		ts := TagSet{}
-		if rapid.Bool().Draw(t, "hasFlag") {
-			ts.Flag = rapid.String().Draw(t, "flag")
-		}
-		if rapid.Bool().Draw(t, "hasShort") {
-			ts.FlagShort = rapid.String().Draw(t, "short")
-		}
-		if rapid.Bool().Draw(t, "hasHidden") {
-			ts.FlagHidden = rapid.String().Draw(t, "hidden")
-		}
-		if rapid.Bool().Draw(t, "hasRequired") {
-			ts.FlagRequired = rapid.String().Draw(t, "required")
-		}
-		if rapid.Bool().Draw(t, "hasIgnore") {
-			ts.FlagIgnore = rapid.String().Draw(t, "ignore")
-		}
-		if rapid.Bool().Draw(t, "hasCustom") {
-			ts.FlagCustom = rapid.String().Draw(t, "custom")
-		}
-		if rapid.Bool().Draw(t, "hasEnv") {
-			ts.FlagEnv = rapid.String().Draw(t, "env")
-		}
 		return ts
 	})
 }
@@ -243,10 +211,4 @@ func IsValidFlagNameCheck(name string) bool {
 	return validFlagNameRegex.MatchString(name)
 }
 
-// FlagNameForField returns the flag name that Define/validation would use.
-func FlagNameForField(spec FieldSpec) string {
-	if spec.Tags.Flag != "" {
-		return spec.Tags.Flag
-	}
-	return strings.ToLower(spec.Name)
-}
+

--- a/internal/proptest/gen/generators.go
+++ b/internal/proptest/gen/generators.go
@@ -1,0 +1,252 @@
+// Package gen provides shared rapid generators for property-based tests.
+//
+// Generators produce random struct types, tag sets, and field types
+// for use in validation and Define() property tests.
+package gen
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"pgregory.net/rapid"
+)
+
+var validFlagNameRegex = regexp.MustCompile(`^[a-zA-Z0-9]+([.-][a-zA-Z0-9]+)*$`)
+
+// Supported field types for generation.
+var SupportedFieldTypes = []reflect.Type{
+	reflect.TypeOf(false),          // bool
+	reflect.TypeOf(""),             // string
+	reflect.TypeOf(int(0)),         // int
+	reflect.TypeOf(int8(0)),        // int8
+	reflect.TypeOf(int16(0)),       // int16
+	reflect.TypeOf(int32(0)),       // int32
+	reflect.TypeOf(int64(0)),       // int64
+	reflect.TypeOf(uint(0)),        // uint
+	reflect.TypeOf(uint8(0)),       // uint8
+	reflect.TypeOf(uint16(0)),      // uint16
+	reflect.TypeOf(uint32(0)),      // uint32
+	reflect.TypeOf(uint64(0)),      // uint64
+	reflect.TypeOf(float32(0)),     // float32
+	reflect.TypeOf(float64(0)),     // float64
+	reflect.TypeOf([]string(nil)),  // []string
+	reflect.TypeOf([]int(nil)),     // []int
+}
+
+// FieldType draws a random supported field type.
+func FieldType() *rapid.Generator[reflect.Type] {
+	return rapid.SampledFrom(SupportedFieldTypes)
+}
+
+// ValidFlagName produces strings matching ^[a-zA-Z0-9]+([.-][a-zA-Z0-9]+)*$.
+func ValidFlagName() *rapid.Generator[string] {
+	segment := rapid.StringMatching(`[a-zA-Z0-9]+`)
+	sep := rapid.SampledFrom([]string{".", "-"})
+
+	return rapid.Custom(func(t *rapid.T) string {
+		n := rapid.IntRange(1, 3).Draw(t, "segments")
+		parts := make([]string, n)
+		for i := range n {
+			parts[i] = segment.Draw(t, "segment")
+		}
+		if n == 1 {
+			return parts[0]
+		}
+		var b strings.Builder
+		b.WriteString(parts[0])
+		for i := 1; i < n; i++ {
+			b.WriteString(sep.Draw(t, "sep"))
+			b.WriteString(parts[i])
+		}
+		return b.String()
+	})
+}
+
+// BoolTagValue draws a value suitable for boolean struct tags.
+func BoolTagValue() *rapid.Generator[string] {
+	return rapid.SampledFrom([]string{"true", "false", "1", "0", "TRUE", "FALSE"})
+}
+
+// InvalidBoolTagValue draws a string that is NOT a valid boolean.
+func InvalidBoolTagValue() *rapid.Generator[string] {
+	return rapid.SampledFrom([]string{"yes", "no", "2", "maybe", "on", "off", "TRUE!", "abc"})
+}
+
+// TagSet represents a set of struct tags for a single field.
+type TagSet struct {
+	Flag         string // flag alias (may be empty)
+	FlagShort    string // single char shorthand
+	FlagDescr    string
+	FlagGroup    string
+	FlagHidden   string // "true" or "false" or ""
+	FlagRequired string // "true" or "false" or ""
+	FlagIgnore   string // "true" or "false" or ""
+	FlagCustom   string // "true" or "false" or ""
+	FlagEnv      string // "true" or "false" or ""
+	FlagPreset   string
+	Default      string
+}
+
+// ToStructTag converts a TagSet to a reflect.StructTag string.
+func (ts TagSet) ToStructTag() reflect.StructTag {
+	var parts []string
+	add := func(key, val string) {
+		if val != "" {
+			parts = append(parts, fmt.Sprintf(`%s:"%s"`, key, val))
+		}
+	}
+	add("flag", ts.Flag)
+	add("flagshort", ts.FlagShort)
+	add("flagdescr", ts.FlagDescr)
+	add("flaggroup", ts.FlagGroup)
+	add("flaghidden", ts.FlagHidden)
+	add("flagrequired", ts.FlagRequired)
+	add("flagignore", ts.FlagIgnore)
+	add("flagcustom", ts.FlagCustom)
+	add("flagenv", ts.FlagEnv)
+	add("flagpreset", ts.FlagPreset)
+	add("default", ts.Default)
+	return reflect.StructTag(strings.Join(parts, " "))
+}
+
+// ValidTagSet generates a well-formed tag set with no conflicts.
+// The flagName parameter is used as the flag alias if non-empty.
+func ValidTagSet(flagName string) *rapid.Generator[TagSet] {
+	return rapid.Custom(func(t *rapid.T) TagSet {
+		ts := TagSet{}
+		if flagName != "" {
+			ts.Flag = flagName
+		}
+
+		// Optionally add a shorthand (single ASCII letter)
+		if rapid.Bool().Draw(t, "hasShort") {
+			ts.FlagShort = string(rapid.ByteRange('a', 'z').Draw(t, "short"))
+		}
+
+		// Optionally add a description
+		if rapid.Bool().Draw(t, "hasDescr") {
+			ts.FlagDescr = rapid.StringMatching(`[a-zA-Z0-9 ]{1,30}`).Draw(t, "descr")
+		}
+
+		// Optionally add a group
+		if rapid.Bool().Draw(t, "hasGroup") {
+			ts.FlagGroup = rapid.StringMatching(`[A-Z][a-zA-Z]{2,10}`).Draw(t, "group")
+		}
+
+		// Hidden and required can coexist, but neither can coexist with ignore
+		useIgnore := rapid.Bool().Draw(t, "useIgnore")
+		if useIgnore {
+			ts.FlagIgnore = "true"
+			// No hidden, required, or preset when ignored
+		} else {
+			if rapid.Bool().Draw(t, "hidden") {
+				ts.FlagHidden = "true"
+			}
+			if rapid.Bool().Draw(t, "required") {
+				ts.FlagRequired = "true"
+			}
+		}
+
+		return ts
+	})
+}
+
+// ArbitraryTagSet generates a tag set with arbitrary (possibly invalid) values.
+func ArbitraryTagSet() *rapid.Generator[TagSet] {
+	return rapid.Custom(func(t *rapid.T) TagSet {
+		ts := TagSet{}
+		if rapid.Bool().Draw(t, "hasFlag") {
+			ts.Flag = rapid.String().Draw(t, "flag")
+		}
+		if rapid.Bool().Draw(t, "hasShort") {
+			ts.FlagShort = rapid.String().Draw(t, "short")
+		}
+		if rapid.Bool().Draw(t, "hasHidden") {
+			ts.FlagHidden = rapid.String().Draw(t, "hidden")
+		}
+		if rapid.Bool().Draw(t, "hasRequired") {
+			ts.FlagRequired = rapid.String().Draw(t, "required")
+		}
+		if rapid.Bool().Draw(t, "hasIgnore") {
+			ts.FlagIgnore = rapid.String().Draw(t, "ignore")
+		}
+		if rapid.Bool().Draw(t, "hasCustom") {
+			ts.FlagCustom = rapid.String().Draw(t, "custom")
+		}
+		if rapid.Bool().Draw(t, "hasEnv") {
+			ts.FlagEnv = rapid.String().Draw(t, "env")
+		}
+		return ts
+	})
+}
+
+// FieldSpec describes a generated struct field.
+type FieldSpec struct {
+	Name string
+	Type reflect.Type
+	Tags TagSet
+}
+
+// UniqueFieldSpecs generates 1–maxFields field specs with unique valid flag names.
+func UniqueFieldSpecs(maxFields int) *rapid.Generator[[]FieldSpec] {
+	return rapid.Custom(func(t *rapid.T) []FieldSpec {
+		n := rapid.IntRange(1, maxFields).Draw(t, "fieldCount")
+		usedNames := make(map[string]struct{})
+		fields := make([]FieldSpec, 0, n)
+
+		for len(fields) < n {
+			flagName := strings.ToLower(ValidFlagName().Draw(t, "flagName"))
+			if _, dup := usedNames[flagName]; dup {
+				continue
+			}
+			usedNames[flagName] = struct{}{}
+
+			fieldType := FieldType().Draw(t, "fieldType")
+			tags := ValidTagSet(flagName).Draw(t, "tags")
+
+			// Field name must be exported (uppercase first letter)
+			exportedName := fmt.Sprintf("F%d", len(fields))
+
+			fields = append(fields, FieldSpec{
+				Name: exportedName,
+				Type: fieldType,
+				Tags: tags,
+			})
+		}
+		return fields
+	})
+}
+
+// BuildStructType creates a reflect.Type from field specs.
+func BuildStructType(specs []FieldSpec) reflect.Type {
+	fields := make([]reflect.StructField, len(specs))
+	for i, s := range specs {
+		fields[i] = reflect.StructField{
+			Name: s.Name,
+			Type: s.Type,
+			Tag:  s.Tags.ToStructTag(),
+		}
+	}
+	return reflect.StructOf(fields)
+}
+
+// NewStructValue creates a zero-valued pointer to a struct of the given type.
+func NewStructValue(typ reflect.Type) any {
+	return reflect.New(typ).Interface()
+}
+
+// IsValidFlagNameCheck checks if a string matches the valid flag name regex.
+// Duplicated here to avoid importing internal/tag from the gen package.
+func IsValidFlagNameCheck(name string) bool {
+	return validFlagNameRegex.MatchString(name)
+}
+
+// FlagNameForField returns the flag name that Define/validation would use.
+func FlagNameForField(spec FieldSpec) string {
+	if spec.Tags.Flag != "" {
+		return spec.Tags.Flag
+	}
+	return strings.ToLower(spec.Name)
+}

--- a/internal/proptest/validation/validation_prop_test.go
+++ b/internal/proptest/validation/validation_prop_test.go
@@ -120,11 +120,11 @@ func TestProperty_Validation_AllowsHiddenAndRequired(t *testing.T) {
 	})
 }
 
-// --- P2.5: Validation rejects struct-only tags on struct-typed fields ---
+// --- P2.5: Validation rejects leaf-only tags on struct-typed fields ---
 
-func TestProperty_Validation_RejectsStructOnlyTagsOnStructFields(t *testing.T) {
+func TestProperty_Validation_RejectsLeafOnlyTagsOnStructFields(t *testing.T) {
 	// Tags like flagshort, flagcustom, flagignore, flagrequired, flaghidden
-	// are invalid on struct-typed fields.
+	// are valid only on leaf (non-struct) fields and rejected on struct fields.
 	tags := []struct {
 		name string
 		tag  string
@@ -314,22 +314,6 @@ func TestProperty_Validation_AcceptsWellFormedStructs(t *testing.T) {
 // --- P2.10: Validation errors are always well-typed ---
 
 func TestProperty_Validation_ErrorsAreWellTyped(t *testing.T) {
-	knownErrorTypes := []any{
-		(*structclierrors.InvalidBooleanTagError)(nil),
-		(*structclierrors.InvalidShorthandError)(nil),
-		(*structclierrors.InvalidTagUsageError)(nil),
-		(*structclierrors.ConflictingTagsError)(nil),
-		(*structclierrors.DuplicateFlagError)(nil),
-		(*structclierrors.InvalidFlagNameError)(nil),
-		(*structclierrors.ConflictingTypeError)(nil),
-		(*structclierrors.InputError)(nil),
-		(*structclierrors.MissingDefineHookError)(nil),
-		(*structclierrors.MissingDecodeHookError)(nil),
-		(*structclierrors.InvalidDefineHookSignatureError)(nil),
-		(*structclierrors.InvalidDecodeHookSignatureError)(nil),
-		(*structclierrors.InvalidCompleteHookSignatureError)(nil),
-	}
-
 	rapid.Check(t, func(t *rapid.T) {
 		specs := gen.UniqueFieldSpecs(4).Draw(t, "fields")
 		typ := gen.BuildStructType(specs)
@@ -340,27 +324,48 @@ func TestProperty_Validation_ErrorsAreWellTyped(t *testing.T) {
 			return // success is fine
 		}
 
-		// The error should either be a known typed error or wrap one.
 		// Validation wraps errors with fmt.Errorf("validation failed: %w", ...),
-		// so we need to unwrap.
-		unwrapped := errors.Unwrap(err)
-		if unwrapped == nil {
-			unwrapped = err
+		// so unwrap first.
+		inner := errors.Unwrap(err)
+		if inner == nil {
+			inner = err
 		}
 
-		for _, knownType := range knownErrorTypes {
-			target := reflect.New(reflect.TypeOf(knownType).Elem()).Interface()
-			if errors.As(unwrapped, &target) {
-				return // matched a known type
-			}
-		}
+		// Check against each known error type with concrete typed pointers.
+		// Using *any as the errors.As target would match everything — each
+		// check must use a concretely-typed pointer variable.
+		var (
+			invalidBoolTag     *structclierrors.InvalidBooleanTagError
+			invalidShorthand   *structclierrors.InvalidShorthandError
+			invalidTagUsage    *structclierrors.InvalidTagUsageError
+			conflictingTags    *structclierrors.ConflictingTagsError
+			duplicateFlag      *structclierrors.DuplicateFlagError
+			invalidFlagName    *structclierrors.InvalidFlagNameError
+			conflictingType    *structclierrors.ConflictingTypeError
+			inputErr           *structclierrors.InputError
+			missingDefineHook  *structclierrors.MissingDefineHookError
+			missingDecodeHook  *structclierrors.MissingDecodeHookError
+			invalidDefineSig   *structclierrors.InvalidDefineHookSignatureError
+			invalidDecodeSig   *structclierrors.InvalidDecodeHookSignatureError
+			invalidCompleteSig *structclierrors.InvalidCompleteHookSignatureError
+		)
 
-		// Also accept fmt.Errorf-wrapped errors that contain "validation failed"
-		// (these wrap the typed errors above)
-		if strings.Contains(err.Error(), "validation failed") {
-			return
+		switch {
+		case errors.As(inner, &invalidBoolTag):
+		case errors.As(inner, &invalidShorthand):
+		case errors.As(inner, &invalidTagUsage):
+		case errors.As(inner, &conflictingTags):
+		case errors.As(inner, &duplicateFlag):
+		case errors.As(inner, &invalidFlagName):
+		case errors.As(inner, &conflictingType):
+		case errors.As(inner, &inputErr):
+		case errors.As(inner, &missingDefineHook):
+		case errors.As(inner, &missingDecodeHook):
+		case errors.As(inner, &invalidDefineSig):
+		case errors.As(inner, &invalidDecodeSig):
+		case errors.As(inner, &invalidCompleteSig):
+		default:
+			t.Fatalf("validation returned unrecognized error type %T: %v", inner, inner)
 		}
-
-		t.Fatalf("validation returned unrecognized error type %T: %v", err, err)
 	})
 }

--- a/internal/proptest/validation/validation_prop_test.go
+++ b/internal/proptest/validation/validation_prop_test.go
@@ -1,0 +1,366 @@
+// Property-based tests for the validation functions in internal/validation.
+//
+// Uses pgregory.net/rapid to generate random struct types with various tag
+// combinations, then asserts invariants on the validation output.
+package validation_test
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	structclierrors "github.com/leodido/structcli/errors"
+	"github.com/leodido/structcli/internal/proptest/gen"
+	internalvalidation "github.com/leodido/structcli/internal/validation"
+	"github.com/spf13/cobra"
+	"pgregory.net/rapid"
+)
+
+// newCmd creates a fresh cobra.Command for each test iteration.
+func newCmd() *cobra.Command {
+	return &cobra.Command{Use: "test"}
+}
+
+// --- P2.1: IsValidBoolTag never panics and returns well-typed errors ---
+
+func TestProperty_IsValidBoolTag_NoPanicAndTypedErrors(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		input := rapid.String().Draw(t, "input")
+		result, err := internalvalidation.IsValidBoolTag("Field", "flagcustom", input)
+		if err != nil {
+			var target *structclierrors.InvalidBooleanTagError
+			if !errors.As(err, &target) {
+				t.Fatalf("IsValidBoolTag(%q) returned non-typed error: %v", input, err)
+			}
+		}
+		if err == nil && result != nil {
+			if *result != true && *result != false {
+				t.Fatalf("IsValidBoolTag(%q) returned non-bool value: %v", input, *result)
+			}
+		}
+	})
+}
+
+// --- P2.2: Validation rejects flagignore + flagrequired ---
+
+func TestProperty_Validation_RejectsIgnoreAndRequired(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		fieldType := gen.FieldType().Draw(t, "type")
+		flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+
+		typ := reflect.StructOf([]reflect.StructField{
+			{
+				Name: "F0",
+				Type: fieldType,
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s" flagignore:"true" flagrequired:"true"`, flagName)),
+			},
+		})
+		opts := reflect.New(typ).Interface()
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err == nil {
+			t.Fatal("expected error for flagignore+flagrequired, got nil")
+		}
+		var target *structclierrors.ConflictingTagsError
+		if !errors.As(err, &target) {
+			t.Fatalf("expected ConflictingTagsError, got: %v", err)
+		}
+	})
+}
+
+// --- P2.3: Validation rejects flaghidden + flagignore ---
+
+func TestProperty_Validation_RejectsHiddenAndIgnore(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		fieldType := gen.FieldType().Draw(t, "type")
+		flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+
+		typ := reflect.StructOf([]reflect.StructField{
+			{
+				Name: "F0",
+				Type: fieldType,
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s" flaghidden:"true" flagignore:"true"`, flagName)),
+			},
+		})
+		opts := reflect.New(typ).Interface()
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err == nil {
+			t.Fatal("expected error for flaghidden+flagignore, got nil")
+		}
+		var target *structclierrors.ConflictingTagsError
+		if !errors.As(err, &target) {
+			t.Fatalf("expected ConflictingTagsError, got: %v", err)
+		}
+	})
+}
+
+// --- P2.4: Validation allows flaghidden + flagrequired ---
+
+func TestProperty_Validation_AllowsHiddenAndRequired(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		fieldType := gen.FieldType().Draw(t, "type")
+		flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+
+		typ := reflect.StructOf([]reflect.StructField{
+			{
+				Name: "F0",
+				Type: fieldType,
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s" flaghidden:"true" flagrequired:"true"`, flagName)),
+			},
+		})
+		opts := reflect.New(typ).Interface()
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err != nil {
+			t.Fatalf("flaghidden+flagrequired should be allowed, got: %v", err)
+		}
+	})
+}
+
+// --- P2.5: Validation rejects struct-only tags on struct-typed fields ---
+
+func TestProperty_Validation_RejectsStructOnlyTagsOnStructFields(t *testing.T) {
+	// Tags like flagshort, flagcustom, flagignore, flagrequired, flaghidden
+	// are invalid on struct-typed fields.
+	tags := []struct {
+		name string
+		tag  string
+	}{
+		{"flagshort", `flagshort:"x"`},
+		{"flagcustom", `flagcustom:"true"`},
+		{"flagignore", `flagignore:"true"`},
+		{"flagrequired", `flagrequired:"true"`},
+		{"flaghidden", `flaghidden:"true"`},
+	}
+
+	for _, tc := range tags {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			rapid.Check(t, func(t *rapid.T) {
+				// Create an inner struct type
+				innerType := reflect.StructOf([]reflect.StructField{
+					{
+						Name: "Inner",
+						Type: reflect.TypeOf(""),
+						Tag:  reflect.StructTag(`flag:"inner"`),
+					},
+				})
+
+				outerType := reflect.StructOf([]reflect.StructField{
+					{
+						Name: "Nested",
+						Type: innerType,
+						Tag:  reflect.StructTag(tc.tag),
+					},
+				})
+				opts := reflect.New(outerType).Interface()
+
+				err := internalvalidation.Struct(newCmd(), opts)
+				if err == nil {
+					t.Fatalf("expected error for %s on struct field, got nil", tc.name)
+				}
+				var target *structclierrors.InvalidTagUsageError
+				if !errors.As(err, &target) {
+					t.Fatalf("expected InvalidTagUsageError for %s, got: %v", tc.name, err)
+				}
+			})
+		})
+	}
+}
+
+// --- P2.6: Validation rejects duplicate flag names ---
+
+func TestProperty_Validation_RejectsDuplicateFlagNames(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+		typeA := gen.FieldType().Draw(t, "typeA")
+		typeB := gen.FieldType().Draw(t, "typeB")
+
+		typ := reflect.StructOf([]reflect.StructField{
+			{
+				Name: "F0",
+				Type: typeA,
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s"`, flagName)),
+			},
+			{
+				Name: "F1",
+				Type: typeB,
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s"`, flagName)),
+			},
+		})
+		opts := reflect.New(typ).Interface()
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err == nil {
+			t.Fatalf("expected error for duplicate flag name %q, got nil", flagName)
+		}
+		var target *structclierrors.DuplicateFlagError
+		if !errors.As(err, &target) {
+			t.Fatalf("expected DuplicateFlagError, got: %v", err)
+		}
+	})
+}
+
+// --- P2.7: Validation rejects invalid flag names ---
+
+func TestProperty_Validation_RejectsInvalidFlagNames(t *testing.T) {
+	// Generate strings that are invalid flag names AND survive struct tag
+	// encoding (no quotes, backslashes, or control chars that would make
+	// Tag.Get return empty and fall back to the valid field name).
+	invalidNames := rapid.OneOf(
+		rapid.Just("bad name"),
+		rapid.Just("has space"),
+		rapid.Just("-leading"),
+		rapid.Just(".leading"),
+		rapid.Just("trailing-"),
+		rapid.Just("trailing."),
+		rapid.Just("a--b"),
+		rapid.Just("a..b"),
+		rapid.Just("a b c"),
+		rapid.Just("foo!bar"),
+		rapid.Just("x@y"),
+		rapid.StringMatching(`[a-zA-Z][a-zA-Z0-9]*[ !@#$%^&*()][a-zA-Z0-9]+`),
+	)
+
+	rapid.Check(t, func(t *rapid.T) {
+		flagName := invalidNames.Draw(t, "flagName")
+		// Skip if it accidentally matches the valid pattern
+		if gen.IsValidFlagNameCheck(flagName) {
+			return
+		}
+		// Skip names with chars that break struct tag parsing
+		if strings.ContainsAny(flagName, `"\\`) {
+			return
+		}
+
+		typ := reflect.StructOf([]reflect.StructField{
+			{
+				Name: "F0",
+				Type: reflect.TypeOf(""),
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s"`, flagName)),
+			},
+		})
+
+		// Verify the tag round-trips correctly
+		if typ.Field(0).Tag.Get("flag") != flagName {
+			return // tag encoding mangled the name, skip
+		}
+
+		opts := reflect.New(typ).Interface()
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err == nil {
+			t.Fatalf("expected error for invalid flag name %q, got nil", flagName)
+		}
+		var target *structclierrors.InvalidFlagNameError
+		if !errors.As(err, &target) {
+			t.Fatalf("expected InvalidFlagNameError for %q, got: %v", flagName, err)
+		}
+	})
+}
+
+// --- P2.8: Validation rejects invalid boolean tag values ---
+
+func TestProperty_Validation_RejectsInvalidBooleanTagValues(t *testing.T) {
+	boolTags := []string{"flagcustom", "flagenv", "flagignore", "flagrequired", "flaghidden"}
+
+	for _, tagName := range boolTags {
+		tagName := tagName
+		t.Run(tagName, func(t *testing.T) {
+			rapid.Check(t, func(t *rapid.T) {
+				badVal := gen.InvalidBoolTagValue().Draw(t, "badVal")
+				flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+
+				typ := reflect.StructOf([]reflect.StructField{
+					{
+						Name: "F0",
+						Type: reflect.TypeOf(""),
+						Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s" %s:"%s"`, flagName, tagName, badVal)),
+					},
+				})
+				opts := reflect.New(typ).Interface()
+
+				err := internalvalidation.Struct(newCmd(), opts)
+				if err == nil {
+					t.Fatalf("expected error for %s=%q, got nil", tagName, badVal)
+				}
+				var target *structclierrors.InvalidBooleanTagError
+				if !errors.As(err, &target) {
+					t.Fatalf("expected InvalidBooleanTagError for %s=%q, got: %v", tagName, badVal, err)
+				}
+			})
+		})
+	}
+}
+
+// --- P2.9: Validation accepts well-formed structs ---
+
+func TestProperty_Validation_AcceptsWellFormedStructs(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		specs := gen.UniqueFieldSpecs(6).Draw(t, "fields")
+		typ := gen.BuildStructType(specs)
+		opts := gen.NewStructValue(typ)
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err != nil {
+			t.Fatalf("expected nil error for well-formed struct, got: %v\nspecs: %+v", err, specs)
+		}
+	})
+}
+
+// --- P2.10: Validation errors are always well-typed ---
+
+func TestProperty_Validation_ErrorsAreWellTyped(t *testing.T) {
+	knownErrorTypes := []any{
+		(*structclierrors.InvalidBooleanTagError)(nil),
+		(*structclierrors.InvalidShorthandError)(nil),
+		(*structclierrors.InvalidTagUsageError)(nil),
+		(*structclierrors.ConflictingTagsError)(nil),
+		(*structclierrors.DuplicateFlagError)(nil),
+		(*structclierrors.InvalidFlagNameError)(nil),
+		(*structclierrors.ConflictingTypeError)(nil),
+		(*structclierrors.InputError)(nil),
+		(*structclierrors.MissingDefineHookError)(nil),
+		(*structclierrors.MissingDecodeHookError)(nil),
+		(*structclierrors.InvalidDefineHookSignatureError)(nil),
+		(*structclierrors.InvalidDecodeHookSignatureError)(nil),
+		(*structclierrors.InvalidCompleteHookSignatureError)(nil),
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		specs := gen.UniqueFieldSpecs(4).Draw(t, "fields")
+		typ := gen.BuildStructType(specs)
+		opts := gen.NewStructValue(typ)
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err == nil {
+			return // success is fine
+		}
+
+		// The error should either be a known typed error or wrap one.
+		// Validation wraps errors with fmt.Errorf("validation failed: %w", ...),
+		// so we need to unwrap.
+		unwrapped := errors.Unwrap(err)
+		if unwrapped == nil {
+			unwrapped = err
+		}
+
+		for _, knownType := range knownErrorTypes {
+			target := reflect.New(reflect.TypeOf(knownType).Elem()).Interface()
+			if errors.As(unwrapped, &target) {
+				return // matched a known type
+			}
+		}
+
+		// Also accept fmt.Errorf-wrapped errors that contain "validation failed"
+		// (these wrap the typed errors above)
+		if strings.Contains(err.Error(), "validation failed") {
+			return
+		}
+
+		t.Fatalf("validation returned unrecognized error type %T: %v", err, err)
+	})
+}


### PR DESCRIPTION
## Description

Second of 3 PRs adding `rapid`-based property tests (per spec.md). This one covers `internal/validation`: `Struct`, `Fields`, `IsValidBoolTag`.

Also introduces `internal/proptest/gen/` — shared generators for struct type and tag set generation, reused by this PR and the upcoming Define() PR.

**Properties:**

| ID | Property | What it asserts |
|---|---|---|
| P2.1 | `IsValidBoolTag` typed errors | Never panics; errors are `*InvalidBooleanTagError` |
| P2.2 | `flagignore` + `flagrequired` | Returns `*ConflictingTagsError` |
| P2.3 | `flaghidden` + `flagignore` | Returns `*ConflictingTagsError` |
| P2.4 | `flaghidden` + `flagrequired` | Allowed (no error) |
| P2.5 | Struct-only tags on struct fields | Returns `*InvalidTagUsageError` (5 tags tested) |
| P2.6 | Duplicate flag names | Returns `*DuplicateFlagError` |
| P2.7 | Invalid flag names | Returns `*InvalidFlagNameError` |
| P2.8 | Invalid boolean tag values | Returns `*InvalidBooleanTagError` (5 tags tested) |
| P2.9 | Well-formed structs | Pass validation (nil error) |
| P2.10 | Error typing | All errors are known `structclierrors` types |

**Shared generators (`internal/proptest/gen/`):**
- `FieldType()` — draws from supported field types
- `ValidFlagName()` — generates regex-valid flag names
- `ValidTagSet()` / `ArbitraryTagSet()` — generates tag combinations
- `UniqueFieldSpecs()` — generates N fields with unique flag names
- `BuildStructType()` / `NewStructValue()` — creates `reflect.StructOf` types

Stacked on PR #106 (tag parsing property tests).

## How to test

```
go test -v ./internal/proptest/validation/
```