### PR TITLE
test: verify non-callable commands are excluded from all generators

### DIFF
--- a/generate/agents_test.go
+++ b/generate/agents_test.go
@@ -149,6 +149,67 @@ func TestAgents_EmptyFlagDescription(t *testing.T) {
 	assert.Contains(t, line, "| - |")
 }
 
+func TestAgents_NonCallableCommandsExcluded(t *testing.T) {
+	// buildRunnableParentTree: root (non-callable), srv (callable, Run), srv version (callable, RunE)
+	root := buildRunnableParentTree()
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+
+	// Non-callable root should not appear in the commands table
+	assert.NotContains(t, content, "| `myapp` |", "non-callable root should not appear in commands table")
+
+	// Callable subcommands should appear
+	assert.Contains(t, content, "| `myapp srv` |")
+	assert.Contains(t, content, "| `myapp srv version` |")
+}
+
+func TestAgents_NonCallableCommandFlagsExcluded(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+
+	// Root is non-callable container with a persistent flag
+	root := &cobra.Command{Use: "app", Short: "A CLI"}
+	root.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+
+	sub := &cobra.Command{Use: "run", Short: "Run something", RunE: noop}
+	sub.Flags().Int("count", 1, "Repeat count")
+	root.AddCommand(sub)
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+
+	// Non-callable root's flags section should not appear
+	assert.NotContains(t, content, "#### `app`", "non-callable root should not have a flags section")
+
+	// Callable sub's flags should appear
+	assert.Contains(t, content, "#### `app run`")
+	assert.Contains(t, content, "--count")
+}
+
+func TestAgents_ZeroFlagCommand(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}
+
+	// Subcommand with no flags
+	sub := &cobra.Command{Use: "ping", Short: "Ping the server", RunE: noop}
+	root.AddCommand(sub)
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+
+	// Both commands should appear in the table
+	assert.Contains(t, content, "| `app` |")
+	assert.Contains(t, content, "| `app ping` |")
+
+	// No flags section for ping (zero flags)
+	assert.NotContains(t, content, "#### `app ping`")
+}
+
 // --- helpers ---
 
 func extractSection(content, heading string) string {

--- a/generate/llmstxt_test.go
+++ b/generate/llmstxt_test.go
@@ -170,6 +170,22 @@ func TestLLMsTxt_EmptyDescription(t *testing.T) {
 	assert.NotContains(t, content, "> \n")
 }
 
+func TestLLMsTxt_NonCallableCommandsExcluded(t *testing.T) {
+	// buildRunnableParentTree: root (non-callable), srv (callable), srv version (callable)
+	root := buildRunnableParentTree()
+	out, err := generate.LLMsTxt(root, generate.LLMsTxtOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+
+	// Non-callable root should not appear as a command section
+	assert.NotContains(t, content, "## myapp\n", "non-callable root should not have its own section")
+
+	// Callable subcommands should appear
+	assert.Contains(t, content, "## myapp srv")
+	assert.Contains(t, content, "## myapp srv version")
+}
+
 func TestLLMsTxt_EmptyFlagDescription(t *testing.T) {
 	noop := func(cmd *cobra.Command, args []string) error { return nil }
 	root := &cobra.Command{Use: "app", Short: "App", RunE: noop}

--- a/generate/skill_test.go
+++ b/generate/skill_test.go
@@ -279,6 +279,43 @@ func TestSkill_DescriptionSkipsRootCommandTrigger(t *testing.T) {
 	assert.NotContains(t, content, "Use when you need to: a test cli application")
 }
 
+func TestSkill_NonCallableCommandsExcluded(t *testing.T) {
+	// buildRunnableParentTree: root (non-callable), srv (callable), srv version (callable)
+	root := buildRunnableParentTree()
+	out, err := generate.Skill(root, generate.SkillOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+
+	// Non-callable root should not appear as a command in the flags table
+	// (skill.go uses isCallableCommand to filter)
+	assert.NotContains(t, content, "### `myapp`\n", "non-callable root should not have its own command section")
+
+	// Callable subcommands should appear
+	assert.Contains(t, content, "### `myapp srv`")
+	assert.Contains(t, content, "### `myapp srv version`")
+}
+
+func TestSkill_NonCallableExamplesExcluded(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{
+		Use:     "myapp",
+		Short:   "A CLI",
+		Example: "myapp --help",
+	}
+	sub := &cobra.Command{Use: "run", Short: "Run", RunE: noop,
+		Example: "myapp run --fast"}
+	root.AddCommand(sub)
+
+	out, err := generate.Skill(root, generate.SkillOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+	assert.NotContains(t, content, "myapp --help",
+		"non-callable root example should not appear")
+	assert.Contains(t, content, "myapp run --fast")
+}
+
 // --- helpers ---
 
 func findTableLine(section, substr string) string {


### PR DESCRIPTION
## Description

Stacked on #111. Adds 5 tests verifying that non-callable commands (container commands with no `RunE`/`Run`) are excluded from all three generators:

- `TestAgents_NonCallableCommandsExcluded` — non-callable root excluded from commands table
- `TestAgents_NonCallableCommandFlagsExcluded` — non-callable root's flags section excluded
- `TestAgents_ZeroFlagCommand` — callable command with zero flags has no flags section
- `TestLLMsTxt_NonCallableCommandsExcluded` — non-callable root excluded from command sections
- `TestSkill_NonCallableCommandsExcluded` — non-callable root excluded from Available Commands

## How to test

```bash
go test ./generate/ -v -run 'NonCallable|ZeroFlag'
```