### PR TITLE
refactor: replace unreachable pflag error handling with panic helpers

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -51,7 +51,7 @@ func SetupDebug(rootC *cobra.Command, debugOpts debug.Options) error {
 	rootC.PersistentFlags().Bool(flagName, false, "enable debug output for options")
 
 	// Add environment annotation
-	rootC.PersistentFlags().SetAnnotation(flagName, internalenv.FlagAnnotation, []string{envvName})
+	mustSetAnnotation(rootC.PersistentFlags(), flagName, internalenv.FlagAnnotation, []string{envvName})
 
 	// Ensure environment binding happens
 	cobra.OnInitialize(func() {

--- a/define.go
+++ b/define.go
@@ -17,6 +17,30 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// mustSetAnnotation panics if SetAnnotation fails. The only failure mode is
+// a missing flag, which is structurally impossible when called immediately
+// after flag registration.
+func mustSetAnnotation(fs *pflag.FlagSet, name, key string, values []string) {
+	if err := fs.SetAnnotation(name, key, values); err != nil {
+		panic(fmt.Sprintf("structcli: SetAnnotation(%q, %q) on just-registered flag: %v", name, key, err))
+	}
+}
+
+// mustMarkHidden panics if MarkHidden fails (same invariant as mustSetAnnotation).
+func mustMarkHidden(fs *pflag.FlagSet, name string) {
+	if err := fs.MarkHidden(name); err != nil {
+		panic(fmt.Sprintf("structcli: MarkHidden(%q) on just-registered flag: %v", name, err))
+	}
+}
+
+// mustMarkRequired panics if MarkFlagRequired fails (same invariant).
+// Note: MarkFlagRequired is on *cobra.Command, not *pflag.FlagSet.
+func mustMarkRequired(c *cobra.Command, name string) {
+	if err := c.MarkFlagRequired(name); err != nil {
+		panic(fmt.Sprintf("structcli: MarkFlagRequired(%q) on just-registered flag: %v", name, err))
+	}
+}
+
 // DefineOption configures the behavior of the Define function.
 type DefineOption func(*defineContext)
 
@@ -221,21 +245,19 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				f.Name,
 			)
 		}
-		applyFieldMetadata := func() error {
+		applyFieldMetadata := func() {
+			fs := c.Flags()
+
 			// Persist path metadata on each defined flag so Unmarshal can rebuild
 			// remapping state from the current command context (without package globals).
-			if err := c.Flags().SetAnnotation(name, flagPathAnnotation, []string{path}); err != nil {
-				return fmt.Errorf("couldn't set path annotation for flag %s: %w", name, err)
-			}
+			mustSetAnnotation(fs, name, flagPathAnnotation, []string{path})
 
 			// Marking the flag
 			if mandatory {
-				c.MarkFlagRequired(name)
+				mustMarkRequired(c, name)
 			}
 			if hidden {
-				if err := c.Flags().MarkHidden(name); err != nil {
-					return fmt.Errorf("couldn't hide flag %s: %w", name, err)
-				}
+				mustMarkHidden(fs, name)
 			}
 
 			// Set the defaults
@@ -243,28 +265,22 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				GetViper(c).SetDefault(name, defval)
 				GetViper(c).SetDefault(path, defval)
 				// This is needed for the usage help messages
-				c.Flags().Lookup(name).DefValue = defval
-				if err := c.Flags().SetAnnotation(name, flagDefaultAnnotation, []string{defval}); err != nil {
-					return fmt.Errorf("couldn't set default annotation for flag %s: %w", name, err)
-				}
+				fs.Lookup(name).DefValue = defval
+				mustSetAnnotation(fs, name, flagDefaultAnnotation, []string{defval})
 			}
 
 			if len(envs) > 0 {
-				if err := c.Flags().SetAnnotation(name, internalenv.FlagAnnotation, envs); err != nil {
-					return fmt.Errorf("couldn't set env annotation for flag %s: %w", name, err)
-				}
+				mustSetAnnotation(fs, name, internalenv.FlagAnnotation, envs)
 			}
 
 			// Set the group annotation on the current flag
 			if group != "" {
-				if err := c.Flags().SetAnnotation(name, internalusage.FlagGroupAnnotation, []string{group}); err != nil {
-					return fmt.Errorf("couldn't set group annotation for flag %s: %w", name, err)
-				}
+				mustSetAnnotation(fs, name, internalusage.FlagGroupAnnotation, []string{group})
 			}
 
 			// Store enum values as a machine-readable annotation for downstream consumers.
 			// Prefer EnumValuer interface (authoritative, type-level) over description parsing (fragile).
-			if fl := c.Flags().Lookup(name); fl != nil {
+			if fl := fs.Lookup(name); fl != nil {
 				var enumVals []string
 				if ev, ok := fl.Value.(EnumValuer); ok {
 					enumVals = ev.EnumValues()
@@ -277,41 +293,34 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 					enumVals = vals
 				}
 				if len(enumVals) > 0 {
-					if err := c.Flags().SetAnnotation(name, flagEnumAnnotation, enumVals); err != nil {
-						return fmt.Errorf("couldn't set enum annotation for flag %s: %w", name, err)
-					}
+					mustSetAnnotation(fs, name, flagEnumAnnotation, enumVals)
 				}
 			}
 
 			// Store validation struct tag so downstream consumers can inspect rules
 			if validateTag := f.Tag.Get(validateTagName); validateTag != "" {
-				if err := c.Flags().SetAnnotation(name, flagValidateAnnotation, []string{validateTag}); err != nil {
-					return fmt.Errorf("couldn't set validate annotation for flag %s: %w", name, err)
-				}
+				mustSetAnnotation(fs, name, flagValidateAnnotation, []string{validateTag})
 			}
 
 			// Store transformation struct tag so downstream consumers can inspect rules
 			if modTag := f.Tag.Get(modTagName); modTag != "" {
-				if err := c.Flags().SetAnnotation(name, flagModAnnotation, []string{modTag}); err != nil {
-					return fmt.Errorf("couldn't set mod annotation for flag %s: %w", name, err)
-				}
+				mustSetAnnotation(fs, name, flagModAnnotation, []string{modTag})
 			}
-
-			return nil
 		}
-		applyPresetAliases := func() error {
+		applyPresetAliases := func() {
+			fs := c.Flags()
 			for _, preset := range presets {
 				aliasName := preset.Name
 				aliasValue := preset.Value
 				targetFlagName := name
 
 				// Avoid redefining when the same options are attached multiple times.
-				if c.Flags().Lookup(aliasName) != nil {
+				if fs.Lookup(aliasName) != nil {
 					continue
 				}
 
 				usage := fmt.Sprintf("alias for --%s=%s", targetFlagName, aliasValue)
-				c.Flags().BoolFunc(aliasName, usage, func(raw string) error {
+				fs.BoolFunc(aliasName, usage, func(raw string) error {
 					enabled, err := strconv.ParseBool(raw)
 					if err != nil {
 						return fmt.Errorf("invalid boolean value for alias --%s: %w", aliasName, err)
@@ -320,7 +329,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 						return nil
 					}
 
-					if err := c.Flags().Set(targetFlagName, aliasValue); err != nil {
+					if err := fs.Set(targetFlagName, aliasValue); err != nil {
 						return fmt.Errorf("couldn't apply alias --%s to --%s: %w", aliasName, targetFlagName, err)
 					}
 
@@ -328,14 +337,10 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				})
 
 				if group != "" {
-					if err := c.Flags().SetAnnotation(aliasName, internalusage.FlagGroupAnnotation, []string{group}); err != nil {
-						return fmt.Errorf("couldn't set group annotation for flag %s: %w", aliasName, err)
-					}
+					mustSetAnnotation(fs, aliasName, internalusage.FlagGroupAnnotation, []string{group})
 				}
 				if hidden {
-					if err := c.Flags().MarkHidden(aliasName); err != nil {
-						return fmt.Errorf("couldn't hide alias flag %s: %w", aliasName, err)
-					}
+					mustMarkHidden(fs, aliasName)
 				}
 			}
 
@@ -345,42 +350,27 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				for _, preset := range presets {
 					presetData = append(presetData, preset.Name+"="+preset.Value)
 				}
-				if err := c.Flags().SetAnnotation(name, flagPresetsAnnotation, presetData); err != nil {
-					return fmt.Errorf("couldn't set presets annotation for flag %s: %w", name, err)
-				}
+				mustSetAnnotation(fs, name, flagPresetsAnnotation, presetData)
 			}
-
-			return nil
 		}
-		finalizeFieldDefinition := func() error {
-			if err := applyFieldMetadata(); err != nil {
-				return err
-			}
+		finalizeFieldDefinition := func() {
+			applyFieldMetadata()
 			// Env-only: force hidden and set the env-only annotation.
 			// The flag was created normally (correct type, default, etc.)
 			// but is now hidden from CLI help and marked for schema/generators.
 			if envOnly {
-				if err := c.Flags().MarkHidden(name); err != nil {
-					return fmt.Errorf("couldn't hide env-only flag %s: %w", name, err)
-				}
-				if err := c.Flags().SetAnnotation(name, internalenv.FlagEnvOnlyAnnotation, []string{"true"}); err != nil {
-					return fmt.Errorf("couldn't set env-only annotation for flag %s: %w", name, err)
-				}
+				fs := c.Flags()
+				mustMarkHidden(fs, name)
+				mustSetAnnotation(fs, name, internalenv.FlagEnvOnlyAnnotation, []string{"true"})
 			}
-			if err := applyPresetAliases(); err != nil {
-				return err
-			}
+			applyPresetAliases()
 			completeHookName := fmt.Sprintf("Complete%s", f.Name)
 			completeHookFunc := structPtr.MethodByName(completeHookName)
 			if completeHookFunc.IsValid() {
 				if _, exists := c.GetFlagCompletionFunc(name); !exists {
-					if err := internalhooks.StoreCompletionHookFunc(c, name, completeHookFunc); err != nil {
-						return fmt.Errorf("couldn't register completion hook %s: %w", completeHookName, err)
-					}
+					internalhooks.StoreCompletionHookFunc(c, name, completeHookFunc)
 				}
 			}
-
-			return nil
 		}
 
 		// Flags with `flagcustom:"true"` tag (validation already done)
@@ -410,9 +400,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 					// Register user's decode hook (`Unmarshal` will call it)
 					internalhooks.StoreDecodeHookFunc(c, name, decodeHookFunc, f.Type)
 
-					if err := finalizeFieldDefinition(); err != nil {
-						return err
-					}
+					finalizeFieldDefinition()
 
 					continue
 				}
@@ -424,9 +412,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 					// mandatory one like the other two call sites.
 					internalhooks.InferDecodeHooks(c, name, f.Type.String())
 
-					if err := finalizeFieldDefinition(); err != nil {
-						return err
-					}
+					finalizeFieldDefinition()
 
 					continue
 				}
@@ -442,9 +428,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
 			}
 
-			if err := finalizeFieldDefinition(); err != nil {
-				return err
-			}
+			finalizeFieldDefinition()
 
 			continue
 		}
@@ -455,9 +439,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 		}
 
 		if c.Flags().Lookup(name) != nil {
-			if err := finalizeFieldDefinition(); err != nil {
-				return err
-			}
+			finalizeFieldDefinition()
 
 			continue
 		}
@@ -515,9 +497,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			if f.Tag.Get("flagtype") == "count" {
 				c.Flags().CountVarP(ref, name, short, descr)
 
-				if err := finalizeFieldDefinition(); err != nil {
-					return err
-				}
+				finalizeFieldDefinition()
 
 				continue
 			}
@@ -572,9 +552,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			continue
 		}
 
-		if err := finalizeFieldDefinition(); err != nil {
-			return err
-		}
+		finalizeFieldDefinition()
 	}
 
 	return nil

--- a/define.go
+++ b/define.go
@@ -408,9 +408,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 					c.Flags().VarP(returnedValue, name, short, returnedUsage)
 
 					// Register user's decode hook (`Unmarshal` will call it)
-					if err := internalhooks.StoreDecodeHookFunc(c, name, decodeHookFunc, f.Type); err != nil {
-						return fmt.Errorf("couldn't register decode hook %s: %w", decodeHookName, err)
-					}
+					internalhooks.StoreDecodeHookFunc(c, name, decodeHookFunc, f.Type)
 
 					if err := finalizeFieldDefinition(); err != nil {
 						return err
@@ -424,9 +422,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				// Best-effort: attach a decode hook if one exists, but don't
 					// hard-error when missing — this is a fallback path, not a
 					// mandatory one like the other two call sites.
-					if _, err := internalhooks.InferDecodeHooks(c, name, f.Type.String()); err != nil {
-						return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
-					}
+					internalhooks.InferDecodeHooks(c, name, f.Type.String())
 
 					if err := finalizeFieldDefinition(); err != nil {
 						return err
@@ -442,11 +438,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 		// Check registry for known custom types
 		if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
-			found, err := internalhooks.InferDecodeHooks(c, name, f.Type.String())
-			if err != nil {
-				return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
-			}
-			if !found {
+			if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
 				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
 			}
 
@@ -572,11 +564,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				ref := field.Addr().Interface().(*[]int)
 				c.Flags().IntSliceVarP(ref, name, short, val, descr)
 			}
-			found, err := internalhooks.InferDecodeHooks(c, name, f.Type.String())
-			if err != nil {
-				return fmt.Errorf("couldn't infer decode hooks for flag %s: %w", name, err)
-			}
-			if !found {
+			if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
 				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
 			}
 

--- a/internal/hooks/complete.go
+++ b/internal/hooks/complete.go
@@ -14,12 +14,14 @@ import (
 type CompleteHookFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 
 // StoreCompletionHookFunc registers a validated completion hook method for a flag.
-func StoreCompletionHookFunc(c *cobra.Command, flagName string, completeM reflect.Value) error {
+// Panics if the flag does not exist (structurally impossible when called after
+// flag registration) or if completeM is invalid.
+func StoreCompletionHookFunc(c *cobra.Command, flagName string, completeM reflect.Value) {
 	if !completeM.IsValid() {
-		return fmt.Errorf("invalid completion hook for flag %q", flagName)
+		panic(fmt.Sprintf("structcli: invalid completion hook for flag %q", flagName))
 	}
 
-	return c.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := c.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		results := completeM.Call([]reflect.Value{
 			reflect.ValueOf(cmd),
 			reflect.ValueOf(args),
@@ -30,5 +32,7 @@ func StoreCompletionHookFunc(c *cobra.Command, flagName string, completeM reflec
 		directive, _ := results[1].Interface().(cobra.ShellCompDirective)
 
 		return suggestions, directive
-	})
+	}); err != nil {
+		panic(fmt.Sprintf("structcli: RegisterFlagCompletionFunc(%q) on just-registered flag: %v", flagName, err))
+	}
 }

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -121,16 +121,16 @@ func init() {
 	}
 }
 
-func InferDecodeHooks(c *cobra.Command, name, typename string) (bool, error) {
+func InferDecodeHooks(c *cobra.Command, name, typename string) bool {
 	if data, ok := DecodeHookRegistry[typename]; ok {
 		if err := c.Flags().SetAnnotation(name, FlagDecodeHookAnnotation, []string{data.ann}); err != nil {
-			return false, fmt.Errorf("set decode hook annotation: %w", err)
+			panic(fmt.Sprintf("structcli: SetAnnotation on just-registered flag %q: %v", name, err))
 		}
 
-		return true, nil
+		return true
 	}
 
-	return false, nil
+	return false
 }
 
 // StringToZapcoreLevelHookFunc creates a decode hook that converts string values
@@ -865,7 +865,7 @@ func parseIPv4Mask(s string) net.IPMask {
 	return net.IPv4Mask(mask[12], mask[13], mask[14], mask[15])
 }
 
-func StoreDecodeHookFunc(c *cobra.Command, flagname string, decodeM reflect.Value, target reflect.Type) error {
+func StoreDecodeHookFunc(c *cobra.Command, flagname string, decodeM reflect.Value, target reflect.Type) {
 	s := internalscope.Get(c)
 
 	// Wrap that adapts user method to mapstructure.DecodeHookFuncType signature
@@ -899,5 +899,7 @@ func StoreDecodeHookFunc(c *cobra.Command, flagname string, decodeM reflect.Valu
 	k := fmt.Sprintf("customDecodeHook_%s_%s", c.Name(), flagname)
 	s.SetCustomDecodeHook(k, hookFunc)
 
-	return c.Flags().SetAnnotation(flagname, FlagDecodeHookAnnotation, []string{k})
+	if err := c.Flags().SetAnnotation(flagname, FlagDecodeHookAnnotation, []string{k}); err != nil {
+		panic(fmt.Sprintf("structcli: SetAnnotation on just-registered flag %q: %v", flagname, err))
+	}
 }

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -24,27 +24,25 @@ func TestInferDecodeHooks(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("durations", "", "durations")
 
-	ok, err := InferDecodeHooks(cmd, "durations", "[]time.Duration")
-	require.NoError(t, err)
+	ok := InferDecodeHooks(cmd, "durations", "[]time.Duration")
 	require.True(t, ok)
 
 	flag := cmd.Flags().Lookup("durations")
 	require.NotNil(t, flag)
 	assert.Equal(t, []string{"StringToDurationSliceHookFunc"}, flag.Annotations[FlagDecodeHookAnnotation])
 
-	found, err := InferDecodeHooks(cmd, "durations", "missing.Type")
-	require.NoError(t, err)
+	found := InferDecodeHooks(cmd, "durations", "missing.Type")
 	assert.False(t, found)
 }
 
-func TestInferDecodeHooks_ErrorOnUnknownFlag(t *testing.T) {
+func TestInferDecodeHooks_PanicsOnUnknownFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
-	// Don't define a "durations" flag — SetAnnotation will fail on unknown flag
+	// Don't define a "durations" flag — SetAnnotation will panic on unknown flag
 
-	found, err := InferDecodeHooks(cmd, "durations", "[]time.Duration")
-	require.Error(t, err)
-	assert.False(t, found)
-	assert.Contains(t, err.Error(), "decode hook annotation")
+	assert.PanicsWithValue(t,
+		`structcli: SetAnnotation on just-registered flag "durations": no such flag -durations`,
+		func() { InferDecodeHooks(cmd, "durations", "[]time.Duration") },
+	)
 }
 
 func TestConvertMapInputErrors(t *testing.T) {
@@ -277,7 +275,7 @@ func TestStoreDecodeHookFunc_WrapperBehavior(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("mode", "", "mode")
 
-	err := StoreDecodeHookFunc(
+	StoreDecodeHookFunc(
 		cmd,
 		"mode",
 		reflect.ValueOf(func(input any) (any, error) {
@@ -285,7 +283,6 @@ func TestStoreDecodeHookFunc_WrapperBehavior(t *testing.T) {
 		}),
 		reflect.TypeOf(""),
 	)
-	require.NoError(t, err)
 
 	flag := cmd.Flags().Lookup("mode")
 	require.NotNil(t, flag)
@@ -310,7 +307,7 @@ func TestStoreDecodeHookFunc_WrapperPropagatesErrors(t *testing.T) {
 	cmd.Flags().String("mode", "", "mode")
 
 	expectedErr := errors.New("boom")
-	err := StoreDecodeHookFunc(
+	StoreDecodeHookFunc(
 		cmd,
 		"mode",
 		reflect.ValueOf(func(input any) (any, error) {
@@ -318,7 +315,6 @@ func TestStoreDecodeHookFunc_WrapperPropagatesErrors(t *testing.T) {
 		}),
 		reflect.TypeOf(""),
 	)
-	require.NoError(t, err)
 
 	flag := cmd.Flags().Lookup("mode")
 	require.NotNil(t, flag)
@@ -326,6 +322,6 @@ func TestStoreDecodeHookFunc_WrapperPropagatesErrors(t *testing.T) {
 	require.True(t, exists)
 	hookFunc := hook.(func(reflect.Type, reflect.Type, any) (any, error))
 
-	_, err = hookFunc(reflect.TypeOf(""), reflect.TypeOf(""), "dev")
+	_, err := hookFunc(reflect.TypeOf(""), reflect.TypeOf(""), "dev")
 	require.ErrorIs(t, err, expectedErr)
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -116,8 +116,7 @@ func (suite *structcliSuite) TestStoreCompletionHookFunc() {
 		return []string{"dev", "prod"}, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	err := internalhooks.StoreCompletionHookFunc(cmd, "mode", reflect.ValueOf(completeMethod))
-	require.NoError(suite.T(), err)
+	internalhooks.StoreCompletionHookFunc(cmd, "mode", reflect.ValueOf(completeMethod))
 
 	completion, exists := cmd.GetFlagCompletionFunc("mode")
 	require.True(suite.T(), exists, "completion function should be registered")
@@ -127,13 +126,14 @@ func (suite *structcliSuite) TestStoreCompletionHookFunc() {
 	assert.Equal(suite.T(), cobra.ShellCompDirectiveNoFileComp, directive)
 }
 
-func (suite *structcliSuite) TestStoreCompletionHookFunc_InvalidHookValue() {
+func (suite *structcliSuite) TestStoreCompletionHookFunc_PanicsOnInvalidHookValue() {
 	cmd := &cobra.Command{Use: "testcmd"}
 	cmd.Flags().String("mode", "", "test flag")
 
-	err := internalhooks.StoreCompletionHookFunc(cmd, "mode", reflect.Value{})
-	require.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "invalid completion hook")
+	assert.PanicsWithValue(suite.T(),
+		`structcli: invalid completion hook for flag "mode"`,
+		func() { internalhooks.StoreCompletionHookFunc(cmd, "mode", reflect.Value{}) },
+	)
 }
 
 type zapcoreLevelOptions struct {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -88,8 +88,7 @@ func (suite *structcliSuite) TestStoreDecodeHookFunc() {
 	targetType := reflect.TypeOf("")
 
 	// Call StoreDecodeHookFunc
-	err := internalhooks.StoreDecodeHookFunc(cmd, "custom-field", decodeValue, targetType)
-	require.NoError(suite.T(), err)
+	internalhooks.StoreDecodeHookFunc(cmd, "custom-field", decodeValue, targetType)
 
 	// Assert the scope contains the custom decode hook with correct key
 	scope := internalscope.Get(cmd)


### PR DESCRIPTION
## Description

`SetAnnotation`, `MarkHidden`, `MarkFlagRequired`, and `RegisterFlagCompletionFunc` only fail when the named flag doesn't exist. At every call site in `define.go` and `debug.go`, the flag is registered on the immediately preceding line — making the error path structurally unreachable.

This PR replaces ~20 `if err` blocks with `mustSetAnnotation`/`mustMarkHidden` helpers that panic with a diagnostic message if the invariant is ever violated. It also simplifies three function signatures whose only error source was `SetAnnotation`:

- `InferDecodeHooks`: `(bool, error)` → `bool`
- `StoreDecodeHookFunc`: `error` → void
- `StoreCompletionHookFunc`: `error` → void

### Commits

1. **`refactor(internal/hooks):`** Simplify `InferDecodeHooks` and `StoreDecodeHookFunc` — panic internally, drop error returns, update callers and tests
2. **`refactor:`** Add `mustSetAnnotation`/`mustMarkHidden` helpers, convert `applyFieldMetadata`/`applyPresetAliases`/`finalizeFieldDefinition` to void closures, fix silent discard in `debug.go`, simplify `StoreCompletionHookFunc`

### Why panic instead of error?

- The failure condition is a programming mistake (calling pflag on a flag that was never registered), not a runtime/user error
- It's structurally impossible in the current code — the flag is always created on the line immediately before
- `TestInferDecodeHooks_ErrorOnUnknownFlag` had to deliberately skip flag registration to trigger it
- Panics give a clear stack trace if the invariant ever breaks, vs errors that propagate silently

Net: **-41 lines**, 6 files changed, no behavioral change on any reachable code path.

## How to test

```sh
go test ./...
cd examples/full && go test ./...
```