### PR TITLE
feat: implement `flagenv:"only"` for env-only options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: '~1.24.0'
+          check-latest: true
+
+      - name: Verify generated files are up to date
+        run: |
+          (cd examples/full && go generate ./...)
+          if ! git diff --quiet examples/full/; then
+            echo "::error::Generated files in examples/full/ are stale. Run 'cd examples/full && go generate ./...' and commit the result."
+            git diff examples/full/
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ From the previous options struct, you get the following env vars automatically:
 - `FULL_SRV_LOGFILE`, `FULL_SRV_LOG_FILE`
 
 Every struct field with the `flagenv:"true"` tag gets an environment variable (two if the struct field also has the `flag:"..."` tag, see struct field `LogFile`).
+Use `flagenv:"only"` for fields that should be settable exclusively via environment variable or config file — CLI usage (`--flag=value`) is rejected at runtime.
 
 The prefix of the environment variable name is the CLI name plus the command name to which those options are attached to.
 
@@ -682,7 +683,7 @@ Use these tags in your struct fields to control the behavior:
 | `flagshort`    | Sets a single-character shorthand for the flag                                                                                          | `flagshort:"l"`             |
 | `flagdescr`    | Provides the help text for the flag                                                                                                     | `flagdescr:"Logging level"` |
 | `default`      | Sets the default value for the flag                                                                                                     | `default:"info"`            |
-| `flagenv`      | Enables binding to an environment variable (`"true"`/`"false"`)                                                                         | `flagenv:"true"`            |
+| `flagenv`      | Enables binding to an environment variable (`"true"`, `"false"`, or `"only"`)                                                           | `flagenv:"true"`            |
 | `flagrequired` | Marks the flag as required (`"true"`/`"false"`)                                                                                         | `flagrequired:"true"`       |
 | `flaghidden`   | Hides the flag from help/usage output and machine-readable schemas while keeping it fully functional (`"true"`/`"false"`)               | `flaghidden:"true"`         |
 | `flaggroup`    | Assigns the flag to a group in the help message                                                                                         | `flaggroup:"Database"`      |
@@ -695,6 +696,13 @@ Format: `<alias>=<value>`; multiple entries can be separated by `;` or `,`.
 Example: `flagpreset:"logeverything=5;logquiet=0"` makes `--logeverything` behave like `--loglevel=5`.
 If both alias and canonical flags are passed, the last assignment in argv wins.
 It does not bypass transform/validate flow.
+
+**`flaghidden:"true" + flagenv:"true"` vs `flagenv:"only"`:**
+
+- `flaghidden:"true" + flagenv:"true"` — hidden from help, but **accepts CLI input** via `--flag=value`. Use for flags that should be discoverable only by advanced users or scripts.
+- `flagenv:"only"` — hidden from help, **rejects CLI input** at runtime. The field is settable only via environment variable or config file. Use for secrets and deployment-time configuration that should never appear on a command line.
+
+`flagenv:"only"` is incompatible with `flagshort`, `flagpreset`, `flagtype`, and `flagcustom` (these are CLI-only concepts). It supports `flagdescr`, `flaggroup`, `flagrequired`, and `default`.
 
 ## 📖 Documentation
 

--- a/define.go
+++ b/define.go
@@ -191,10 +191,28 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			cName = c.Name()
 		}
 
-		envs, defineEnv := internalenv.GetEnv(f, defineEnv, path, alias, cName)
+		envs, envMode := internalenv.GetEnv(f, defineEnv, path, alias, cName)
+		// Use := to shadow the parameter, matching the original semantics where
+		// each field's own tag value drives inheritance for struct recursion
+		// but does NOT propagate to subsequent siblings.
+		defineEnv := envMode != internalenv.EnvOff
+		envOnly := envMode == internalenv.EnvOnly
 		mandatory := internaltag.IsMandatory(f) || mandatory
 
 		kind := f.Type.Kind()
+
+		// Lint: suggest flagenv:"only" when flaghidden:"true" + flagenv:"true" is used
+		// without any flag-specific tags that would be incompatible with flagenv:"only".
+		if hidden && envMode == internalenv.EnvOn && !envOnly && kind != reflect.Struct {
+			custom, _ := strconv.ParseBool(f.Tag.Get("flagcustom"))
+			flagType := f.Tag.Get("flagtype")
+			if short == "" && len(presets) == 0 && flagType == "" && !custom {
+				fmt.Fprintf(c.ErrOrStderr(),
+					"structcli: field '%s': flaghidden:\"true\" + flagenv:\"true\" can be replaced with flagenv:\"only\" (which also rejects CLI input)\n",
+					f.Name,
+				)
+			}
+		}
 		applyFieldMetadata := func() error {
 			// Persist path metadata on each defined flag so Unmarshal can rebuild
 			// remapping state from the current command context (without package globals).
@@ -329,6 +347,15 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 		finalizeFieldDefinition := func() error {
 			if err := applyFieldMetadata(); err != nil {
 				return err
+			}
+			// Env-only: force hidden and set the env-only annotation.
+			// The flag was created normally (correct type, default, etc.)
+			// but is now hidden from CLI help and marked for schema/generators.
+			if envOnly {
+				_ = c.Flags().MarkHidden(name)
+				if err := c.Flags().SetAnnotation(name, internalenv.FlagEnvOnlyAnnotation, []string{"true"}); err != nil {
+					return fmt.Errorf("couldn't set env-only annotation for flag %s: %w", name, err)
+				}
 			}
 			if err := applyPresetAliases(); err != nil {
 				return err

--- a/define.go
+++ b/define.go
@@ -203,7 +203,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 		// Lint: suggest flagenv:"only" when flaghidden:"true" + flagenv:"true" is used
 		// without any flag-specific tags that would be incompatible with flagenv:"only".
-		if hidden && envMode == internalenv.EnvOn && !envOnly && kind != reflect.Struct {
+		if hidden && envMode == internalenv.EnvOn && kind != reflect.Struct {
 			custom, _ := strconv.ParseBool(f.Tag.Get("flagcustom"))
 			flagType := f.Tag.Get("flagtype")
 			if short == "" && len(presets) == 0 && flagType == "" && !custom {
@@ -212,6 +212,14 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 					f.Name,
 				)
 			}
+		}
+		// Lint: flaghidden:"true" is redundant with flagenv:"only" since env-only
+		// already forces the flag hidden.
+		if hidden && envOnly {
+			fmt.Fprintf(c.ErrOrStderr(),
+				"structcli: field '%s': flaghidden:\"true\" is redundant with flagenv:\"only\" (env-only fields are always hidden)\n",
+				f.Name,
+			)
 		}
 		applyFieldMetadata := func() error {
 			// Persist path metadata on each defined flag so Unmarshal can rebuild
@@ -225,9 +233,9 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				c.MarkFlagRequired(name)
 			}
 			if hidden {
-				// Error discarded: MarkHidden only fails on unknown flags,
-				// which cannot happen here since the flag was just defined above.
-				_ = c.Flags().MarkHidden(name)
+				if err := c.Flags().MarkHidden(name); err != nil {
+					return fmt.Errorf("couldn't hide flag %s: %w", name, err)
+				}
 			}
 
 			// Set the defaults
@@ -325,9 +333,9 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 					}
 				}
 				if hidden {
-					// Error discarded: MarkHidden only fails on unknown flags,
-					// which cannot happen here since the alias was just defined above.
-					_ = c.Flags().MarkHidden(aliasName)
+					if err := c.Flags().MarkHidden(aliasName); err != nil {
+						return fmt.Errorf("couldn't hide alias flag %s: %w", aliasName, err)
+					}
 				}
 			}
 
@@ -352,7 +360,9 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			// The flag was created normally (correct type, default, etc.)
 			// but is now hidden from CLI help and marked for schema/generators.
 			if envOnly {
-				_ = c.Flags().MarkHidden(name)
+				if err := c.Flags().MarkHidden(name); err != nil {
+					return fmt.Errorf("couldn't hide env-only flag %s: %w", name, err)
+				}
 				if err := c.Flags().SetAnnotation(name, internalenv.FlagEnvOnlyAnnotation, []string{"true"}); err != nil {
 					return fmt.Errorf("couldn't set env-only annotation for flag %s: %w", name, err)
 				}

--- a/define_test.go
+++ b/define_test.go
@@ -1585,7 +1585,7 @@ func (suite *structcliSuite) TestFlagenv_CombinedWithOtherTags_FailureCase() {
 	require.Error(suite.T(), err, "Should return error for invalid flagenv value")
 	assert.Contains(suite.T(), err.Error(), "flagenv", "Error should mention flagenv")
 	assert.Contains(suite.T(), err.Error(), "invalid", "Error should mention the invalid value")
-	assert.Contains(suite.T(), err.Error(), "boolean", "Error should mention that the value must be boolean")
+	assert.Contains(suite.T(), err.Error(), "expected true, false, or only", "Error should list accepted values")
 }
 
 type validFlagEnvInteractionOptions struct {
@@ -1679,7 +1679,7 @@ func (suite *structcliSuite) TestFlagenv_ErrorMessages_ContainExpectedContent() 
 	assert.Contains(suite.T(), errorMsg, "BadValue", "Error should contain field name")
 	assert.Contains(suite.T(), errorMsg, "flagenv", "Error should contain tag name")
 	assert.Contains(suite.T(), errorMsg, "maybe", "Error should contain tag value")
-	assert.Contains(suite.T(), errorMsg, "invalid boolean value", "Error should contain message")
+	assert.Contains(suite.T(), errorMsg, "expected true, false, or only", "Error should list accepted values")
 }
 
 type flagIgnoreTestOptions struct {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -114,6 +114,7 @@ func (e *ValidationError) UnderlyingErrors() []error {
 // These are all DefinitionError
 var (
 	ErrInvalidBooleanTag            = errors.New("invalid boolean tag value")
+	ErrInvalidFlagEnvTag            = errors.New("invalid flagenv tag value")
 	ErrInvalidShorthand             = errors.New("invalid shorthand flag")
 	ErrMissingDefineHook            = errors.New("missing custom flag definition hook")
 	ErrMissingDecodeHook            = errors.New("missing custom flag decoding hook")
@@ -170,6 +171,31 @@ func (e *InvalidBooleanTagError) Field() string {
 
 func (e *InvalidBooleanTagError) Unwrap() error {
 	return ErrInvalidBooleanTag
+}
+
+// InvalidFlagEnvTagError represents an invalid value for the flagenv tag.
+type InvalidFlagEnvTagError struct {
+	FieldName string
+	TagValue  string
+}
+
+func (e *InvalidFlagEnvTagError) Error() string {
+	return fmt.Sprintf("field '%s': tag 'flagenv=%s': invalid value (expected true, false, or only)", e.FieldName, e.TagValue)
+}
+
+func (e *InvalidFlagEnvTagError) Field() string {
+	return e.FieldName
+}
+
+func (e *InvalidFlagEnvTagError) Unwrap() error {
+	return ErrInvalidFlagEnvTag
+}
+
+func NewInvalidFlagEnvTagError(fieldName, tagValue string) error {
+	return &InvalidFlagEnvTagError{
+		FieldName: fieldName,
+		TagValue:  tagValue,
+	}
 }
 
 // InvalidShorthandError represents an invalid shorthand flag specification

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -490,6 +490,50 @@ func NewUnsupportedTypeError(fieldName, fieldType, message string) error {
 	}
 }
 
+var ErrMissingRequiredEnv = errors.New("missing required environment variable")
+
+var ErrEnvOnlyCLIUsage = errors.New("env-only flag set via CLI")
+
+// EnvOnlyCLIUsageError represents an attempt to set an env-only flag via the CLI.
+type EnvOnlyCLIUsageError struct {
+	FlagNames []string
+}
+
+func (e *EnvOnlyCLIUsageError) Error() string {
+	return fmt.Sprintf("flag(s) %s can only be set via environment variable, not --flag",
+		strings.Join(e.FlagNames, ", "))
+}
+
+func (e *EnvOnlyCLIUsageError) Unwrap() error {
+	return ErrEnvOnlyCLIUsage
+}
+
+// MissingRequiredEnvError represents an env-only field that was not set.
+type MissingRequiredEnvError struct {
+	FieldName string
+	EnvVars   []string
+}
+
+func (e *MissingRequiredEnvError) Error() string {
+	return fmt.Sprintf("required environment variable(s) not set: %s (for field '%s')",
+		strings.Join(e.EnvVars, " or "), e.FieldName)
+}
+
+func (e *MissingRequiredEnvError) Field() string {
+	return e.FieldName
+}
+
+func (e *MissingRequiredEnvError) Unwrap() error {
+	return ErrMissingRequiredEnv
+}
+
+func NewMissingRequiredEnvError(fieldName string, envVars []string) error {
+	return &MissingRequiredEnvError{
+		FieldName: fieldName,
+		EnvVars:   envVars,
+	}
+}
+
 var ErrInputValue = errors.New("invalid input value")
 
 // InputError represents an invalid input value for flag definition

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -76,6 +76,63 @@ func TestInvalidBooleanTagError_ErrorsAs(t *testing.T) {
 	assert.Equal(t, "TestField", fieldErr.Field())
 }
 
+func TestInvalidFlagEnvTagError_ErrorMessage(t *testing.T) {
+	err := &InvalidFlagEnvTagError{
+		FieldName: "Secret",
+		TagValue:  "oops",
+	}
+
+	expected := "field 'Secret': tag 'flagenv=oops': invalid value (expected true, false, or only)"
+	assert.Equal(t, expected, err.Error())
+}
+
+func TestInvalidFlagEnvTagError_ContainsExpectedStrings(t *testing.T) {
+	err := &InvalidFlagEnvTagError{
+		FieldName: "APIKey",
+		TagValue:  "bad",
+	}
+
+	errorMsg := err.Error()
+	assert.Contains(t, errorMsg, "APIKey")
+	assert.Contains(t, errorMsg, "flagenv")
+	assert.Contains(t, errorMsg, "bad")
+	assert.Contains(t, errorMsg, "expected true, false, or only")
+}
+
+func TestInvalidFlagEnvTagError_FieldInterface(t *testing.T) {
+	err := &InvalidFlagEnvTagError{
+		FieldName: "Token",
+		TagValue:  "nope",
+	}
+
+	var fieldErr DefinitionError = err
+	assert.Equal(t, "Token", fieldErr.Field())
+}
+
+func TestInvalidFlagEnvTagError_ErrorsIs(t *testing.T) {
+	err := &InvalidFlagEnvTagError{
+		FieldName: "Secret",
+		TagValue:  "invalid",
+	}
+
+	assert.True(t, errors.Is(err, ErrInvalidFlagEnvTag))
+	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
+	assert.False(t, errors.Is(err, ErrInvalidShorthand))
+}
+
+func TestInvalidFlagEnvTagError_ErrorsAs(t *testing.T) {
+	err := NewInvalidFlagEnvTagError("Secret", "maybe")
+
+	var flagEnvErr *InvalidFlagEnvTagError
+	require.True(t, errors.As(err, &flagEnvErr))
+	assert.Equal(t, "Secret", flagEnvErr.FieldName)
+	assert.Equal(t, "maybe", flagEnvErr.TagValue)
+
+	var fieldErr DefinitionError
+	require.True(t, errors.As(err, &fieldErr))
+	assert.Equal(t, "Secret", fieldErr.Field())
+}
+
 func TestInvalidShorthandError_ErrorMessage(t *testing.T) {
 	err := &InvalidShorthandError{
 		FieldName: "VerboseFlag",
@@ -317,6 +374,15 @@ func TestNewInvalidBooleanTagError_Constructor(t *testing.T) {
 	assert.Equal(t, "TestField", boolErr.FieldName)
 	assert.Equal(t, "flagenv", boolErr.TagName)
 	assert.Equal(t, "maybe", boolErr.TagValue)
+}
+
+func TestNewInvalidFlagEnvTagError_Constructor(t *testing.T) {
+	err := NewInvalidFlagEnvTagError("Secret", "maybe")
+
+	var flagEnvErr *InvalidFlagEnvTagError
+	require.True(t, errors.As(err, &flagEnvErr))
+	assert.Equal(t, "Secret", flagEnvErr.FieldName)
+	assert.Equal(t, "maybe", flagEnvErr.TagValue)
 }
 
 func TestNewInvalidShorthandError_Constructor(t *testing.T) {

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -92,6 +92,8 @@ go install github.com/leodido/structcli/examples/full@latest
 | `FULL_SRV_LOGFILE` | `--log-file` | - |
 | `FULL_SRV_LOG_FILE` | `--log-file` | - |
 | `FULL_SRV_PORT` | `--port` | 0 |
+| `FULL_SRV_SECRETKEY` | *(env only)* | - |
+| `FULL_SRV_SECRET_KEY` | *(env only)* | - |
 | `FULL_SRV_TOKENBASE64` | `--token-base64` | aGVsbG8= |
 | `FULL_SRV_TOKENHEX` | `--token-hex` | 68656c6c6f |
 | `FULL_SRV_TOKEN_BASE64` | `--token-base64` | aGVsbG8= |

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -16,7 +16,6 @@ go install github.com/leodido/structcli/examples/full@latest
 | `full preset` | Demonstrate that flagpreset aliases are syntactic sugar and still flow through Transform and Validate |  |
 | `full srv` | Start the server with the specified configuration | `--port` |
 | `full srv version` | Print version information |  |
-| `full usr` | Commands for managing users in the server |  |
 | `full usr add` | Add a new user to the system with the specified details |  |
 
 ## Configuration

--- a/examples/full/SKILL.md
+++ b/examples/full/SKILL.md
@@ -83,6 +83,8 @@ Start the server with the specified configuration
 | `FULL_SRV_LOGFILE` | `--log-file` | Log file path |
 | `FULL_SRV_LOG_FILE` | `--log-file` | Log file path |
 | `FULL_SRV_PORT` | `--port` | Server port |
+| `FULL_SRV_SECRETKEY` | *(env only)* | Secret signing key (env only) |
+| `FULL_SRV_SECRET_KEY` | *(env only)* | Secret signing key (env only) |
 | `FULL_SRV_TOKENBASE64` | `--token-base64` | Token bytes encoded as base64 |
 | `FULL_SRV_TOKEN_BASE64` | `--token-base64` | Token bytes encoded as base64 |
 | `FULL_SRV_TOKENHEX` | `--token-hex` | Token bytes encoded as hex |

--- a/examples/full/SKILL.md
+++ b/examples/full/SKILL.md
@@ -4,7 +4,7 @@ description: |
   A demonstration of the structcli library with beautiful CLI features. Use when you need to: demonstrate that flagpreset aliases are syntactic sugar and still flow through transform and validate, start the server with the specified configuration, print version information, add a new user to the system with the specified details.
 metadata:
   author: leodido
-  version: 0.13.0
+  version: 0.15.0
 ---
 
 # full
@@ -107,10 +107,6 @@ Print version information
 |----------|------|-------------|
 | `FULL_DRYRUN` | `--dry` |  |
 | `FULL_DRY` | `--dry` |  |
-
-#### `full usr`
-
-Commands for managing users in the server
 
 #### `full usr add`
 

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -46,6 +46,9 @@ type ServerOptions struct {
 	// Environment variable binding
 	APIKey string `flagenv:"true" flagdescr:"API authentication key"`
 
+	// Env-only field: settable only via environment variable, not CLI flag
+	SecretKey string `flagenv:"only" flag:"secret-key" flagdescr:"Secret signing key (env only)"`
+
 	// Same in-memory type (bytes), different textual contracts at the CLI boundary.
 	TokenHex    structcli.Hex    `flag:"token-hex" flaggroup:"Security" flagdescr:"Token bytes encoded as hex" flagenv:"true" default:"68656c6c6f"`
 	TokenBase64 structcli.Base64 `flag:"token-base64" flaggroup:"Security" flagdescr:"Token bytes encoded as base64" flagenv:"true" default:"aGVsbG8="`

--- a/examples/full/llms.txt
+++ b/examples/full/llms.txt
@@ -72,6 +72,8 @@ Start the server with the specified configuration
 - `FULL_SRV_LOGFILE`: maps to `--log-file`
 - `FULL_SRV_LOG_FILE`: maps to `--log-file`
 - `FULL_SRV_PORT`: maps to `--port`
+- `FULL_SRV_SECRETKEY`: env only (no CLI flag)
+- `FULL_SRV_SECRET_KEY`: env only (no CLI flag)
 - `FULL_SRV_TOKENBASE64`: maps to `--token-base64`
 - `FULL_SRV_TOKEN_BASE64`: maps to `--token-base64`
 - `FULL_SRV_TOKENHEX`: maps to `--token-hex`

--- a/exitcode/exitcode.go
+++ b/exitcode/exitcode.go
@@ -76,10 +76,8 @@ const (
 	// wrong format or type for its target flag.
 	EnvInvalidValue = 25
 
-	// EnvMissingRequired is reserved for future env-only required inputs.
-	// HandleError currently reports missing required flags/inputs as
-	// MissingRequiredFlag and may include env fallback hints in the
-	// structured error payload instead.
+	// EnvMissingRequired indicates a flagenv:"only" field with
+	// flagrequired:"true" had no environment variable set at execution time.
 	EnvMissingRequired = 26
 )
 

--- a/flagenvonly_test.go
+++ b/flagenvonly_test.go
@@ -1,0 +1,547 @@
+package structcli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	structclierrors "github.com/leodido/structcli/errors"
+	internalenv "github.com/leodido/structcli/internal/env"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Option structs ---
+
+type envOnlyOptions struct {
+	Secret  string `flagenv:"only" flag:"secret" flagdescr:"a secret value"`
+	Visible string `flag:"visible" flagdescr:"a visible flag"`
+}
+
+func (o *envOnlyOptions) Attach(c *cobra.Command) error { return nil }
+
+type envOnlyRequiredOptions struct {
+	APIKey string `flagenv:"only" flag:"api-key" flagrequired:"true" flagdescr:"API key"`
+}
+
+func (o *envOnlyRequiredOptions) Attach(c *cobra.Command) error { return nil }
+
+type envOnlyDefaultOptions struct {
+	Port string `flagenv:"only" flag:"port" default:"8080" flagdescr:"server port"`
+}
+
+func (o *envOnlyDefaultOptions) Attach(c *cobra.Command) error { return nil }
+
+type envOnlyWithGroupOptions struct {
+	Token string `flagenv:"only" flag:"token" flaggroup:"auth" flagdescr:"auth token"`
+}
+
+func (o *envOnlyWithGroupOptions) Attach(c *cobra.Command) error { return nil }
+
+type envOnlyWithDescrOptions struct {
+	Key string `flagenv:"only" flag:"key" flagdescr:"encryption key"`
+}
+
+func (o *envOnlyWithDescrOptions) Attach(c *cobra.Command) error { return nil }
+
+// --- Invalid combinations ---
+
+type envOnlyWithShortOptions struct {
+	Bad string `flagenv:"only" flag:"bad" flagshort:"b"`
+}
+
+func (o *envOnlyWithShortOptions) Attach(c *cobra.Command) error { return nil }
+
+type envOnlyWithPresetOptions struct {
+	Bad string `flagenv:"only" flag:"bad" flagpreset:"max=10"`
+}
+
+func (o *envOnlyWithPresetOptions) Attach(c *cobra.Command) error { return nil }
+
+type envOnlyWithTypeOptions struct {
+	Bad int `flagenv:"only" flag:"bad" flagtype:"count"`
+}
+
+func (o *envOnlyWithTypeOptions) Attach(c *cobra.Command) error { return nil }
+
+type envOnlyWithCustomOptions struct {
+	Bad string `flagenv:"only" flag:"bad" flagcustom:"true"`
+}
+
+func (o *envOnlyWithCustomOptions) Attach(c *cobra.Command) error { return nil }
+
+func (o *envOnlyWithCustomOptions) DefineBad(name, alias, group string, f reflect.StructField, v reflect.Value) (pflag.Value, string) {
+	return nil, ""
+}
+func (o *envOnlyWithCustomOptions) DecodeBad(name, alias, group string, f reflect.StructField, v reflect.Value) error {
+	return nil
+}
+
+type envOnlyWithIgnoreOptions struct {
+	Bad string `flagenv:"only" flagignore:"true"`
+}
+
+func (o *envOnlyWithIgnoreOptions) Attach(c *cobra.Command) error { return nil }
+
+// --- Struct inheritance ---
+
+type envOnlyStructOptions struct {
+	Auth envOnlyStructAuth `flagenv:"only"`
+}
+
+type envOnlyStructAuth struct {
+	User string `flag:"user" flagdescr:"username"`
+	Pass string `flag:"pass" flagdescr:"password"`
+}
+
+func (o *envOnlyStructOptions) Attach(c *cobra.Command) error { return nil }
+
+// --- Test helpers ---
+
+func resetEnvOnlyTestState() {
+	viper.Reset()
+	SetEnvPrefix("")
+}
+
+// --- Validation tests ---
+
+func TestDefine_EnvOnly_Accepted(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyOptions{}
+	err := Define(cmd, opts)
+	require.NoError(t, err)
+
+	// Carrier flag exists and is hidden
+	flag := cmd.Flags().Lookup("secret")
+	require.NotNil(t, flag)
+	assert.True(t, flag.Hidden, "env-only carrier flag should be hidden")
+
+	// Has env-only annotation
+	envOnlyAnnotation := flag.Annotations[internalenv.FlagEnvOnlyAnnotation]
+	assert.Equal(t, []string{"true"}, envOnlyAnnotation)
+
+	// Has env annotation
+	envAnnotation := flag.Annotations[internalenv.FlagAnnotation]
+	assert.NotEmpty(t, envAnnotation, "env-only flag should have env annotation")
+
+	// Visible flag still works normally
+	visibleFlag := cmd.Flags().Lookup("visible")
+	require.NotNil(t, visibleFlag)
+	assert.False(t, visibleFlag.Hidden)
+}
+
+func TestDefine_EnvOnly_WithDescr_Accepted(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyWithDescrOptions{}
+	err := Define(cmd, opts)
+	require.NoError(t, err)
+}
+
+func TestDefine_EnvOnly_WithGroup_Accepted(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyWithGroupOptions{}
+	err := Define(cmd, opts)
+	require.NoError(t, err)
+}
+
+func TestDefine_EnvOnly_WithRequired_Accepted(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyRequiredOptions{}
+	err := Define(cmd, opts)
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("api-key")
+	require.NotNil(t, flag)
+
+	// Should have cobra's standard required annotation (env-only uses MarkFlagRequired normally)
+	reqAnnotation := flag.Annotations[cobra.BashCompOneRequiredFlag]
+	assert.Equal(t, []string{"true"}, reqAnnotation)
+}
+
+func TestDefine_EnvOnly_WithDefault_Accepted(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyDefaultOptions{}
+	err := Define(cmd, opts)
+	require.NoError(t, err)
+}
+
+func TestDefine_EnvOnly_RejectsShort(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyWithShortOptions{}
+	err := Define(cmd, opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, structclierrors.ErrConflictingTags)
+	assert.Contains(t, err.Error(), "flagshort cannot be used with flagenv='only'")
+}
+
+func TestDefine_EnvOnly_RejectsPreset(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyWithPresetOptions{}
+	err := Define(cmd, opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, structclierrors.ErrConflictingTags)
+	assert.Contains(t, err.Error(), "flagpreset cannot be used with flagenv='only'")
+}
+
+func TestDefine_EnvOnly_RejectsType(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyWithTypeOptions{}
+	err := Define(cmd, opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, structclierrors.ErrConflictingTags)
+	assert.Contains(t, err.Error(), "flagtype cannot be used with flagenv='only'")
+}
+
+func TestDefine_EnvOnly_RejectsCustom(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyWithCustomOptions{}
+	err := Define(cmd, opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, structclierrors.ErrConflictingTags)
+	assert.Contains(t, err.Error(), "flagcustom cannot be used with flagenv='only'")
+}
+
+func TestDefine_EnvOnly_RejectsIgnore(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyWithIgnoreOptions{}
+	err := Define(cmd, opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, structclierrors.ErrConflictingTags)
+}
+
+// --- Struct inheritance ---
+
+func TestDefine_EnvOnly_StructInheritance(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	cmd := &cobra.Command{Use: "app"}
+	opts := &envOnlyStructOptions{}
+	err := Define(cmd, opts)
+	require.NoError(t, err)
+
+	// Children should have env binding (inherited from struct's flagenv:"only")
+	userFlag := cmd.Flags().Lookup("user")
+	require.NotNil(t, userFlag)
+	assert.NotEmpty(t, userFlag.Annotations[internalenv.FlagAnnotation], "child should inherit env binding")
+	// Children should NOT be env-only themselves (they get normal CLI flags)
+	_, isEnvOnly := userFlag.Annotations[internalenv.FlagEnvOnlyAnnotation]
+	assert.False(t, isEnvOnly, "child should not be env-only")
+	assert.False(t, userFlag.Hidden, "child should be a normal visible flag")
+}
+
+// --- Unmarshal tests ---
+
+func TestUnmarshal_EnvOnly_PopulatedFromEnv(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	t.Setenv("APP_SECRET", "mysecret")
+
+	opts := &envOnlyOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, "mysecret", opts.Secret)
+}
+
+func TestUnmarshal_EnvOnly_FallsBackToDefault(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyDefaultOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, "8080", opts.Port)
+}
+
+func TestUnmarshal_EnvOnly_RejectsCLIUsage(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	// pflag allows setting hidden flags, but Unmarshal rejects it for env-only fields
+	require.NoError(t, cmd.Flags().Parse([]string{"--secret=shouldfail"}))
+
+	err := Unmarshal(cmd, opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, structclierrors.ErrEnvOnlyCLIUsage)
+	assert.Contains(t, err.Error(), "secret")
+	assert.Contains(t, err.Error(), "environment variable")
+}
+
+func TestHandleError_EnvOnlyCLIUsage(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--secret=bad"}))
+
+	err := Unmarshal(cmd, opts)
+	require.Error(t, err)
+
+	code := HandleError(cmd, err, os.Stderr)
+	assert.Equal(t, 11, code, "should use InvalidFlagValue exit code")
+}
+
+func TestUnmarshal_EnvOnly_CLINotSetPassesThrough(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	t.Setenv("APP_SECRET", "envvalue")
+
+	opts := &envOnlyOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--visible=hello"}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, "envvalue", opts.Secret)
+	assert.Equal(t, "hello", opts.Visible)
+}
+
+func TestUnmarshal_EnvOnly_RequiredMissing(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyRequiredOptions{}
+	cmd := &cobra.Command{
+		Use:  "app",
+		RunE: func(cmd *cobra.Command, args []string) error { return Unmarshal(cmd, opts) },
+	}
+	require.NoError(t, Define(cmd, opts))
+
+	// Execute without setting the env var — cobra's required flag check fires
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	require.Error(t, err)
+	// Cobra produces: required flag(s) "api-key" not set
+	assert.Contains(t, err.Error(), "api-key")
+
+	// HandleError should classify it as missing_required_env with exit code 26
+	code := HandleError(cmd, err, os.Stderr)
+	assert.Equal(t, 26, code, "should use EnvMissingRequired exit code")
+}
+
+func TestUnmarshal_EnvOnly_RequiredSatisfiedByEnv(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	t.Setenv("APP_API_KEY", "mykey")
+
+	opts := &envOnlyRequiredOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, "mykey", opts.APIKey)
+}
+
+// --- Help / usage tests ---
+
+func TestDefine_EnvOnly_ExcludedFromHelp(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	usage := cmd.UsageString()
+	assert.NotContains(t, usage, "--secret", "env-only flag should not appear in usage")
+	assert.Contains(t, usage, "--visible", "visible flag should appear in usage")
+}
+
+// --- JSON schema tests ---
+
+func TestJSONSchema_EnvOnly_IncludedWithMarker(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyOptions{}
+	cmd := &cobra.Command{Use: "app", Short: "test app"}
+	require.NoError(t, Define(cmd, opts))
+
+	schemas, err := JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	schema := schemas[0]
+
+	// env-only field should be in schema
+	secretFlag, ok := schema.Flags["secret"]
+	require.True(t, ok, "env-only field should appear in JSON schema")
+	assert.True(t, secretFlag.EnvOnly, "env-only field should have EnvOnly marker")
+	assert.NotEmpty(t, secretFlag.EnvVars, "env-only field should have env vars in schema")
+
+	// visible flag should also be there, without env-only
+	visibleFlag, ok := schema.Flags["visible"]
+	require.True(t, ok)
+	assert.False(t, visibleFlag.EnvOnly)
+
+	// Verify JSON serialization includes env_only
+	data, err := json.Marshal(secretFlag)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"env_only":true`)
+}
+
+func TestJSONSchema_EnvOnly_Required(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyRequiredOptions{}
+	cmd := &cobra.Command{Use: "app", Short: "test app"}
+	require.NoError(t, Define(cmd, opts))
+
+	schemas, err := JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	flag, ok := schemas[0].Flags["api-key"]
+	require.True(t, ok)
+	assert.True(t, flag.EnvOnly)
+	assert.True(t, flag.Required)
+}
+
+// --- HandleError tests ---
+
+func TestHandleError_MissingRequiredEnv(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	opts := &envOnlyRequiredOptions{}
+	cmd := &cobra.Command{
+		Use:  "app",
+		RunE: func(cmd *cobra.Command, args []string) error { return Unmarshal(cmd, opts) },
+	}
+	require.NoError(t, Define(cmd, opts))
+
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	code := HandleError(cmd, err, os.Stderr)
+	assert.Equal(t, 26, code, "should use EnvMissingRequired exit code")
+}
+
+// --- Lint warning tests ---
+
+type lintHiddenEnvOptions struct {
+	Secret string `flaghidden:"true" flagenv:"true" flag:"secret" flagdescr:"should trigger lint"`
+}
+
+func (o *lintHiddenEnvOptions) Attach(c *cobra.Command) error { return nil }
+
+type lintHiddenEnvWithShortOptions struct {
+	Secret string `flaghidden:"true" flagenv:"true" flag:"secret" flagshort:"s" flagdescr:"has short, no lint"`
+}
+
+func (o *lintHiddenEnvWithShortOptions) Attach(c *cobra.Command) error { return nil }
+
+type lintHiddenEnvWithPresetOptions struct {
+	Level int `flaghidden:"true" flagenv:"true" flag:"level" flagpreset:"quiet=0" flagdescr:"has preset, no lint"`
+}
+
+func (o *lintHiddenEnvWithPresetOptions) Attach(c *cobra.Command) error { return nil }
+
+type lintHiddenNoEnvOptions struct {
+	Secret string `flaghidden:"true" flag:"secret" flagdescr:"hidden but no env, no lint"`
+}
+
+func (o *lintHiddenNoEnvOptions) Attach(c *cobra.Command) error { return nil }
+
+func TestDefine_Lint_HiddenEnvSuggestsEnvOnly(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "app"}
+	cmd.SetErr(&stderr)
+	opts := &lintHiddenEnvOptions{}
+	require.NoError(t, Define(cmd, opts))
+
+	output := stderr.String()
+	assert.Contains(t, output, `flagenv:"only"`,
+		"should suggest flagenv:\"only\" for flaghidden+flagenv")
+	assert.Contains(t, output, "Secret")
+}
+
+func TestDefine_Lint_NoWarningWithShort(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "app"}
+	cmd.SetErr(&stderr)
+	opts := &lintHiddenEnvWithShortOptions{}
+	require.NoError(t, Define(cmd, opts))
+
+	assert.Empty(t, stderr.String(),
+		"should not warn when flagshort is present (incompatible with flagenv:only)")
+}
+
+func TestDefine_Lint_NoWarningWithPreset(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "app"}
+	cmd.SetErr(&stderr)
+	opts := &lintHiddenEnvWithPresetOptions{}
+	require.NoError(t, Define(cmd, opts))
+
+	assert.Empty(t, stderr.String(),
+		"should not warn when flagpreset is present (incompatible with flagenv:only)")
+}
+
+func TestDefine_Lint_NoWarningWithoutEnv(t *testing.T) {
+	resetEnvOnlyTestState()
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "app"}
+	cmd.SetErr(&stderr)
+	opts := &lintHiddenNoEnvOptions{}
+	require.NoError(t, Define(cmd, opts))
+
+	assert.Empty(t, stderr.String(),
+		"should not warn when flagenv is not set")
+}
+

--- a/flagenvonly_test.go
+++ b/flagenvonly_test.go
@@ -545,3 +545,25 @@ func TestDefine_Lint_NoWarningWithoutEnv(t *testing.T) {
 		"should not warn when flagenv is not set")
 }
 
+type lintRedundantHiddenEnvOnlyOptions struct {
+	Secret string `flaghidden:"true" flagenv:"only" flag:"secret" flagdescr:"redundant hidden with env-only"`
+}
+
+func (o *lintRedundantHiddenEnvOnlyOptions) Attach(c *cobra.Command) error { return nil }
+
+func TestDefine_Lint_RedundantHiddenWithEnvOnly(t *testing.T) {
+	resetEnvOnlyTestState()
+	SetEnvPrefix("APP")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "app"}
+	cmd.SetErr(&stderr)
+	opts := &lintRedundantHiddenEnvOnlyOptions{}
+	require.NoError(t, Define(cmd, opts))
+
+	output := stderr.String()
+	assert.Contains(t, output, "redundant",
+		"should warn that flaghidden is redundant with flagenv:\"only\"")
+	assert.Contains(t, output, "Secret")
+}
+

--- a/generate/agents.go
+++ b/generate/agents.go
@@ -80,6 +80,9 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 		fmt.Fprintf(&buf, "| Flag | Type | Default | Description |\n")
 		fmt.Fprintf(&buf, "|------|------|---------|-------------|\n")
 		for _, f := range sortedFlags(s) {
+			if f.EnvOnly {
+				continue
+			}
 			def := f.Default
 			if def == "" {
 				def = "-"
@@ -104,7 +107,11 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 			if def == "" {
 				def = "-"
 			}
-			fmt.Fprintf(&buf, "| `%s` | `--%s` | %s |\n", e.envVar, e.flagName, def)
+			flag := fmt.Sprintf("`--%s`", e.flagName)
+			if e.envOnly {
+				flag = "*(env only)*"
+			}
+			fmt.Fprintf(&buf, "| `%s` | %s | %s |\n", e.envVar, flag, def)
 		}
 		buf.WriteString("\n")
 	}
@@ -130,6 +137,7 @@ type envRow struct {
 	envVar   string
 	flagName string
 	defVal   string
+	envOnly  bool
 }
 
 func collectEnvVars(schemas []*structcli.CommandSchema) []envRow {
@@ -142,7 +150,7 @@ func collectEnvVars(schemas []*structcli.CommandSchema) []envRow {
 					continue
 				}
 				seen[ev] = true
-				rows = append(rows, envRow{envVar: ev, flagName: f.Name, defVal: f.Default})
+				rows = append(rows, envRow{envVar: ev, flagName: f.Name, defVal: f.Default, envOnly: f.EnvOnly})
 			}
 		}
 	}
@@ -153,7 +161,7 @@ func collectEnvVars(schemas []*structcli.CommandSchema) []envRow {
 func requiredFlags(s *structcli.CommandSchema) string {
 	var req []string
 	for _, f := range sortedFlags(s) {
-		if f.Required {
+		if f.Required && !f.EnvOnly {
 			req = append(req, fmt.Sprintf("`--%s`", f.Name))
 		}
 	}

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -212,3 +212,81 @@ func TestWriteAll_ErrorOnBadDir(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "writing SKILL.md")
 }
+
+// --- Env-only field tests ---
+
+type testEnvOnlyOptions struct {
+	APIKey string `flagenv:"only" flag:"api-key" flagdescr:"API secret key" flagrequired:"true"`
+	Port   int    `flagshort:"p" flagdescr:"Server port" flagenv:"true" default:"3000"`
+}
+
+func (o *testEnvOnlyOptions) Attach(c *cobra.Command) error {
+	return structcli.Define(c, o)
+}
+
+func buildEnvOnlyTree() *cobra.Command {
+	structcli.SetEnvPrefix("APP")
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+
+	root := &cobra.Command{
+		Use:   "envapp",
+		Short: "App with env-only fields",
+		RunE:  noop,
+	}
+
+	serve := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the server",
+		RunE:  noop,
+	}
+	opts := &testEnvOnlyOptions{}
+	opts.Attach(serve)
+	root.AddCommand(serve)
+
+	return root
+}
+
+func TestAgents_EnvOnlyExcludedFromFlagTable(t *testing.T) {
+	root := buildEnvOnlyTree()
+	data, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+	output := string(data)
+
+	// env-only field should NOT appear in the flag table
+	assert.NotContains(t, output, "| `--api-key`", "env-only field should not appear in flag table")
+	// normal flag should appear
+	assert.Contains(t, output, "| `--port`", "normal flag should appear in flag table")
+	// env-only field should appear in env var table with "(env only)" marker
+	assert.Contains(t, output, "*(env only)*", "env-only field should have env-only marker in env table")
+	assert.Contains(t, output, "APP_SERVE_API_KEY", "env-only field's env var should appear")
+}
+
+func TestSkill_EnvOnlyExcludedFromFlagTable(t *testing.T) {
+	root := buildEnvOnlyTree()
+	data, err := generate.Skill(root, generate.SkillOptions{})
+	require.NoError(t, err)
+	output := string(data)
+
+	// env-only field should NOT appear in the flags table
+	assert.NotContains(t, output, "| `--api-key`", "env-only field should not appear in flag table")
+	// normal flag should appear
+	assert.Contains(t, output, "| `--port`", "normal flag should appear in flag table")
+	// env-only field should appear in env var table
+	assert.Contains(t, output, "*(env only)*", "env-only field should have env-only marker")
+	assert.Contains(t, output, "APP_SERVE_API_KEY", "env-only field's env var should appear")
+}
+
+func TestLLMSTxt_EnvOnlyExcludedFromFlagSection(t *testing.T) {
+	root := buildEnvOnlyTree()
+	data, err := generate.LLMsTxt(root, generate.LLMsTxtOptions{})
+	require.NoError(t, err)
+	output := string(data)
+
+	// env-only field should NOT appear in flags section
+	assert.NotContains(t, output, "- `--api-key`", "env-only field should not appear in flags section")
+	// normal flag should appear
+	assert.Contains(t, output, "- `--port`", "normal flag should appear in flags section")
+	// env-only field should appear in env vars section
+	assert.Contains(t, output, "env only", "env-only field should have env-only marker")
+	assert.Contains(t, output, "APP_SERVE_API_KEY", "env-only field's env var should appear")
+}

--- a/generate/llmstxt.go
+++ b/generate/llmstxt.go
@@ -88,12 +88,23 @@ func LLMsTxt(rootCmd *cobra.Command, opts LLMsTxtOptions) ([]byte, error) {
 		// Build sorted flags once for this command
 		flagNames := sortedFlagNames(callable.schema.Flags)
 
-		// Flags section
-		if len(flagNames) > 0 {
+		// Flags section (excludes env-only fields)
+		hasFlags := false
+		for _, name := range flagNames {
+			if !callable.schema.Flags[name].EnvOnly {
+				hasFlags = true
+
+				break
+			}
+		}
+		if hasFlags {
 			fmt.Fprintf(&buf, "\n### Flags\n\n")
 
 			for _, name := range flagNames {
 				f := callable.schema.Flags[name]
+				if f.EnvOnly {
+					continue
+				}
 				parts := []string{f.Type}
 				if f.Default != "" {
 					parts = append(parts, fmt.Sprintf("default: %s", f.Default))
@@ -113,6 +124,7 @@ func LLMsTxt(rootCmd *cobra.Command, opts LLMsTxtOptions) ([]byte, error) {
 		var envEntries []struct {
 			envVar   string
 			flagName string
+			envOnly  bool
 		}
 		for _, name := range flagNames {
 			f := callable.schema.Flags[name]
@@ -120,14 +132,19 @@ func LLMsTxt(rootCmd *cobra.Command, opts LLMsTxtOptions) ([]byte, error) {
 				envEntries = append(envEntries, struct {
 					envVar   string
 					flagName string
-				}{envVar: envVar, flagName: f.Name})
+					envOnly  bool
+				}{envVar: envVar, flagName: f.Name, envOnly: f.EnvOnly})
 			}
 		}
 
 		if len(envEntries) > 0 {
 			fmt.Fprintf(&buf, "\n### Environment Variables\n\n")
 			for _, entry := range envEntries {
-				fmt.Fprintf(&buf, "- `%s`: maps to `--%s`\n", entry.envVar, entry.flagName)
+				if entry.envOnly {
+					fmt.Fprintf(&buf, "- `%s`: env only (no CLI flag)\n", entry.envVar)
+				} else {
+					fmt.Fprintf(&buf, "- `%s`: maps to `--%s`\n", entry.envVar, entry.flagName)
+				}
 			}
 		}
 	}

--- a/generate/skill.go
+++ b/generate/skill.go
@@ -154,8 +154,21 @@ func writeCommandSection(buf *bytes.Buffer, schema *structcli.CommandSchema, cmd
 	}
 }
 
-// writeFlagsTable writes the flags markdown table.
+// writeFlagsTable writes the flags markdown table (excludes env-only fields).
 func writeFlagsTable(buf *bytes.Buffer, flags map[string]*structcli.FlagSchema) {
+	// Check if there are any non-env-only flags to render
+	hasFlags := false
+	for _, f := range flags {
+		if !f.EnvOnly {
+			hasFlags = true
+
+			break
+		}
+	}
+	if !hasFlags {
+		return
+	}
+
 	fmt.Fprintf(buf, "\n**Flags:**\n\n")
 	fmt.Fprintf(buf, "| Flag | Type | Default | Required | Description |\n")
 	fmt.Fprintf(buf, "|------|------|---------|----------|-------------|\n")
@@ -163,6 +176,9 @@ func writeFlagsTable(buf *bytes.Buffer, flags map[string]*structcli.FlagSchema) 
 	names := sortedFlagNames(flags)
 	for _, name := range names {
 		f := flags[name]
+		if f.EnvOnly {
+			continue
+		}
 		reqStr := "no"
 		if f.Required {
 			reqStr = "yes"
@@ -184,6 +200,7 @@ type envVarRow struct {
 	variable string
 	flag     string
 	descr    string
+	envOnly  bool
 }
 
 // collectEnvVarRows collects env var rows from flags that have env vars.
@@ -197,6 +214,7 @@ func collectEnvVarRows(flags map[string]*structcli.FlagSchema) []envVarRow {
 				variable: env,
 				flag:     f.Name,
 				descr:    f.Description,
+				envOnly:  f.EnvOnly,
 			})
 		}
 	}
@@ -209,7 +227,11 @@ func writeEnvVarsTable(buf *bytes.Buffer, rows []envVarRow) {
 	fmt.Fprintf(buf, "| Variable | Flag | Description |\n")
 	fmt.Fprintf(buf, "|----------|------|-------------|\n")
 	for _, r := range rows {
-		fmt.Fprintf(buf, "| `%s` | `--%s` | %s |\n", r.variable, r.flag, r.descr)
+		flag := fmt.Sprintf("`--%s`", r.flag)
+		if r.envOnly {
+			flag = "*(env only)*"
+		}
+		fmt.Fprintf(buf, "| `%s` | %s | %s |\n", r.variable, flag, r.descr)
 	}
 }
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -32,6 +32,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/leodido/structcli v0.15.0/go.mod h1:Tn8D3VE3eupE7H23HF92TMX+sMwBD04pNQAIu7PRl+I=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/sftp v1.13.7/go.mod h1:KMKI0t3T6hfA+lTR/ssZdunHo+uwq7ghoN09/FSu3DY=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -19,7 +19,8 @@ var (
 )
 
 const (
-	FlagAnnotation = "___leodido_structcli_flagenvs"
+	FlagAnnotation        = "___leodido_structcli_flagenvs"
+	FlagEnvOnlyAnnotation = "___leodido_structcli_flagenvonly"
 )
 
 func NormEnv(str string) string {
@@ -42,14 +43,46 @@ func GetPrefix() string {
 	return ""
 }
 
-func GetEnv(f reflect.StructField, inherit bool, path, alias, envPrefix string) ([]string, bool) {
+// EnvMode describes how a field participates in environment variable binding.
+type EnvMode int
+
+const (
+	// EnvOff means no env binding for this field.
+	EnvOff EnvMode = iota
+	// EnvOn means the field has both a CLI flag and env binding.
+	EnvOn
+	// EnvOnly means the field is settable only via env var (and config), not CLI.
+	EnvOnly
+)
+
+// IsEnvOnly returns true if the struct field's flagenv tag is set to "only".
+func IsEnvOnly(f reflect.StructField) bool {
+	return strings.EqualFold(f.Tag.Get("flagenv"), "only")
+}
+
+// IsValidFlagEnvTag validates the flagenv tag value.
+// Returns nil for valid values ("", "true", "false", "only") and an error otherwise.
+func IsValidFlagEnvTag(tagValue string) bool {
+	if tagValue == "" {
+		return true
+	}
+	if strings.EqualFold(tagValue, "only") {
+		return true
+	}
+	_, err := strconv.ParseBool(tagValue)
+
+	return err == nil
+}
+
+func GetEnv(f reflect.StructField, inherit bool, path, alias, envPrefix string) ([]string, EnvMode) {
 	ret := []string{}
 	currentPrefix := GetPrefix()
 
 	env := f.Tag.Get("flagenv")
+	envOnly := strings.EqualFold(env, "only")
 	defineEnv, _ := strconv.ParseBool(env)
 
-	if defineEnv || inherit {
+	if defineEnv || envOnly || inherit {
 		envPath := path
 		envAlias := alias
 
@@ -72,7 +105,14 @@ func GetEnv(f reflect.StructField, inherit bool, path, alias, envPrefix string) 
 		}
 	}
 
-	return ret, defineEnv
+	if envOnly {
+		return ret, EnvOnly
+	}
+	if defineEnv {
+		return ret, EnvOn
+	}
+
+	return ret, EnvOff
 }
 
 func BindEnv(c *cobra.Command) error {

--- a/internal/proptest/gen/generators.go
+++ b/internal/proptest/gen/generators.go
@@ -79,7 +79,7 @@ type TagSet struct {
 	FlagRequired string // "true" or "false" or ""
 	FlagIgnore   string // "true" or "false" or ""
 	FlagCustom   string // "true" or "false" or ""
-	FlagEnv      string // "true" or "false" or ""
+	FlagEnv      string // "true", "false", "only", or ""
 	FlagPreset   string
 	Default      string
 }

--- a/internal/proptest/validation/validation_prop_test.go
+++ b/internal/proptest/validation/validation_prop_test.go
@@ -311,6 +311,68 @@ func TestProperty_Validation_AcceptsWellFormedStructs(t *testing.T) {
 	})
 }
 
+// --- P2.9b: flagenv:"only" rejects incompatible flag-specific tags ---
+
+func TestProperty_Validation_EnvOnlyRejectsIncompatibleTags(t *testing.T) {
+	incompatibleTags := []struct {
+		tagName string
+		tagVal  string
+	}{
+		{"flagshort", "x"},
+		{"flagpreset", "max=10"},
+		{"flagtype", "count"},
+	}
+
+	for _, tc := range incompatibleTags {
+		tc := tc
+		t.Run(tc.tagName, func(t *testing.T) {
+			rapid.Check(t, func(t *rapid.T) {
+				flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+
+				typ := reflect.StructOf([]reflect.StructField{
+					{
+						Name: "F0",
+						Type: reflect.TypeOf(""),
+						Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s" flagenv:"only" %s:"%s"`, flagName, tc.tagName, tc.tagVal)),
+					},
+				})
+				opts := reflect.New(typ).Interface()
+
+				err := internalvalidation.Struct(newCmd(), opts)
+				if err == nil {
+					t.Fatalf("expected error for flagenv='only' + %s=%q, got nil", tc.tagName, tc.tagVal)
+				}
+				var target *structclierrors.ConflictingTagsError
+				if !errors.As(err, &target) {
+					t.Fatalf("expected ConflictingTagsError for flagenv='only' + %s, got: %v", tc.tagName, err)
+				}
+			})
+		})
+	}
+}
+
+// --- P2.9c: flagenv:"only" is accepted on well-formed fields ---
+
+func TestProperty_Validation_EnvOnlyAcceptedAlone(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+
+		typ := reflect.StructOf([]reflect.StructField{
+			{
+				Name: "F0",
+				Type: reflect.TypeOf(""),
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s" flagenv:"only" flagdescr:"test"`, flagName)),
+			},
+		})
+		opts := reflect.New(typ).Interface()
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err != nil {
+			t.Fatalf("expected nil error for flagenv='only' with valid flag name %q, got: %v", flagName, err)
+		}
+	})
+}
+
 // --- P2.10: Validation errors are always well-typed ---
 
 func TestProperty_Validation_ErrorsAreWellTyped(t *testing.T) {

--- a/internal/proptest/validation/validation_prop_test.go
+++ b/internal/proptest/validation/validation_prop_test.go
@@ -265,7 +265,8 @@ func TestProperty_Validation_RejectsInvalidFlagNames(t *testing.T) {
 // --- P2.8: Validation rejects invalid boolean tag values ---
 
 func TestProperty_Validation_RejectsInvalidBooleanTagValues(t *testing.T) {
-	boolTags := []string{"flagcustom", "flagenv", "flagignore", "flagrequired", "flaghidden"}
+	// flagenv is excluded: it accepts "only" in addition to booleans and uses InvalidFlagEnvTagError.
+	boolTags := []string{"flagcustom", "flagignore", "flagrequired", "flaghidden"}
 
 	for _, tagName := range boolTags {
 		tagName := tagName
@@ -296,6 +297,33 @@ func TestProperty_Validation_RejectsInvalidBooleanTagValues(t *testing.T) {
 	}
 }
 
+// --- P2.8b: flagenv rejects invalid values with InvalidFlagEnvTagError ---
+
+func TestProperty_Validation_RejectsInvalidFlagEnvValues(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		badVal := gen.InvalidBoolTagValue().Draw(t, "badVal")
+		flagName := strings.ToLower(gen.ValidFlagName().Draw(t, "flagName"))
+
+		typ := reflect.StructOf([]reflect.StructField{
+			{
+				Name: "F0",
+				Type: reflect.TypeOf(""),
+				Tag:  reflect.StructTag(fmt.Sprintf(`flag:"%s" flagenv:"%s"`, flagName, badVal)),
+			},
+		})
+		opts := reflect.New(typ).Interface()
+
+		err := internalvalidation.Struct(newCmd(), opts)
+		if err == nil {
+			t.Fatalf("expected error for flagenv=%q, got nil", badVal)
+		}
+		var target *structclierrors.InvalidFlagEnvTagError
+		if !errors.As(err, &target) {
+			t.Fatalf("expected InvalidFlagEnvTagError for flagenv=%q, got: %v", badVal, err)
+		}
+	})
+}
+
 // --- P2.9: Validation accepts well-formed structs ---
 
 func TestProperty_Validation_AcceptsWellFormedStructs(t *testing.T) {
@@ -314,6 +342,8 @@ func TestProperty_Validation_AcceptsWellFormedStructs(t *testing.T) {
 // --- P2.9b: flagenv:"only" rejects incompatible flag-specific tags ---
 
 func TestProperty_Validation_EnvOnlyRejectsIncompatibleTags(t *testing.T) {
+	// flagcustom is omitted: it requires matching Define/Decode hook methods
+	// on the struct, which cannot be generated via reflect.StructOf.
 	incompatibleTags := []struct {
 		tagName string
 		tagVal  string

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -131,7 +131,7 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 		flagEnvValue := structF.Tag.Get("flagenv")
 		flagEnvOnly := internalenv.IsEnvOnly(structF)
 		if !internalenv.IsValidFlagEnvTag(flagEnvValue) {
-			return structclierrors.NewInvalidBooleanTagError(fieldName, "flagenv", flagEnvValue)
+			return structclierrors.NewInvalidFlagEnvTagError(fieldName, flagEnvValue)
 		}
 
 		// flagenv:"only" is incompatible with flag-specific tags

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	structclierrors "github.com/leodido/structcli/errors"
+	internalenv "github.com/leodido/structcli/internal/env"
 	internalhooks "github.com/leodido/structcli/internal/hooks"
 	internalpath "github.com/leodido/structcli/internal/path"
 	internalreflect "github.com/leodido/structcli/internal/reflect"
@@ -110,6 +111,11 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 			return structclierrors.NewInvalidTagUsageError(fieldName, "flagcustom", "flagcustom cannot be used on struct types")
 		}
 
+		// Reject flagcustom + flagenv:"only" before validating hooks (avoids confusing hook errors)
+		if flagCustomValue != nil && *flagCustomValue && internalenv.IsEnvOnly(structF) && !isStructKind {
+			return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagcustom"}, "flagcustom cannot be used with flagenv='only'")
+		}
+
 		// Validate the define and decode hooks when flagcustom is true
 		if flagCustomValue != nil && *flagCustomValue && !isStructKind {
 			// Map current field name to its custom type
@@ -122,8 +128,26 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 		}
 
 		// Validate flagenv tag (can be on struct fields for inheritance)
-		if _, err := IsValidBoolTag(fieldName, "flagenv", structF.Tag.Get("flagenv")); err != nil {
-			return err
+		flagEnvValue := structF.Tag.Get("flagenv")
+		flagEnvOnly := internalenv.IsEnvOnly(structF)
+		if !internalenv.IsValidFlagEnvTag(flagEnvValue) {
+			return structclierrors.NewInvalidBooleanTagError(fieldName, "flagenv", flagEnvValue)
+		}
+
+		// flagenv:"only" is incompatible with flag-specific tags
+		if flagEnvOnly && !isStructKind {
+			if short != "" {
+				return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagshort"}, "flagshort cannot be used with flagenv='only'")
+			}
+			if len(presets) > 0 {
+				return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagpreset"}, "flagpreset cannot be used with flagenv='only'")
+			}
+			if structF.Tag.Get("flagtype") != "" {
+				return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagtype"}, "flagtype cannot be used with flagenv='only'")
+			}
+			if flagCustomValue != nil && *flagCustomValue {
+				return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagcustom"}, "flagcustom cannot be used with flagenv='only'")
+			}
 		}
 
 		// Validate flagignore tag
@@ -138,6 +162,9 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 		}
 		if len(presets) > 0 && flagIgnoreValue != nil && *flagIgnoreValue {
 			return structclierrors.NewInvalidTagUsageError(fieldName, "flagpreset", "flagpreset cannot be used with flagignore='true'")
+		}
+		if flagEnvOnly && flagIgnoreValue != nil && *flagIgnoreValue {
+			return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagignore"}, "mutually exclusive tags")
 		}
 		if !isStructKind && !(flagIgnoreValue != nil && *flagIgnoreValue) {
 			if err := validateCompletionHook(val, methodFieldName); err != nil {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -18,7 +18,7 @@ type invalidShorthandOpts struct {
 	Name string `flagshort:"ab"`
 }
 
-type invalidBoolTagOpts struct {
+type invalidFlagEnvTagOpts struct {
 	Name string `flagenv:"oops"`
 }
 
@@ -175,7 +175,7 @@ func TestStructValidationErrors(t *testing.T) {
 		err  error
 	}{
 		{name: "invalid shorthand", opts: &invalidShorthandOpts{}, err: structclierrors.ErrInvalidShorthand},
-		{name: "invalid bool tag", opts: &invalidBoolTagOpts{}, err: structclierrors.ErrInvalidBooleanTag},
+		{name: "invalid flagenv tag", opts: &invalidFlagEnvTagOpts{}, err: structclierrors.ErrInvalidFlagEnvTag},
 		{name: "conflicting tags", opts: &conflictingTagsOpts{}, err: structclierrors.ErrConflictingTags},
 		{name: "invalid flag name", opts: &invalidFlagNameOpts{}, err: structclierrors.ErrInvalidFlagName},
 		{name: "duplicate flag", opts: &duplicateFlagOpts{}, err: structclierrors.ErrDuplicateFlag},

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -34,6 +34,7 @@ type FlagSchema struct {
 	Default     string       `json:"default,omitempty"`
 	Description string       `json:"description,omitempty"`
 	Required    bool         `json:"required,omitempty"`
+	EnvOnly     bool         `json:"env_only,omitempty"`
 	EnvVars     []string     `json:"env_vars,omitempty"`
 	Group       string       `json:"group,omitempty"`
 	FieldPath   string       `json:"field_path,omitempty"`
@@ -112,8 +113,10 @@ func jsonSchemaOne(c *cobra.Command, cfg *jsonschema.Config) (*CommandSchema, er
 
 	// Walk all flags (local + inherited)
 	c.Flags().VisitAll(func(f *pflag.Flag) {
-		// Skip hidden and deprecated flags
-		if f.Hidden || f.Deprecated != "" {
+		_, isEnvOnly := f.Annotations[internalenv.FlagEnvOnlyAnnotation]
+
+		// Skip hidden and deprecated flags (but not env-only carrier flags)
+		if (f.Hidden && !isEnvOnly) || f.Deprecated != "" {
 			return
 		}
 
@@ -169,6 +172,11 @@ func jsonSchemaOne(c *cobra.Command, cfg *jsonschema.Config) (*CommandSchema, er
 			if requiredAnnotation[0] == "true" {
 				fs.Required = true
 			}
+		}
+
+		// Env-only fields
+		if isEnvOnly {
+			fs.EnvOnly = true
 		}
 
 		// Read default from structcli annotation (more reliable than pflag DefValue for custom types)

--- a/structerr.go
+++ b/structerr.go
@@ -207,6 +207,27 @@ func classify(cmd *cobra.Command, err error) *StructuredError {
 		}
 	}
 
+	// EnvOnlyCLIUsageError from Unmarshal's post-parse check
+	var envOnlyCLIErr *structclierrors.EnvOnlyCLIUsageError
+	if errors.As(err, &envOnlyCLIErr) {
+		se := &StructuredError{
+			Error:    "env_only_cli_usage",
+			ExitCode: exitcode.InvalidFlagValue,
+			Command:  cmdPath,
+			Message:  errMsg,
+		}
+		if len(envOnlyCLIErr.FlagNames) == 1 {
+			se.Flag = envOnlyCLIErr.FlagNames[0]
+			envVars := flagEnvVars(cmd, envOnlyCLIErr.FlagNames[0])
+			if len(envVars) > 0 {
+				se.Hint = fmt.Sprintf("set %s instead", envVars[0])
+				se.EnvVar = envVars[0]
+			}
+		}
+
+		return se
+	}
+
 	// 2. Typed flag errors from SetupFlagErrors (errors.As — no regex needed)
 	// FlagError carries only the flag name, value, and kind. Metadata enrichment
 	// (expected type, enum values, env vars) happens here via the same code path
@@ -366,6 +387,23 @@ func classifyMissingRequired(cmd *cobra.Command, cmdPath, flagList, errMsg strin
 	// For single-flag errors, provide enriched output with remedy hints.
 	if len(flagNames) == 1 {
 		flagName := flagNames[0]
+
+		// Env-only flags get a distinct error classification and exit code.
+		if flagIsEnvOnly(cmd, flagName) {
+			envVars := flagEnvVars(cmd, flagName)
+			se := &StructuredError{
+				Error:    "missing_required_env",
+				ExitCode: exitcode.EnvMissingRequired,
+				Command:  cmdPath,
+				Message:  structclierrors.NewMissingRequiredEnvError(flagName, envVars).Error(),
+			}
+			if len(envVars) > 0 {
+				se.EnvVar = envVars[0]
+				se.Hint = fmt.Sprintf("set %s", strings.Join(envVars, " or "))
+			}
+
+			return se
+		}
 
 		// Build hint from env fallbacks and validation rules without changing the
 		// top-level classification away from the missing required flag.
@@ -646,6 +684,19 @@ func findFlagForField(cmd *cobra.Command, fieldName string) string {
 }
 
 // flagEnvVars returns the env var names bound to a flag, or nil if none.
+func flagIsEnvOnly(cmd *cobra.Command, flagName string) bool {
+	f := cmd.Flags().Lookup(flagName)
+	if f == nil {
+		f = cmd.InheritedFlags().Lookup(flagName)
+	}
+	if f == nil || f.Annotations == nil {
+		return false
+	}
+	_, ok := f.Annotations[internalenv.FlagEnvOnlyAnnotation]
+
+	return ok
+}
+
 func flagEnvVars(cmd *cobra.Command, flagName string) []string {
 	f := cmd.Flags().Lookup(flagName)
 	if f == nil {

--- a/viper.go
+++ b/viper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	structclierrors "github.com/leodido/structcli/errors"
 	internalconfig "github.com/leodido/structcli/internal/config"
+	internalenv "github.com/leodido/structcli/internal/env"
 	internalhooks "github.com/leodido/structcli/internal/hooks"
 	internalscope "github.com/leodido/structcli/internal/scope"
 	"github.com/spf13/cobra"
@@ -87,6 +88,11 @@ func GetConfigViper(c *cobra.Command) *viper.Viper {
 // Before decoding, Unmarshal merges command-relevant config from the root-scoped
 // config-source viper (GetConfigViper(c)).
 func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookFunc) error {
+	// Reject CLI usage of env-only flags before any resolution.
+	if err := rejectEnvOnlyCLIUsage(c); err != nil {
+		return err
+	}
+
 	scope := internalscope.Get(c)
 	vip := scope.Viper()
 
@@ -171,6 +177,25 @@ func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookF
 
 	// Automatic debug output if debug is on
 	UseDebug(c, c.OutOrStdout())
+
+	return nil
+}
+
+// rejectEnvOnlyCLIUsage checks whether any env-only flag was explicitly set
+// via the CLI (--flag=value) and returns an error if so.
+func rejectEnvOnlyCLIUsage(c *cobra.Command) error {
+	var rejected []string
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		if !f.Changed {
+			return
+		}
+		if _, ok := f.Annotations[internalenv.FlagEnvOnlyAnnotation]; ok {
+			rejected = append(rejected, f.Name)
+		}
+	})
+	if len(rejected) > 0 {
+		return &structclierrors.EnvOnlyCLIUsageError{FlagNames: rejected}
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

Implement `flagenv:"only"` — fields settable only via environment variable or config file, with CLI usage (`--flag=value`) rejected at runtime.

### Commits

1. **chore: dogfood go:generate in examples/full** — regenerate stale AGENTS.md/SKILL.md, add CI freshness check
2. **feat: implement `flagenv:"only"`** — core feature (17 files)
3. **docs: document `flagenv:"only"` vs `flaghidden`+`flagenv`** — README + lint warning

### How it works

Env-only fields go through the normal flag creation path (correct pflag type, default, etc.), then get force-hidden and annotated with `FlagEnvOnlyAnnotation`. Three behaviors distinguish `flagenv:"only"` from `flaghidden:"true"` + `flagenv:"true"`:

- **CLI rejection**: `rejectEnvOnlyCLIUsage()` in `Unmarshal` checks `f.Changed` on env-only flags and returns `EnvOnlyCLIUsageError`
- **Tag conflict validation**: hard errors on `flagshort`, `flagpreset`, `flagtype`, `flagcustom`, `flagignore`
- **Schema/generator distinction**: `FlagSchema.EnvOnly` marker; generators exclude from flag tables, include in env sections

`flaghidden:"true"` + `flagenv:"true"` — hidden from help, but **accepts** CLI input via `--flag=value`

`flagenv:"only"` — hidden from help, **rejects** CLI input at runtime. Settable only via env var or config file.

### Required env-only fields

Flow through cobra's standard `MarkFlagRequired`. `HandleError` detects the env-only annotation on the flag and produces exit code 26 (`EnvMissingRequired`) with env-var-specific error messages instead of `--flag` references.

### Lint warning

`Define()` emits a warning to `c.ErrOrStderr()` when it detects `flaghidden:"true"` + `flagenv:"true"` without any flag-specific tags that would be incompatible with `flagenv:"only"`, suggesting migration.

## How to test

```sh
go test ./...
cd examples/full && go test ./...
```

## Test coverage

28 new tests: 24 unit (validation, define, unmarshal, schema, handleError, lint), 2 property-based (300 rapid iterations), 3 generator tests.