### PR TITLE
feat: add `RegisterIntEnum` for integer-based enum flags

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -34,6 +34,42 @@ import (
 //	        EnvProd: {"prod", "production"},
 //	    })
 //	}
+// RegisterIntEnum registers an integer-based enum type for automatic flag handling.
+// Same semantics as RegisterEnum but for types with an integer underlying type
+// (e.g., custom iota-based enums). Uses enumflag/v2 internally for flag parsing.
+//
+// Must be called in init() before any Define() calls. Panics if the type
+// is already registered.
+//
+// Example:
+//
+//	type Priority int
+//	const (
+//	    PriorityLow    Priority = 0
+//	    PriorityMedium Priority = 1
+//	    PriorityHigh   Priority = 2
+//	)
+//
+//	func init() {
+//	    structcli.RegisterIntEnum[Priority](map[Priority][]string{
+//	        PriorityLow:    {"low"},
+//	        PriorityMedium: {"medium", "med"},
+//	        PriorityHigh:   {"high", "hi"},
+//	    })
+//	}
+func RegisterIntEnum[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map[E][]string) {
+	typeName := reflect.TypeFor[E]().String()
+
+	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
+		panic(fmt.Sprintf("structcli: RegisterIntEnum: type %q is already registered", typeName))
+	}
+
+	internalhooks.DefineHookRegistry[typeName] = internalhooks.DefineIntEnumHookFunc(values)
+
+	annName := fmt.Sprintf("StringTo%sHookFunc", typeName)
+	internalhooks.RegisterDecodeHook(typeName, annName, internalhooks.StringToIntEnumHookFunc(values))
+}
+
 func RegisterEnum[E ~string](values map[E][]string) {
 	if len(values) == 0 {
 		panic("structcli: RegisterEnum: values must not be empty")

--- a/enum.go
+++ b/enum.go
@@ -34,12 +34,35 @@ import (
 //	        EnvProd: {"prod", "production"},
 //	    })
 //	}
+func RegisterEnum[E ~string](values map[E][]string) {
+	if len(values) == 0 {
+		panic("structcli: RegisterEnum: values must not be empty")
+	}
+
+	typeName := reflect.TypeFor[E]().String()
+
+	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
+		panic(fmt.Sprintf("structcli: RegisterEnum: type %q is already registered", typeName))
+	}
+
+	internalhooks.DefineHookRegistry[typeName] = internalhooks.DefineStringEnumHookFunc(values)
+
+	annName := fmt.Sprintf("StringTo%sHookFunc", typeName)
+	internalhooks.RegisterDecodeHook(typeName, annName, internalhooks.StringToEnumHookFunc(values))
+}
+
 // RegisterIntEnum registers an integer-based enum type for automatic flag handling.
-// Same semantics as RegisterEnum but for types with an integer underlying type
-// (e.g., custom iota-based enums). Uses enumflag/v2 internally for flag parsing.
+// Same semantics as [RegisterEnum] but for types with a signed integer underlying
+// type (e.g., custom iota-based enums). Uses enumflag/v2 internally for flag
+// parsing.
+//
+// Values appear in help text sorted by their integer value.
+//
+// Unsigned integer types (~uint, ~uint8, etc.) are not supported. For those,
+// use flagcustom:"true" with manual Define/Decode/Complete hooks.
 //
 // Must be called in init() before any Define() calls. Panics if the type
-// is already registered.
+// is already registered, or if values is empty.
 //
 // Example:
 //
@@ -58,6 +81,10 @@ import (
 //	    })
 //	}
 func RegisterIntEnum[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map[E][]string) {
+	if len(values) == 0 {
+		panic("structcli: RegisterIntEnum: values must not be empty")
+	}
+
 	typeName := reflect.TypeFor[E]().String()
 
 	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
@@ -70,21 +97,3 @@ func RegisterIntEnum[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map[E][]s
 	internalhooks.RegisterDecodeHook(typeName, annName, internalhooks.StringToIntEnumHookFunc(values))
 }
 
-func RegisterEnum[E ~string](values map[E][]string) {
-	if len(values) == 0 {
-		panic("structcli: RegisterEnum: values must not be empty")
-	}
-
-	typeName := reflect.TypeFor[E]().String()
-
-	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
-		panic(fmt.Sprintf("structcli: RegisterEnum: type %q is already registered", typeName))
-	}
-
-	// Register define hook
-	internalhooks.DefineHookRegistry[typeName] = internalhooks.DefineStringEnumHookFunc(values)
-
-	// Register decode hook (panics on duplicate annotation name)
-	annName := fmt.Sprintf("StringTo%sHookFunc", typeName)
-	internalhooks.RegisterDecodeHook(typeName, annName, internalhooks.StringToEnumHookFunc(values))
-}

--- a/enum_test.go
+++ b/enum_test.go
@@ -279,3 +279,164 @@ func TestRegisterEnum_DescriptionEnhanced(t *testing.T) {
 	require.NotNil(t, flag)
 	assert.Contains(t, flag.Usage, "{dev,prod,staging}")
 }
+
+// --- Integer enum tests ---
+
+type testPriority int
+
+const (
+	testPriorityLow    testPriority = 0
+	testPriorityMedium testPriority = 1
+	testPriorityHigh   testPriority = 2
+)
+
+func testPriorityMap() map[testPriority][]string {
+	return map[testPriority][]string{
+		testPriorityLow:    {"low"},
+		testPriorityMedium: {"medium", "med"},
+		testPriorityHigh:   {"high", "hi"},
+	}
+}
+
+type intEnumOptions struct {
+	Priority testPriority `flag:"priority" flagdescr:"task priority"`
+}
+
+func (o *intEnumOptions) Attach(c *cobra.Command) error { return nil }
+
+type intEnumDefaultOptions struct {
+	Priority testPriority `flag:"priority" flagdescr:"task priority" default:"medium"`
+}
+
+func (o *intEnumDefaultOptions) Attach(c *cobra.Command) error { return nil }
+
+func registerTestIntEnum(t *testing.T) {
+	t.Helper()
+	saveAndRestoreRegistries(t)
+	RegisterIntEnum[testPriority](testPriorityMap())
+}
+
+func TestRegisterIntEnum_DefineAndUnmarshal(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--priority", "high"}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testPriorityHigh, opts.Priority)
+}
+
+func TestRegisterIntEnum_Aliases(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--priority", "med"}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testPriorityMedium, opts.Priority)
+}
+
+func TestRegisterIntEnum_CaseInsensitive(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{"--priority", "HIGH"}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testPriorityHigh, opts.Priority)
+}
+
+func TestRegisterIntEnum_InvalidValue(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	err := cmd.Flags().Parse([]string{"--priority", "critical"})
+	require.Error(t, err)
+}
+
+func TestRegisterIntEnum_DefaultValue(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumDefaultOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testPriorityMedium, opts.Priority)
+}
+
+func TestRegisterIntEnum_AutoCompletion(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	completionFunc, exists := cmd.GetFlagCompletionFunc("priority")
+	require.True(t, exists, "completion function should be auto-registered")
+
+	suggestions, directive := completionFunc(cmd, nil, "")
+	assert.Equal(t, []string{"low", "medium", "high"}, suggestions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestRegisterIntEnum_JSONSchema(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	schema, err := JSONSchema(cmd)
+	require.NoError(t, err)
+
+	data, err := json.Marshal(schema)
+	require.NoError(t, err)
+
+	schemaStr := string(data)
+	assert.Contains(t, schemaStr, `"enum"`)
+	assert.Contains(t, schemaStr, `"low"`)
+	assert.Contains(t, schemaStr, `"medium"`)
+	assert.Contains(t, schemaStr, `"high"`)
+}
+
+func TestRegisterIntEnum_DuplicatePanics(t *testing.T) {
+	saveAndRestoreRegistries(t)
+
+	RegisterIntEnum[testPriority](testPriorityMap())
+
+	assert.PanicsWithValue(t,
+		`structcli: RegisterIntEnum: type "structcli.testPriority" is already registered`,
+		func() { RegisterIntEnum[testPriority](testPriorityMap()) },
+	)
+}
+
+func TestRegisterIntEnum_DescriptionEnhanced(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+
+	opts := &intEnumOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+
+	flag := cmd.Flags().Lookup("priority")
+	require.NotNil(t, flag)
+	assert.Contains(t, flag.Usage, "{low,medium,high}")
+}

--- a/enum_test.go
+++ b/enum_test.go
@@ -428,6 +428,19 @@ func TestRegisterIntEnum_DuplicatePanics(t *testing.T) {
 	)
 }
 
+func TestRegisterIntEnum_EmptyValuesPanics(t *testing.T) {
+	saveAndRestoreRegistries(t)
+
+	assert.PanicsWithValue(t,
+		"structcli: RegisterIntEnum: values must not be empty",
+		func() { RegisterIntEnum[testPriority](nil) },
+	)
+	assert.PanicsWithValue(t,
+		"structcli: RegisterIntEnum: values must not be empty",
+		func() { RegisterIntEnum[testPriority](map[testPriority][]string{}) },
+	)
+}
+
 func TestRegisterIntEnum_DescriptionEnhanced(t *testing.T) {
 	resetEnumTestState()
 	registerTestIntEnum(t)
@@ -439,4 +452,48 @@ func TestRegisterIntEnum_DescriptionEnhanced(t *testing.T) {
 	flag := cmd.Flags().Lookup("priority")
 	require.NotNil(t, flag)
 	assert.Contains(t, flag.Usage, "{low,medium,high}")
+}
+
+type intEnumEnvVarOptions struct {
+	Priority testPriority `flag:"priority" flagdescr:"task priority" flagenv:"true"`
+}
+
+func (o *intEnumEnvVarOptions) Attach(c *cobra.Command) error { return nil }
+
+type intEnumEnvOnlyOptions struct {
+	Priority testPriority `flag:"priority" flagdescr:"task priority" flagenv:"only"`
+}
+
+func (o *intEnumEnvOnlyOptions) Attach(c *cobra.Command) error { return nil }
+
+func TestRegisterIntEnum_EnvVar(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+	SetEnvPrefix("APP")
+
+	t.Setenv("APP_PRIORITY", "high")
+
+	opts := &intEnumEnvVarOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testPriorityHigh, opts.Priority)
+}
+
+func TestRegisterIntEnum_EnvOnly(t *testing.T) {
+	resetEnumTestState()
+	registerTestIntEnum(t)
+	SetEnvPrefix("APP")
+
+	t.Setenv("APP_PRIORITY", "medium")
+
+	opts := &intEnumEnvOnlyOptions{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, Define(cmd, opts))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, Unmarshal(cmd, opts))
+
+	assert.Equal(t, testPriorityMedium, opts.Priority)
 }

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -211,7 +211,11 @@ func StringToIntEnumHookFunc[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values m
 	allowed := make(map[string]E)
 	for enumVal, names := range values {
 		for _, name := range names {
-			allowed[strings.ToLower(name)] = enumVal
+			key := strings.ToLower(name)
+			if existing, ok := allowed[key]; ok {
+				panic(fmt.Sprintf("structcli: alias %q (lowercased) maps to both %v and %v", key, existing, enumVal))
+			}
+			allowed[key] = enumVal
 		}
 	}
 	targetType := reflect.TypeFor[E]()

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -204,6 +204,37 @@ func StringToEnumHookFunc[E ~string](values map[E][]string) mapstructure.DecodeH
 	}
 }
 
+// StringToIntEnumHookFunc creates a decode hook that converts string values to
+// an integer-based enum type during configuration unmarshaling. It supports
+// case-insensitive matching and aliases.
+func StringToIntEnumHookFunc[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map[E][]string) mapstructure.DecodeHookFunc {
+	allowed := make(map[string]E)
+	for enumVal, names := range values {
+		for _, name := range names {
+			allowed[strings.ToLower(name)] = enumVal
+		}
+	}
+	targetType := reflect.TypeFor[E]()
+
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if t != targetType {
+			return data, nil
+		}
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		s, ok := data.(string)
+		if !ok {
+			return data, nil
+		}
+		if val, found := allowed[strings.ToLower(s)]; found {
+			return val, nil
+		}
+
+		return nil, fmt.Errorf("invalid value %q for %s", s, targetType.Name())
+	}
+}
+
 // StringToZapcoreLevelHookFunc creates a decode hook that converts string values
 // to zapcore.Level types during configuration unmarshaling.
 func StringToZapcoreLevelHookFunc() mapstructure.DecodeHookFunc {

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -486,3 +486,12 @@ func TestStringToIntEnumHookFunc_WrongTargetType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "low", result)
 }
+
+func TestStringToIntEnumHookFunc_AliasCollisionPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		StringToIntEnumHookFunc(map[testPriority][]string{
+			testPriorityLow:    {"low"},
+			testPriorityMedium: {"LOW"},
+		})
+	})
+}

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -430,3 +430,59 @@ func TestRegisterDecodeHook_DuplicatePanics(t *testing.T) {
 		RegisterDecodeHook("test.Env2", "StringToTestEnvHookFunc", hook)
 	})
 }
+
+type testPriority int
+
+const (
+	testPriorityLow    testPriority = 0
+	testPriorityMedium testPriority = 1
+	testPriorityHigh   testPriority = 2
+)
+
+func testPriorityValues() map[testPriority][]string {
+	return map[testPriority][]string{
+		testPriorityLow:    {"low"},
+		testPriorityMedium: {"medium", "med"},
+		testPriorityHigh:   {"high", "hi"},
+	}
+}
+
+func TestStringToIntEnumHookFunc_ValidCanonical(t *testing.T) {
+	hook := StringToIntEnumHookFunc(testPriorityValues())
+
+	result, err := execDecodeHook(t, hook, "low", reflect.TypeFor[testPriority]())
+	require.NoError(t, err)
+	assert.Equal(t, testPriorityLow, result)
+}
+
+func TestStringToIntEnumHookFunc_ValidAlias(t *testing.T) {
+	hook := StringToIntEnumHookFunc(testPriorityValues())
+
+	result, err := execDecodeHook(t, hook, "med", reflect.TypeFor[testPriority]())
+	require.NoError(t, err)
+	assert.Equal(t, testPriorityMedium, result)
+}
+
+func TestStringToIntEnumHookFunc_CaseInsensitive(t *testing.T) {
+	hook := StringToIntEnumHookFunc(testPriorityValues())
+
+	result, err := execDecodeHook(t, hook, "HIGH", reflect.TypeFor[testPriority]())
+	require.NoError(t, err)
+	assert.Equal(t, testPriorityHigh, result)
+}
+
+func TestStringToIntEnumHookFunc_InvalidValue(t *testing.T) {
+	hook := StringToIntEnumHookFunc(testPriorityValues())
+
+	_, err := execDecodeHook(t, hook, "critical", reflect.TypeFor[testPriority]())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value "critical"`)
+}
+
+func TestStringToIntEnumHookFunc_WrongTargetType(t *testing.T) {
+	hook := StringToIntEnumHookFunc(testPriorityValues())
+
+	result, err := execDecodeHook(t, hook, "low", reflect.TypeOf(0))
+	require.NoError(t, err)
+	assert.Equal(t, "low", result)
+}

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -173,9 +173,9 @@ func DefineTimeDurationHookFunc() DefineHookFunc {
 // keyed by integer-typed levels. It returns the sorted value names and the
 // description with the addendum appended.
 func enumHelpText[L ~int | ~int8 | ~int16 | ~int32 | ~int64](levels map[L][]string, descr string) ([]string, string) {
-	keys := make([]int, 0, len(levels))
+	keys := make([]int64, 0, len(levels))
 	for k := range levels {
-		keys = append(keys, int(k))
+		keys = append(keys, int64(k))
 	}
 	slices.Sort(keys)
 

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -172,7 +172,7 @@ func DefineTimeDurationHookFunc() DefineHookFunc {
 // enumHelpText builds a sorted "{val1,val2,...}" addendum from an enum map
 // keyed by integer-typed levels. It returns the sorted value names and the
 // description with the addendum appended.
-func enumHelpText[L ~int8 | ~int](levels map[L][]string, descr string) ([]string, string) {
+func enumHelpText[L ~int | ~int8 | ~int16 | ~int32 | ~int64](levels map[L][]string, descr string) ([]string, string) {
 	keys := make([]int, 0, len(levels))
 	for k := range levels {
 		keys = append(keys, int(k))
@@ -229,6 +229,18 @@ func DefineSlogLevelHookFunc() DefineHookFunc {
 		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), logLevels, enumflag.EnumCaseInsensitive)
 
 		return WrapWithEnumValues(enumFlag, values), enhancedDescr
+	}
+}
+
+// DefineIntEnumHookFunc creates a DefineHookFunc for a registered integer-based enum.
+// It wraps enumflag/v2 and attaches EnumValuer metadata via WrapWithEnumValues.
+func DefineIntEnumHookFunc[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map[E][]string) DefineHookFunc {
+	return func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+		fieldPtr := fieldValue.Addr().Interface().(*E)
+		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), values, enumflag.EnumCaseInsensitive)
+		enumValues, enhancedDescr := enumHelpText(values, descr)
+
+		return WrapWithEnumValues(enumFlag, enumValues), enhancedDescr
 	}
 }
 

--- a/internal/hooks/define_internal_test.go
+++ b/internal/hooks/define_internal_test.go
@@ -96,3 +96,60 @@ func TestDefineStringEnumHookFunc_EnumValues(t *testing.T) {
 	require.True(t, ok, "returned value should implement EnumValuer")
 	assert.Equal(t, []string{"blue", "green", "red"}, ev.EnumValues())
 }
+
+type testSeverity int
+
+const (
+	testSeverityLow    testSeverity = 0
+	testSeverityMedium testSeverity = 1
+	testSeverityHigh   testSeverity = 2
+)
+
+func TestDefineIntEnumHookFunc_CreatesFlag(t *testing.T) {
+	values := map[testSeverity][]string{
+		testSeverityLow:    {"low"},
+		testSeverityMedium: {"medium", "med"},
+		testSeverityHigh:   {"high"},
+	}
+
+	hook := DefineIntEnumHookFunc(values)
+
+	var target testSeverity = testSeverityLow
+	sf := reflect.StructField{Name: "Severity", Type: reflect.TypeFor[testSeverity]()}
+	fv := reflect.ValueOf(&target).Elem()
+
+	pflagVal, usage := hook("severity", "", "task severity", sf, fv)
+
+	require.NotNil(t, pflagVal)
+	assert.Contains(t, usage, "{low,medium,high}")
+	assert.Contains(t, usage, "task severity")
+
+	require.NoError(t, pflagVal.Set("high"))
+	assert.Equal(t, testSeverityHigh, target)
+
+	require.NoError(t, pflagVal.Set("med"))
+	assert.Equal(t, testSeverityMedium, target)
+}
+
+func TestDefineIntEnumHookFunc_EnumValues(t *testing.T) {
+	values := map[testSeverity][]string{
+		testSeverityLow:    {"low"},
+		testSeverityMedium: {"medium"},
+		testSeverityHigh:   {"high"},
+	}
+
+	hook := DefineIntEnumHookFunc(values)
+
+	var target testSeverity
+	sf := reflect.StructField{Name: "Severity", Type: reflect.TypeFor[testSeverity]()}
+	fv := reflect.ValueOf(&target).Elem()
+
+	pflagVal, _ := hook("severity", "", "severity", sf, fv)
+
+	type enumValuerIface interface {
+		EnumValues() []string
+	}
+	ev, ok := pflagVal.(enumValuerIface)
+	require.True(t, ok, "returned value should implement EnumValuer")
+	assert.Equal(t, []string{"low", "medium", "high"}, ev.EnumValues())
+}


### PR DESCRIPTION
## Description

`RegisterIntEnum[E ~int | ~int8 | ~int16 | ~int32 | ~int64]` registers an integer-based enum type for automatic flag handling via `enumflag/v2`. Mirrors `RegisterEnum[E ~string]` (#115) but targets signed integer enum types.

After registration, struct fields of type `E` work without `flagcustom:"true"` or manual `Define`/`Decode`/`Complete` hook methods.

Unsigned integer types are not supported (documented in the doc comment).

### Usage

```go
type Priority int

const (
    PriorityLow    Priority = 0
    PriorityMedium Priority = 1
    PriorityHigh   Priority = 2
)

func init() {
    structcli.RegisterIntEnum[Priority](map[Priority][]string{
        PriorityLow:    {"low"},
        PriorityMedium: {"medium", "med"},
        PriorityHigh:   {"high"},
    })
}

type Options struct {
    Priority Priority `flag:"priority" flagdescr:"task priority" default:"low"`
}
```

### Features

- Case-insensitive matching and alias support (via `enumflag/v2`)
- Automatic `{val1,val2,...}` description enhancement (sorted by integer value)
- Automatic shell completion for all `EnumValuer` flags
- JSON Schema enum annotation
- Works with `flagenv:"true"`, `flagenv:"only"`, `flagrequired:"true"`, `default:"..."`
- Panics on duplicate registration, empty values map, or alias collisions

### Commits

1. **`feat(internal/hooks):`** `DefineIntEnumHookFunc` and `StringToIntEnumHookFunc` — define/decode hook factories for integer enums using `enumflag/v2`. Widens `enumHelpText` constraint to cover all integer widths.
2. **`feat:`** Public `RegisterIntEnum` + integration tests.
3. **`fix:`** Address review findings — fix broken doc comments (2.1), add alias collision panic to `StringToIntEnumHookFunc` (2.2), add env-var/env-only tests (2.3), validate empty values (2.7), document ordering/unsigned exclusion (3.1/3.3), fix `enumHelpText` int64 truncation on 32-bit (3.2).

> **Stacked on #115** — review that PR first.

## How to test

```sh
go test -run "TestRegisterIntEnum|TestDefineIntEnum|TestStringToIntEnum" -v . ./internal/hooks/...
go test ./...
```