### PR TITLE
feat: add `RegisterEnum` for automatic string enum flag handling

### DIFF
--- a/define.go
+++ b/define.go
@@ -371,6 +371,17 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 					internalhooks.StoreCompletionHookFunc(c, name, completeHookFunc)
 				}
 			}
+			// Auto-register enum completion when no explicit Complete hook exists
+			if _, exists := c.GetFlagCompletionFunc(name); !exists {
+				if fl := c.Flags().Lookup(name); fl != nil {
+					if ev, ok := fl.Value.(EnumValuer); ok {
+						vals := ev.EnumValues()
+						c.RegisterFlagCompletionFunc(name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+							return vals, cobra.ShellCompDirectiveNoFileComp
+						})
+					}
+				}
+			}
 		}
 
 		// Flags with `flagcustom:"true"` tag (validation already done)

--- a/define.go
+++ b/define.go
@@ -376,9 +376,11 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				if fl := c.Flags().Lookup(name); fl != nil {
 					if ev, ok := fl.Value.(EnumValuer); ok {
 						vals := ev.EnumValues()
-						c.RegisterFlagCompletionFunc(name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+						if err := c.RegisterFlagCompletionFunc(name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 							return vals, cobra.ShellCompDirectiveNoFileComp
-						})
+						}); err != nil {
+							panic(fmt.Sprintf("structcli: RegisterFlagCompletionFunc(%q): %v", name, err))
+						}
 					}
 				}
 			}

--- a/enum.go
+++ b/enum.go
@@ -1,0 +1,50 @@
+package structcli
+
+import (
+	"fmt"
+	"reflect"
+
+	internalhooks "github.com/leodido/structcli/internal/hooks"
+)
+
+// RegisterEnum registers a string-based enum type for automatic flag handling.
+// After registration, struct fields of type E work without flagcustom:"true"
+// or manual Define/Decode/Complete hook methods.
+//
+// values maps each enum constant to its string representations. The first
+// string in each slice is the canonical name shown in help text and shell
+// completion; additional strings are accepted as aliases during parsing
+// (case-insensitive).
+//
+// Must be called in init() before any Define() calls. Panics if the type
+// is already registered (duplicate registration or conflict with a built-in).
+//
+// Example:
+//
+//	type Environment string
+//	const (
+//	    EnvDev  Environment = "dev"
+//	    EnvProd Environment = "prod"
+//	)
+//
+//	func init() {
+//	    structcli.RegisterEnum[Environment](map[Environment][]string{
+//	        EnvDev:  {"dev", "development"},
+//	        EnvProd: {"prod", "production"},
+//	    })
+//	}
+func RegisterEnum[E ~string](values map[E][]string) {
+	typeName := reflect.TypeFor[E]().String()
+
+	// Panic on duplicate define hook registration
+	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
+		panic(fmt.Sprintf("structcli: RegisterEnum: type %q is already registered", typeName))
+	}
+
+	// Register define hook
+	internalhooks.DefineHookRegistry[typeName] = internalhooks.DefineStringEnumHookFunc(values)
+
+	// Register decode hook (panics on duplicate annotation name)
+	annName := fmt.Sprintf("StringTo%sHookFunc", typeName)
+	internalhooks.RegisterDecodeHook(typeName, annName, internalhooks.StringToEnumHookFunc(values))
+}

--- a/enum.go
+++ b/enum.go
@@ -14,10 +14,11 @@ import (
 // values maps each enum constant to its string representations. The first
 // string in each slice is the canonical name shown in help text and shell
 // completion; additional strings are accepted as aliases during parsing
-// (case-insensitive).
+// (case-insensitive). Canonical names appear sorted alphabetically in help text.
 //
 // Must be called in init() before any Define() calls. Panics if the type
-// is already registered (duplicate registration or conflict with a built-in).
+// is already registered (duplicate registration or conflict with a built-in),
+// or if values is empty.
 //
 // Example:
 //
@@ -34,9 +35,12 @@ import (
 //	    })
 //	}
 func RegisterEnum[E ~string](values map[E][]string) {
+	if len(values) == 0 {
+		panic("structcli: RegisterEnum: values must not be empty")
+	}
+
 	typeName := reflect.TypeFor[E]().String()
 
-	// Panic on duplicate define hook registration
 	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
 		panic(fmt.Sprintf("structcli: RegisterEnum: type %q is already registered", typeName))
 	}

--- a/enum_test.go
+++ b/enum_test.go
@@ -1,0 +1,268 @@
+package structcli
+
+import (
+	"encoding/json"
+	"testing"
+
+	internalhooks "github.com/leodido/structcli/internal/hooks"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test enum type ---
+
+type testEnvironment string
+
+const (
+	testEnvDev     testEnvironment = "dev"
+	testEnvStaging testEnvironment = "staging"
+	testEnvProd    testEnvironment = "prod"
+)
+
+func testEnvMap() map[testEnvironment][]string {
+	return map[testEnvironment][]string{
+		testEnvDev:     {"dev", "development"},
+		testEnvStaging: {"staging", "stage"},
+		testEnvProd:    {"prod", "production"},
+	}
+}
+
+// --- Option structs ---
+
+type enumOptions struct {
+	Env testEnvironment `flag:"env" flagdescr:"target environment"`
+}
+
+func (o *enumOptions) Attach(c *cobra.Command) error { return nil }
+
+type enumDefaultOptions struct {
+	Env testEnvironment `flag:"env" flagdescr:"target environment" default:"staging"`
+}
+
+func (o *enumDefaultOptions) Attach(c *cobra.Command) error { return nil }
+
+type enumRequiredOptions struct {
+	Env testEnvironment `flag:"env" flagdescr:"target environment" flagrequired:"true"`
+}
+
+func (o *enumRequiredOptions) Attach(c *cobra.Command) error { return nil }
+
+type enumEnvVarOptions struct {
+	Env testEnvironment `flag:"env" flagdescr:"target environment" flagenv:"true"`
+}
+
+func (o *enumEnvVarOptions) Attach(c *cobra.Command) error { return nil }
+
+type enumEnvOnlyOptions struct {
+	Env testEnvironment `flag:"env" flagdescr:"target environment" flagenv:"only"`
+}
+
+func (o *enumEnvOnlyOptions) Attach(c *cobra.Command) error { return nil }
+
+// --- Helpers ---
+
+func resetEnumTestState() {
+	viper.Reset()
+	SetEnvPrefix("")
+}
+
+// saveAndRestoreRegistries saves all hook registries and restores them after
+// the test. This prevents enum registration from leaking between tests.
+func saveAndRestoreRegistries(t *testing.T) {
+	t.Helper()
+
+	origDefine := make(map[string]internalhooks.DefineHookFunc)
+	for k, v := range internalhooks.DefineHookRegistry {
+		origDefine[k] = v
+	}
+
+	decodeSnap := internalhooks.SnapshotDecodeRegistries()
+
+	t.Cleanup(func() {
+		internalhooks.DefineHookRegistry = origDefine
+		internalhooks.RestoreDecodeRegistries(decodeSnap)
+	})
+}
+
+func registerTestEnum(t *testing.T) {
+	t.Helper()
+	saveAndRestoreRegistries(t)
+	RegisterEnum[testEnvironment](testEnvMap())
+}
+
+// --- Tests ---
+
+func TestRegisterEnum_DefineAndUnmarshal(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--env", "prod"}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testEnvProd, opts.Env)
+}
+
+func TestRegisterEnum_DefaultValue(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumDefaultOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testEnvStaging, opts.Env)
+}
+
+func TestRegisterEnum_CaseInsensitive(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--env", "DEV"}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testEnvDev, opts.Env)
+}
+
+func TestRegisterEnum_Aliases(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--env", "production"}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testEnvProd, opts.Env)
+}
+
+func TestRegisterEnum_InvalidValue(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	err := cmd.Flags().Parse([]string{"--env", "invalid"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid value")
+}
+
+func TestRegisterEnum_EnvVar(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+	SetEnvPrefix("APP")
+
+	t.Setenv("APP_ENV", "staging")
+
+	opts := &enumEnvVarOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testEnvStaging, opts.Env)
+}
+
+func TestRegisterEnum_EnvOnly(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+	SetEnvPrefix("APP")
+
+	t.Setenv("APP_ENV", "prod")
+
+	opts := &enumEnvOnlyOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testEnvProd, opts.Env)
+}
+
+func TestRegisterEnum_NoFlagcustomNeeded(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	// Define succeeds without flagcustom:"true"
+	require.NoError(t, Define(cmd, opts))
+
+	// Flag exists and works
+	flag := cmd.Flags().Lookup("env")
+	require.NotNil(t, flag)
+	assert.Equal(t, "string", flag.Value.Type())
+}
+
+func TestRegisterEnum_JSONSchema(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	schema, err := JSONSchema(cmd)
+	require.NoError(t, err)
+
+	data, err := json.Marshal(schema)
+	require.NoError(t, err)
+
+	schemaStr := string(data)
+	assert.Contains(t, schemaStr, `"enum"`)
+	assert.Contains(t, schemaStr, `"dev"`)
+	assert.Contains(t, schemaStr, `"staging"`)
+	assert.Contains(t, schemaStr, `"prod"`)
+}
+
+func TestRegisterEnum_AutoCompletion(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	completionFunc, exists := cmd.GetFlagCompletionFunc("env")
+	require.True(t, exists, "completion function should be auto-registered")
+
+	suggestions, directive := completionFunc(cmd, nil, "")
+	assert.Equal(t, []string{"dev", "prod", "staging"}, suggestions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestRegisterEnum_DuplicatePanics(t *testing.T) {
+	saveAndRestoreRegistries(t)
+
+	RegisterEnum[testEnvironment](testEnvMap())
+
+	assert.PanicsWithValue(t,
+		`structcli: RegisterEnum: type "structcli.testEnvironment" is already registered`,
+		func() { RegisterEnum[testEnvironment](testEnvMap()) },
+	)
+}
+
+func TestRegisterEnum_DescriptionEnhanced(t *testing.T) {
+	resetEnumTestState()
+	registerTestEnum(t)
+
+	opts := &enumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	flag := cmd.Flags().Lookup("env")
+	require.NotNil(t, flag)
+	assert.Contains(t, flag.Usage, "{dev,prod,staging}")
+}

--- a/enum_test.go
+++ b/enum_test.go
@@ -254,6 +254,19 @@ func TestRegisterEnum_DuplicatePanics(t *testing.T) {
 	)
 }
 
+func TestRegisterEnum_EmptyValuesPanics(t *testing.T) {
+	saveAndRestoreRegistries(t)
+
+	assert.PanicsWithValue(t,
+		"structcli: RegisterEnum: values must not be empty",
+		func() { RegisterEnum[testEnvironment](nil) },
+	)
+	assert.PanicsWithValue(t,
+		"structcli: RegisterEnum: values must not be empty",
+		func() { RegisterEnum[testEnvironment](map[testEnvironment][]string{}) },
+	)
+}
+
 func TestRegisterEnum_DescriptionEnhanced(t *testing.T) {
 	resetEnumTestState()
 	registerTestEnum(t)

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"reflect"
 	"strings"
 
 	"github.com/go-playground/mold/v4/modifiers"
@@ -14,9 +13,7 @@ import (
 	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/jsonschema"
-	"github.com/leodido/structcli/values"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -27,6 +24,14 @@ const (
 	EnvStaging     Environment = "staging"
 	EnvProduction  Environment = "prod"
 )
+
+func init() {
+	structcli.RegisterEnum[Environment](map[Environment][]string{
+		EnvDevelopment: {"dev", "development"},
+		EnvStaging:    {"staging", "stage"},
+		EnvProduction: {"prod", "production"},
+	})
+}
 
 type EvenDeeper struct {
 	Setting   string `flag:"deeper-setting" default:"default-deeper-setting"`
@@ -67,7 +72,7 @@ type ServerOptions struct {
 	Database DatabaseConfig `flaggroup:"Database"`
 
 	// Custom type
-	TargetEnv Environment `flagcustom:"true" flag:"target-env" flagdescr:"Set the target environment"`
+	TargetEnv Environment `flag:"target-env" flagdescr:"Set the target environment" default:"dev"`
 
 	Deep Deeply
 }
@@ -77,51 +82,7 @@ type DatabaseConfig struct {
 	MaxConns int    `flagdescr:"Max database connections" default:"10" flagenv:"true"`
 }
 
-// DefineTargetEnv defines the custom flag for Environment with autocompletion
-func (o *ServerOptions) DefineTargetEnv(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	enhancedDesc := descr + " {dev,staging,prod}"
-	fieldPtr := fieldValue.Addr().Interface().(*Environment)
-	*fieldPtr = EnvDevelopment
 
-	// Since Environment is a string type, we cast its pointer to *string and use our string value helper.
-	return values.NewString((*string)(fieldPtr)), enhancedDesc
-}
-
-// DecodeTargetEnv converts string input to Environment type with validation
-func (o *ServerOptions) DecodeTargetEnv(input any) (any, error) {
-	var strValue string
-
-	switch v := input.(type) {
-	case string:
-		strValue = v
-	case *string:
-		if v != nil {
-			strValue = *v
-		}
-	default:
-		return nil, fmt.Errorf("expected string input for environment, got %T", input)
-	}
-
-	switch strings.ToLower(strings.TrimSpace(strValue)) {
-	case "dev", "development":
-		return EnvDevelopment, nil
-	case "staging", "stage":
-		return EnvStaging, nil
-	case "prod", "production":
-		return EnvProduction, nil
-	default:
-		return nil, fmt.Errorf("invalid environment: %s (one of: dev, staging, prod)", strValue)
-	}
-}
-
-// CompleteTargetEnv provides shell completion for the target environment flag.
-func (o *ServerOptions) CompleteTargetEnv(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{
-		"dev\tDevelopment environment",
-		"staging\tStaging environment",
-		"prod\tProduction environment",
-	}, cobra.ShellCompDirectiveNoFileComp
-}
 
 // Attach makes ServerOptions implement the Options interface
 func (o *ServerOptions) Attach(c *cobra.Command) error {

--- a/examples/full/cli/cli_test.go
+++ b/examples/full/cli/cli_test.go
@@ -180,7 +180,7 @@ func TestFullApplication(t *testing.T) {
 			args: []string{"srv", "-p", "1234", "--target-env", "ciao"},
 			assertFunc: func(t *testing.T, output string, err error) {
 				require.Error(t, err)
-				assert.ErrorContains(t, err, "invalid environment: ciao")
+				assert.ErrorContains(t, err, `invalid value "ciao"`)
 			},
 		},
 		{

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -179,7 +179,11 @@ func StringToEnumHookFunc[E ~string](values map[E][]string) mapstructure.DecodeH
 	allowed := make(map[string]E)
 	for enumVal, names := range values {
 		for _, name := range names {
-			allowed[strings.ToLower(name)] = enumVal
+			key := strings.ToLower(name)
+			if existing, ok := allowed[key]; ok {
+				panic(fmt.Sprintf("structcli: alias %q (lowercased) maps to both %v and %v", key, existing, enumVal))
+			}
+			allowed[key] = enumVal
 		}
 	}
 	targetType := reflect.TypeFor[E]()

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -133,6 +133,46 @@ func InferDecodeHooks(c *cobra.Command, name, typename string) bool {
 	return false
 }
 
+// RegisterDecodeHook registers a decode hook for a custom type. It updates both
+// DecodeHookRegistry and AnnotationToDecodeHookRegistry. Panics on duplicate
+// annotation name (consistent with init() behavior).
+func RegisterDecodeHook(typeName, annotationName string, hook mapstructure.DecodeHookFunc) {
+	if _, exists := AnnotationToDecodeHookRegistry[annotationName]; exists {
+		panic(fmt.Sprintf("duplicate annotation name '%s' in decode hook registry (type: %s)", annotationName, typeName))
+	}
+
+	DecodeHookRegistry[typeName] = decodingAnnotation{ann: annotationName, fx: hook}
+	AnnotationToDecodeHookRegistry[annotationName] = hook
+}
+
+// StringToEnumHookFunc creates a decode hook that converts string values to a
+// ~string enum type during configuration unmarshaling. It supports
+// case-insensitive matching and aliases.
+func StringToEnumHookFunc[E ~string](values map[E][]string) mapstructure.DecodeHookFunc {
+	allowed := make(map[string]E)
+	for enumVal, names := range values {
+		for _, name := range names {
+			allowed[strings.ToLower(name)] = enumVal
+		}
+	}
+	targetType := reflect.TypeFor[E]()
+
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if f.Kind() != reflect.String || t != targetType {
+			return data, nil
+		}
+		s, ok := data.(string)
+		if !ok {
+			return data, nil
+		}
+		if val, found := allowed[strings.ToLower(s)]; found {
+			return val, nil
+		}
+
+		return nil, fmt.Errorf("invalid value %q for %s", s, targetType.Name())
+	}
+}
+
 // StringToZapcoreLevelHookFunc creates a decode hook that converts string values
 // to zapcore.Level types during configuration unmarshaling.
 func StringToZapcoreLevelHookFunc() mapstructure.DecodeHookFunc {

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -133,6 +133,33 @@ func InferDecodeHooks(c *cobra.Command, name, typename string) bool {
 	return false
 }
 
+// DecodeRegistrySnapshot holds opaque copies of both decode registries for
+// test isolation.
+type DecodeRegistrySnapshot struct {
+	registry    map[string]decodingAnnotation
+	annotations map[string]mapstructure.DecodeHookFunc
+}
+
+// SnapshotDecodeRegistries returns a deep copy of both decode registries.
+func SnapshotDecodeRegistries() DecodeRegistrySnapshot {
+	dr := make(map[string]decodingAnnotation, len(DecodeHookRegistry))
+	for k, v := range DecodeHookRegistry {
+		dr[k] = v
+	}
+	ar := make(map[string]mapstructure.DecodeHookFunc, len(AnnotationToDecodeHookRegistry))
+	for k, v := range AnnotationToDecodeHookRegistry {
+		ar[k] = v
+	}
+
+	return DecodeRegistrySnapshot{registry: dr, annotations: ar}
+}
+
+// RestoreDecodeRegistries replaces both decode registries from a snapshot.
+func RestoreDecodeRegistries(snap DecodeRegistrySnapshot) {
+	DecodeHookRegistry = snap.registry
+	AnnotationToDecodeHookRegistry = snap.annotations
+}
+
 // RegisterDecodeHook registers a decode hook for a custom type. It updates both
 // DecodeHookRegistry and AnnotationToDecodeHookRegistry. Panics on duplicate
 // annotation name (consistent with init() behavior).

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -325,3 +325,117 @@ func TestStoreDecodeHookFunc_WrapperPropagatesErrors(t *testing.T) {
 	_, err := hookFunc(reflect.TypeOf(""), reflect.TypeOf(""), "dev")
 	require.ErrorIs(t, err, expectedErr)
 }
+
+type testEnv string
+
+const (
+	testEnvDev     testEnv = "dev"
+	testEnvStaging testEnv = "staging"
+	testEnvProd    testEnv = "prod"
+)
+
+func testEnvValues() map[testEnv][]string {
+	return map[testEnv][]string{
+		testEnvDev:     {"dev", "development"},
+		testEnvStaging: {"staging", "stage"},
+		testEnvProd:    {"prod", "production"},
+	}
+}
+
+func TestStringToEnumHookFunc_ValidCanonical(t *testing.T) {
+	hook := StringToEnumHookFunc(testEnvValues())
+
+	result, err := execDecodeHook(t, hook, "dev", reflect.TypeFor[testEnv]())
+	require.NoError(t, err)
+	assert.Equal(t, testEnvDev, result)
+}
+
+func TestStringToEnumHookFunc_ValidAlias(t *testing.T) {
+	hook := StringToEnumHookFunc(testEnvValues())
+
+	result, err := execDecodeHook(t, hook, "development", reflect.TypeFor[testEnv]())
+	require.NoError(t, err)
+	assert.Equal(t, testEnvDev, result)
+}
+
+func TestStringToEnumHookFunc_CaseInsensitive(t *testing.T) {
+	hook := StringToEnumHookFunc(testEnvValues())
+
+	result, err := execDecodeHook(t, hook, "STAGING", reflect.TypeFor[testEnv]())
+	require.NoError(t, err)
+	assert.Equal(t, testEnvStaging, result)
+}
+
+func TestStringToEnumHookFunc_InvalidValue(t *testing.T) {
+	hook := StringToEnumHookFunc(testEnvValues())
+
+	_, err := execDecodeHook(t, hook, "invalid", reflect.TypeFor[testEnv]())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value "invalid"`)
+}
+
+func TestStringToEnumHookFunc_WrongTargetType(t *testing.T) {
+	hook := StringToEnumHookFunc(testEnvValues())
+
+	// When target type doesn't match, the hook passes through
+	result, err := execDecodeHook(t, hook, "dev", reflect.TypeOf(""))
+	require.NoError(t, err)
+	assert.Equal(t, "dev", result)
+}
+
+func TestStringToEnumHookFunc_NonStringSource(t *testing.T) {
+	hook := StringToEnumHookFunc(testEnvValues())
+
+	// When source is not a string, the hook passes through
+	result, err := execDecodeHook(t, hook, 42, reflect.TypeFor[testEnv]())
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+}
+
+func TestRegisterDecodeHook(t *testing.T) {
+	// Save and restore registry state
+	origRegistry := make(map[string]decodingAnnotation)
+	for k, v := range DecodeHookRegistry {
+		origRegistry[k] = v
+	}
+	origAnnotations := make(map[string]mapstructure.DecodeHookFunc)
+	for k, v := range AnnotationToDecodeHookRegistry {
+		origAnnotations[k] = v
+	}
+	defer func() {
+		DecodeHookRegistry = origRegistry
+		AnnotationToDecodeHookRegistry = origAnnotations
+	}()
+
+	hook := StringToEnumHookFunc(testEnvValues())
+	RegisterDecodeHook("test.Env", "StringToTestEnvHookFunc", hook)
+
+	data, ok := DecodeHookRegistry["test.Env"]
+	require.True(t, ok)
+	assert.Equal(t, "StringToTestEnvHookFunc", data.ann)
+
+	_, ok = AnnotationToDecodeHookRegistry["StringToTestEnvHookFunc"]
+	assert.True(t, ok)
+}
+
+func TestRegisterDecodeHook_DuplicatePanics(t *testing.T) {
+	origRegistry := make(map[string]decodingAnnotation)
+	for k, v := range DecodeHookRegistry {
+		origRegistry[k] = v
+	}
+	origAnnotations := make(map[string]mapstructure.DecodeHookFunc)
+	for k, v := range AnnotationToDecodeHookRegistry {
+		origAnnotations[k] = v
+	}
+	defer func() {
+		DecodeHookRegistry = origRegistry
+		AnnotationToDecodeHookRegistry = origAnnotations
+	}()
+
+	hook := StringToEnumHookFunc(testEnvValues())
+	RegisterDecodeHook("test.Env", "StringToTestEnvHookFunc", hook)
+
+	assert.Panics(t, func() {
+		RegisterDecodeHook("test.Env2", "StringToTestEnvHookFunc", hook)
+	})
+}

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -392,6 +392,18 @@ func TestStringToEnumHookFunc_NonStringSource(t *testing.T) {
 	assert.Equal(t, 42, result)
 }
 
+func TestStringToEnumHookFunc_AliasCollisionPanics(t *testing.T) {
+	assert.PanicsWithValue(t,
+		`structcli: alias "dev" (lowercased) maps to both dev and staging`,
+		func() {
+			StringToEnumHookFunc(map[testEnv][]string{
+				testEnvDev:     {"dev"},
+				testEnvStaging: {"DEV"},
+			})
+		},
+	)
+}
+
 func TestRegisterDecodeHook(t *testing.T) {
 	snap := SnapshotDecodeRegistries()
 	defer RestoreDecodeRegistries(snap)

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -393,19 +393,8 @@ func TestStringToEnumHookFunc_NonStringSource(t *testing.T) {
 }
 
 func TestRegisterDecodeHook(t *testing.T) {
-	// Save and restore registry state
-	origRegistry := make(map[string]decodingAnnotation)
-	for k, v := range DecodeHookRegistry {
-		origRegistry[k] = v
-	}
-	origAnnotations := make(map[string]mapstructure.DecodeHookFunc)
-	for k, v := range AnnotationToDecodeHookRegistry {
-		origAnnotations[k] = v
-	}
-	defer func() {
-		DecodeHookRegistry = origRegistry
-		AnnotationToDecodeHookRegistry = origAnnotations
-	}()
+	snap := SnapshotDecodeRegistries()
+	defer RestoreDecodeRegistries(snap)
 
 	hook := StringToEnumHookFunc(testEnvValues())
 	RegisterDecodeHook("test.Env", "StringToTestEnvHookFunc", hook)
@@ -419,18 +408,8 @@ func TestRegisterDecodeHook(t *testing.T) {
 }
 
 func TestRegisterDecodeHook_DuplicatePanics(t *testing.T) {
-	origRegistry := make(map[string]decodingAnnotation)
-	for k, v := range DecodeHookRegistry {
-		origRegistry[k] = v
-	}
-	origAnnotations := make(map[string]mapstructure.DecodeHookFunc)
-	for k, v := range AnnotationToDecodeHookRegistry {
-		origAnnotations[k] = v
-	}
-	defer func() {
-		DecodeHookRegistry = origRegistry
-		AnnotationToDecodeHookRegistry = origAnnotations
-	}()
+	snap := SnapshotDecodeRegistries()
+	defer RestoreDecodeRegistries(snap)
 
 	hook := StringToEnumHookFunc(testEnvValues())
 	RegisterDecodeHook("test.Env", "StringToTestEnvHookFunc", hook)

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -232,6 +232,19 @@ func DefineSlogLevelHookFunc() DefineHookFunc {
 	}
 }
 
+// DefineStringEnumHookFunc creates a DefineHookFunc for a registered ~string enum.
+// The returned hook creates an enumStringValue that validates on Set() and
+// appends "{val1,val2,...}" to the flag description.
+func DefineStringEnumHookFunc[E ~string](values map[E][]string) DefineHookFunc {
+	return func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+		target := fieldValue.Addr().Interface().(*E)
+		ev := structclivalues.NewEnumString(target, values)
+		enhancedDescr := descr + fmt.Sprintf(" {%s}", strings.Join(ev.EnumValues(), ","))
+
+		return ev, enhancedDescr
+	}
+}
+
 // InferDefineHooks checks if there's a predefined flag definition function for the given type
 func InferDefineHooks(c *cobra.Command, name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) bool {
 	if defineFunc, ok := DefineHookRegistry[structField.Type.String()]; ok {

--- a/internal/hooks/define_internal_test.go
+++ b/internal/hooks/define_internal_test.go
@@ -1,9 +1,11 @@
 package internalhooks
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnumHelpText_SortsAndFormats(t *testing.T) {
@@ -38,4 +40,59 @@ func TestEnumHelpText_SingleEntry(t *testing.T) {
 
 	assert.Equal(t, []string{"only"}, values)
 	assert.Equal(t, "one {only}", descr)
+}
+
+type testColor string
+
+const (
+	testColorRed   testColor = "red"
+	testColorGreen testColor = "green"
+	testColorBlue  testColor = "blue"
+)
+
+func TestDefineStringEnumHookFunc_CreatesFlag(t *testing.T) {
+	values := map[testColor][]string{
+		testColorRed:   {"red"},
+		testColorGreen: {"green"},
+		testColorBlue:  {"blue"},
+	}
+
+	hook := DefineStringEnumHookFunc(values)
+
+	var target testColor = testColorRed
+	sf := reflect.StructField{Name: "Color", Type: reflect.TypeFor[testColor]()}
+	fv := reflect.ValueOf(&target).Elem()
+
+	pflagVal, usage := hook("color", "c", "pick a color", sf, fv)
+
+	require.NotNil(t, pflagVal)
+	assert.Contains(t, usage, "{blue,green,red}")
+	assert.Contains(t, usage, "pick a color")
+
+	// Set via the returned pflag.Value
+	require.NoError(t, pflagVal.Set("green"))
+	assert.Equal(t, testColorGreen, target)
+}
+
+func TestDefineStringEnumHookFunc_EnumValues(t *testing.T) {
+	values := map[testColor][]string{
+		testColorRed:   {"red", "r"},
+		testColorGreen: {"green"},
+		testColorBlue:  {"blue", "b"},
+	}
+
+	hook := DefineStringEnumHookFunc(values)
+
+	var target testColor
+	sf := reflect.StructField{Name: "Color", Type: reflect.TypeFor[testColor]()}
+	fv := reflect.ValueOf(&target).Elem()
+
+	pflagVal, _ := hook("color", "", "color", sf, fv)
+
+	type enumValuer interface {
+		EnumValues() []string
+	}
+	ev, ok := pflagVal.(enumValuer)
+	require.True(t, ok, "returned value should implement EnumValuer")
+	assert.Equal(t, []string{"blue", "green", "red"}, ev.EnumValues())
 }

--- a/values/enum.go
+++ b/values/enum.go
@@ -29,7 +29,11 @@ func NewEnumString[E ~string](target *E, values map[E][]string) *EnumStringValue
 		}
 		canonical = append(canonical, names[0])
 		for _, name := range names {
-			allowed[strings.ToLower(name)] = enumVal
+			key := strings.ToLower(name)
+			if existing, ok := allowed[key]; ok {
+				panic(fmt.Sprintf("values: alias %q (lowercased) maps to both %v and %v", key, existing, enumVal))
+			}
+			allowed[key] = enumVal
 		}
 	}
 	slices.Sort(canonical)

--- a/values/enum.go
+++ b/values/enum.go
@@ -1,0 +1,72 @@
+package values
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// EnumStringValue implements pflag.Value for string-based enum types.
+// It validates on Set() that the value is in the allowed set, supports
+// case-insensitive matching, and exposes allowed values via EnumValues().
+type EnumStringValue[E ~string] struct {
+	target    *E
+	allowed   map[string]E // lowercase input → enum constant
+	canonical []string     // sorted canonical names (first name per constant)
+}
+
+// NewEnumString creates an EnumStringValue for the given target pointer.
+// values maps each enum constant to its string representations; the first
+// string in each slice is canonical, additional strings are aliases.
+func NewEnumString[E ~string](target *E, values map[E][]string) *EnumStringValue[E] {
+	allowed := make(map[string]E, len(values)*2)
+	canonical := make([]string, 0, len(values))
+	for enumVal, names := range values {
+		if len(names) == 0 {
+			continue
+		}
+		canonical = append(canonical, names[0])
+		for _, name := range names {
+			allowed[strings.ToLower(name)] = enumVal
+		}
+	}
+	slices.Sort(canonical)
+
+	return &EnumStringValue[E]{
+		target:    target,
+		allowed:   allowed,
+		canonical: canonical,
+	}
+}
+
+func (v *EnumStringValue[E]) String() string {
+	if v.target == nil {
+		return ""
+	}
+
+	return string(*v.target)
+}
+
+func (v *EnumStringValue[E]) Set(s string) error {
+	val, ok := v.allowed[strings.ToLower(s)]
+	if !ok {
+		return fmt.Errorf("invalid value %q (allowed: %s)", s, strings.Join(v.canonical, ", "))
+	}
+	*v.target = val
+
+	return nil
+}
+
+func (v *EnumStringValue[E]) Type() string {
+	return "string"
+}
+
+// EnumValues returns the sorted canonical names for this enum.
+// Satisfies the structcli.EnumValuer interface.
+func (v *EnumStringValue[E]) EnumValues() []string {
+	return v.canonical
+}
+
+var _ pflag.Value = (*EnumStringValue[string])(nil)

--- a/values/enum_test.go
+++ b/values/enum_test.go
@@ -108,6 +108,19 @@ func TestEnumStringValue_EnumValues(t *testing.T) {
 	assert.Equal(t, []string{"dev", "prod", "staging"}, vals)
 }
 
+func TestEnumStringValue_AliasCollisionPanics(t *testing.T) {
+	var target testEnv
+	assert.PanicsWithValue(t,
+		`values: alias "dev" (lowercased) maps to both dev and staging`,
+		func() {
+			NewEnumString(&target, map[testEnv][]string{
+				testEnvDev:     {"dev"},
+				testEnvStaging: {"DEV"}, // collides after lowercasing
+			})
+		},
+	)
+}
+
 func TestEnumStringValue_EmptyNames(t *testing.T) {
 	var target testEnv
 	// An entry with empty names slice is skipped

--- a/values/enum_test.go
+++ b/values/enum_test.go
@@ -1,0 +1,124 @@
+package values
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testEnv string
+
+const (
+	testEnvDev     testEnv = "dev"
+	testEnvStaging testEnv = "staging"
+	testEnvProd    testEnv = "prod"
+)
+
+func testEnvValues() map[testEnv][]string {
+	return map[testEnv][]string{
+		testEnvDev:     {"dev", "development"},
+		testEnvStaging: {"staging", "stage"},
+		testEnvProd:    {"prod", "production"},
+	}
+}
+
+func TestEnumStringValue_Set_ValidCanonical(t *testing.T) {
+	var target testEnv
+	ev := NewEnumString(&target, testEnvValues())
+
+	require.NoError(t, ev.Set("dev"))
+	assert.Equal(t, testEnvDev, target)
+
+	require.NoError(t, ev.Set("staging"))
+	assert.Equal(t, testEnvStaging, target)
+
+	require.NoError(t, ev.Set("prod"))
+	assert.Equal(t, testEnvProd, target)
+}
+
+func TestEnumStringValue_Set_ValidAlias(t *testing.T) {
+	var target testEnv
+	ev := NewEnumString(&target, testEnvValues())
+
+	require.NoError(t, ev.Set("development"))
+	assert.Equal(t, testEnvDev, target)
+
+	require.NoError(t, ev.Set("stage"))
+	assert.Equal(t, testEnvStaging, target)
+
+	require.NoError(t, ev.Set("production"))
+	assert.Equal(t, testEnvProd, target)
+}
+
+func TestEnumStringValue_Set_CaseInsensitive(t *testing.T) {
+	var target testEnv
+	ev := NewEnumString(&target, testEnvValues())
+
+	require.NoError(t, ev.Set("DEV"))
+	assert.Equal(t, testEnvDev, target)
+
+	require.NoError(t, ev.Set("Staging"))
+	assert.Equal(t, testEnvStaging, target)
+
+	require.NoError(t, ev.Set("PRODUCTION"))
+	assert.Equal(t, testEnvProd, target)
+}
+
+func TestEnumStringValue_Set_Invalid(t *testing.T) {
+	var target testEnv = testEnvDev
+	ev := NewEnumString(&target, testEnvValues())
+
+	err := ev.Set("invalid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value "invalid"`)
+	assert.Contains(t, err.Error(), "allowed:")
+	assert.Contains(t, err.Error(), "dev")
+	// Target unchanged on error
+	assert.Equal(t, testEnvDev, target)
+}
+
+func TestEnumStringValue_String(t *testing.T) {
+	var target testEnv = testEnvStaging
+	ev := NewEnumString(&target, testEnvValues())
+
+	assert.Equal(t, "staging", ev.String())
+
+	ev.Set("prod")
+	assert.Equal(t, "prod", ev.String())
+}
+
+func TestEnumStringValue_String_NilTarget(t *testing.T) {
+	ev := &EnumStringValue[testEnv]{}
+	assert.Equal(t, "", ev.String())
+}
+
+func TestEnumStringValue_Type(t *testing.T) {
+	var target testEnv
+	ev := NewEnumString(&target, testEnvValues())
+	assert.Equal(t, "string", ev.Type())
+}
+
+func TestEnumStringValue_EnumValues(t *testing.T) {
+	var target testEnv
+	ev := NewEnumString(&target, testEnvValues())
+
+	vals := ev.EnumValues()
+	// Canonical names sorted alphabetically
+	assert.Equal(t, []string{"dev", "prod", "staging"}, vals)
+}
+
+func TestEnumStringValue_EmptyNames(t *testing.T) {
+	var target testEnv
+	// An entry with empty names slice is skipped
+	ev := NewEnumString(&target, map[testEnv][]string{
+		testEnvDev:  {"dev"},
+		testEnvProd: {},
+	})
+
+	vals := ev.EnumValues()
+	assert.Equal(t, []string{"dev"}, vals)
+
+	err := ev.Set("prod")
+	require.Error(t, err, "prod has no registered names")
+}


### PR DESCRIPTION
## Description

`RegisterEnum[E ~string]` registers a string-based enum type for automatic flag handling. After registration, struct fields of type `E` work without `flagcustom:"true"` or manual `Define`/`Decode`/`Complete` hook methods.

### Before (35 lines of boilerplate per enum)

```go
type ServerOptions struct {
    TargetEnv Environment `flagcustom:"true" flag:"target-env" flagdescr:"..."`
}
func (o *ServerOptions) DefineTargetEnv(...) (pflag.Value, string) { ... }
func (o *ServerOptions) DecodeTargetEnv(input any) (any, error) { ... }
func (o *ServerOptions) CompleteTargetEnv(...) ([]string, cobra.ShellCompDirective) { ... }
```

### After (1 init call)

```go
func init() {
    structcli.RegisterEnum[Environment](map[Environment][]string{
        EnvDev:  {"dev", "development"},
        EnvProd: {"prod", "production"},
    })
}
type ServerOptions struct {
    TargetEnv Environment `flag:"target-env" flagdescr:"..." default:"dev"`
}
```

### Features

- Case-insensitive matching and alias support
- Validation on `Set()` (rejects invalid values at parse time)
- Automatic `{val1,val2,...}` description enhancement (sorted alphabetically)
- Automatic shell completion for all `EnumValuer` flags (also benefits existing zapcore/slog)
- JSON Schema enum annotation flows through automatically
- Works with `flagenv:"true"`, `flagenv:"only"`, `flagrequired:"true"`, `default:"..."`
- Panics on duplicate registration, empty values map, or alias collisions (fail loud at init time)

### Commits

1. **`feat(values):`** `enumStringValue[E ~string]` — pflag.Value + EnumValuer with validation, case-insensitivity, aliases
2. **`feat(internal/hooks):`** `DefineStringEnumHookFunc`, `StringToEnumHookFunc`, `RegisterDecodeHook` helper
3. **`feat:`** Public `RegisterEnum` + auto-completion for EnumValuer flags in `finalizeFieldDefinition`
4. **`refactor(examples/full):`** Migrate `Environment` type, remove 47 lines of boilerplate
5. **`fix:`** Panic on alias collisions and discarded completion error
6. **`fix:`** Validate empty values and improve doc comment

## How to test

```sh
go test ./...
cd examples/full && go test ./...
```