### PR TITLE
fix: P1.2 preset round-trip must exclude comma from values

### DIFF
--- a/internal/proptest/tag/tag_prop_test.go
+++ b/internal/proptest/tag/tag_prop_test.go
@@ -116,8 +116,9 @@ func TestProperty_ParseFlagPresets_RoundTrip(t *testing.T) {
 				continue
 			}
 			seen[name] = struct{}{}
-			// Values must not contain ';' to avoid splitting ambiguity
-			value := rapid.StringMatching(`[^;]*`).Draw(t, "value")
+			// Values must not contain ';' or ',' to avoid splitting ambiguity
+			// (ParseFlagPresets falls back to comma when no semicolons are present)
+			value := rapid.StringMatching(`[^;,]*`).Draw(t, "value")
 			entries = append(entries, entry{name, value})
 		}
 


### PR DESCRIPTION
## Description

The P1.2 property test (`TestProperty_ParseFlagPresets_RoundTrip`) generates random preset values with `[^;]*`, which allows commas. When the value is literally `,`, the tag becomes `0.0=,` — `ParseFlagPresets` falls back to comma splitting (no semicolons present), producing an empty entry.

Fix: exclude both `;` and `,` from the value generator (`[^,;]*`), matching the P1.2b comma round-trip test that already did this correctly.

Reproducer: `-rapid.seed=11156423050840467246`

## How to test

```
go test ./internal/proptest/tag/ -run TestProperty_ParseFlagPresets_RoundTrip -rapid.seed=11156423050840467246
```