### PR TITLE
fix: filter non-callable commands in agents.go and skill.go

### DIFF
--- a/generate/agents.go
+++ b/generate/agents.go
@@ -34,6 +34,15 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 	root := schemas[0]
 	cliName := root.Name
 
+	// Filter to callable commands only (commands with a Run/RunE handler)
+	cmdMap := buildCommandMap(rootCmd)
+	var callables []*structcli.CommandSchema
+	for _, s := range schemas {
+		if isCallableCommand(s, cmdMap[s.CommandPath]) {
+			callables = append(callables, s)
+		}
+	}
+
 	var buf bytes.Buffer
 
 	// Header
@@ -51,7 +60,7 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 	fmt.Fprintf(&buf, "## Commands\n\n")
 	fmt.Fprintf(&buf, "| Command | Description | Required Flags |\n")
 	fmt.Fprintf(&buf, "|---------|-------------|---------------|\n")
-	for _, s := range schemas {
+	for _, s := range callables {
 		reqFlags := requiredFlags(s)
 		desc := s.Description
 		if desc == "" {
@@ -63,7 +72,7 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 
 	// Flags per command
 	fmt.Fprintf(&buf, "## Configuration\n\n### Flags\n\n")
-	for _, s := range schemas {
+	for _, s := range callables {
 		if len(s.Flags) == 0 {
 			continue
 		}
@@ -85,7 +94,7 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 	}
 
 	// Environment variables (aggregated, deduplicated)
-	envRows := collectEnvVars(schemas)
+	envRows := collectEnvVars(callables)
 	if len(envRows) > 0 {
 		fmt.Fprintf(&buf, "### Environment Variables\n\n")
 		fmt.Fprintf(&buf, "| Variable | Flag | Default |\n")

--- a/generate/skill.go
+++ b/generate/skill.go
@@ -36,6 +36,14 @@ func Skill(rootCmd *cobra.Command, opts SkillOptions) ([]byte, error) {
 	// Sort for deterministic output
 	schemas = sortedSchemas(schemas)
 
+	// Filter to callable commands only
+	var callables []*structcli.CommandSchema
+	for _, s := range schemas {
+		if isCallableCommand(s, cmdMap[s.CommandPath]) {
+			callables = append(callables, s)
+		}
+	}
+
 	rootSchema := schemas[0]
 
 	name := opts.Name
@@ -75,7 +83,7 @@ func Skill(rootCmd *cobra.Command, opts SkillOptions) ([]byte, error) {
 	fmt.Fprintf(&buf, "## Instructions\n\n")
 	fmt.Fprintf(&buf, "### Available Commands\n")
 
-	for _, schema := range schemas {
+	for _, schema := range callables {
 		cmd := cmdMap[schema.CommandPath]
 		writeCommandSection(&buf, schema, cmd)
 	}
@@ -87,7 +95,7 @@ func Skill(rootCmd *cobra.Command, opts SkillOptions) ([]byte, error) {
 	}
 
 	// Aggregate examples
-	examples := collectExamples(schemas, cmdMap)
+	examples := collectExamples(callables, cmdMap)
 	if len(examples) > 0 {
 		fmt.Fprintf(&buf, "\n### Examples\n")
 		for _, ex := range examples {


### PR DESCRIPTION
## Description

`agents.go` included all commands (including non-runnable parent commands) in the commands table, flags section, and env vars. `skill.go` had the same bug in its Available Commands section — it wrote a section for every command without filtering. `llmstxt.go` already filtered correctly via `isCallableCommand`.

This applies the same `isCallableCommand` filter to both files.

## How to test

```bash
go test ./generate/ -v
```