### PR TITLE
refactor: migrate `zapcore.Level` to `RegisterIntEnum`

### DIFF
--- a/enum_builtin.go
+++ b/enum_builtin.go
@@ -2,6 +2,11 @@ package structcli
 
 import "go.uber.org/zap/zapcore"
 
+// Built-in enum registrations for well-known types.
+//
+// zapcore.Level uses a hardcoded map rather than delegating to
+// zapcore.ParseLevel. The level set has been stable since zapcore v1.
+// If a future version adds levels, this map must be updated.
 func init() {
 	RegisterIntEnum[zapcore.Level](map[zapcore.Level][]string{
 		zapcore.DebugLevel:  {"debug"},

--- a/enum_builtin.go
+++ b/enum_builtin.go
@@ -1,0 +1,15 @@
+package structcli
+
+import "go.uber.org/zap/zapcore"
+
+func init() {
+	RegisterIntEnum[zapcore.Level](map[zapcore.Level][]string{
+		zapcore.DebugLevel:  {"debug"},
+		zapcore.InfoLevel:   {"info"},
+		zapcore.WarnLevel:   {"warn"},
+		zapcore.ErrorLevel:  {"error"},
+		zapcore.DPanicLevel: {"dpanic"},
+		zapcore.PanicLevel:  {"panic"},
+		zapcore.FatalLevel:  {"fatal"},
+	})
+}

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -17,7 +17,6 @@ import (
 	internalscope "github.com/leodido/structcli/internal/scope"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -75,10 +74,6 @@ var DecodeHookRegistry = map[string]decodingAnnotation{
 	"[]net.IP": {
 		"StringToIPSliceHookFunc",
 		StringToIPSliceHookFunc(),
-	},
-	"zapcore.Level": {
-		"StringToZapcoreLevelHookFunc",
-		StringToZapcoreLevelHookFunc(),
 	},
 	"slog.Level": {
 		"StringToSlogLevelHookFunc",
@@ -236,26 +231,6 @@ func StringToIntEnumHookFunc[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values m
 		}
 
 		return nil, fmt.Errorf("invalid value %q for %s", s, targetType.Name())
-	}
-}
-
-// StringToZapcoreLevelHookFunc creates a decode hook that converts string values
-// to zapcore.Level types during configuration unmarshaling.
-func StringToZapcoreLevelHookFunc() mapstructure.DecodeHookFunc {
-	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
-		if f.Kind() != reflect.String {
-			return data, nil
-		}
-		if t != reflect.TypeOf(zapcore.DebugLevel) {
-			return data, nil
-		}
-
-		level, err := zapcore.ParseLevel(data.(string))
-		if err != nil {
-			return nil, fmt.Errorf("invalid string for zapcore.Level '%s': %w", data.(string), err)
-		}
-
-		return level, nil
 	}
 }
 

--- a/internal/hooks/decode_fuzz_test.go
+++ b/internal/hooks/decode_fuzz_test.go
@@ -210,7 +210,15 @@ func FuzzStringToZapcoreLevel(f *testing.F) {
 	f.Add("INVALID")
 	f.Add("DEBUG")
 
-	hook := StringToZapcoreLevelHookFunc().(decodeHookFuncType)
+	hook := StringToIntEnumHookFunc(map[zapcore.Level][]string{
+		zapcore.DebugLevel:  {"debug"},
+		zapcore.InfoLevel:   {"info"},
+		zapcore.WarnLevel:   {"warn"},
+		zapcore.ErrorLevel:  {"error"},
+		zapcore.DPanicLevel: {"dpanic"},
+		zapcore.PanicLevel:  {"panic"},
+		zapcore.FatalLevel:  {"fatal"},
+	}).(decodeHookFuncType)
 	target := reflect.TypeOf(zapcore.DebugLevel)
 
 	f.Fuzz(func(t *testing.T, input string) {

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/thediveo/enumflag/v2"
-	"go.uber.org/zap/zapcore"
 )
 
 // FIXME: remove short from the signature?
@@ -27,7 +26,6 @@ type DefineHookFunc func(name, short, descr string, structField reflect.StructFi
 
 // DefineHookRegistry keeps track of the built-in flag definition functions
 var DefineHookRegistry = map[string]DefineHookFunc{
-	"zapcore.Level":     DefineZapcoreLevelHookFunc(),
 	"time.Duration":     DefineTimeDurationHookFunc(),
 	"[]time.Duration":   DefineDurationSliceHookFunc(),
 	"[]bool":            DefineBoolSliceHookFunc(),
@@ -185,30 +183,6 @@ func enumHelpText[L ~int | ~int8 | ~int16 | ~int32 | ~int64](levels map[L][]stri
 	}
 
 	return values, descr + fmt.Sprintf(" {%s}", strings.Join(values, ","))
-}
-
-// DefineZapcoreLevelHookFunc creates a flag definition function for zapcore.Level.
-//
-// It returns an enum flag that implements pflag.Value.
-func DefineZapcoreLevelHookFunc() DefineHookFunc {
-	return func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-		logLevels := map[zapcore.Level][]string{
-			zapcore.DebugLevel:  {"debug"},
-			zapcore.InfoLevel:   {"info"},
-			zapcore.WarnLevel:   {"warn"},
-			zapcore.ErrorLevel:  {"error"},
-			zapcore.DPanicLevel: {"dpanic"},
-			zapcore.PanicLevel:  {"panic"},
-			zapcore.FatalLevel:  {"fatal"},
-		}
-
-		values, enhancedDescr := enumHelpText(logLevels, descr)
-
-		fieldPtr := fieldValue.Addr().Interface().(*zapcore.Level)
-		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), logLevels, enumflag.EnumCaseInsensitive)
-
-		return WrapWithEnumValues(enumFlag, values), enhancedDescr
-	}
 }
 
 // DefineSlogLevelHookFunc creates a flag definition function for slog.Level.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1688,7 +1688,7 @@ func (suite *structcliSuite) TestHooks_ZapcoreLevelFromYAML_InvalidLevel() {
 
 	assert.Error(suite.T(), err, "Unmarshal should return an error for invalid zapcore.Level")
 	assert.Contains(suite.T(), err.Error(), "couldn't unmarshal config to options:", "Error should be wrapped by Unmarshal")
-	assert.Contains(suite.T(), err.Error(), "invalid string for zapcore.Level 'invalidlevelstring'", "Error should contain the specific hook error message")
+	assert.Contains(suite.T(), err.Error(), "invalidlevelstring", "Error should contain the invalid input value")
 }
 
 type slogLevelOptions struct {
@@ -1875,9 +1875,17 @@ func (suite *structcliSuite) TestStringToZapcoreLevelHookFunc_TypeGuard() {
 
 	opts := &testStruct{}
 
-	// Use our zapcore hook directly with mapstructure
+	// Use the int enum hook for zapcore.Level directly with mapstructure
 	// This will force the hook to be called even for non-zapcore.Level fields
-	zapcoreHook := internalhooks.StringToZapcoreLevelHookFunc()
+	zapcoreHook := internalhooks.StringToIntEnumHookFunc(map[zapcore.Level][]string{
+		zapcore.DebugLevel:  {"debug"},
+		zapcore.InfoLevel:   {"info"},
+		zapcore.WarnLevel:   {"warn"},
+		zapcore.ErrorLevel:  {"error"},
+		zapcore.DPanicLevel: {"dpanic"},
+		zapcore.PanicLevel:  {"panic"},
+		zapcore.FatalLevel:  {"fatal"},
+	})
 
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: zapcoreHook, // Force zapcore hook to be used for all fields

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -137,7 +137,7 @@ func (suite *structcliSuite) TestStoreCompletionHookFunc_PanicsOnInvalidHookValu
 }
 
 type zapcoreLevelOptions struct {
-	LogLevel zapcore.Level `default:"info" flagcustom:"true" flagdescr:"the logging level" flagenv:"true"`
+	LogLevel zapcore.Level `default:"info" flagdescr:"the logging level" flagenv:"true"`
 }
 
 func (o *zapcoreLevelOptions) Attach(c *cobra.Command) error { return nil }


### PR DESCRIPTION
## Description

Replace the hand-written `DefineZapcoreLevelHookFunc` and `StringToZapcoreLevelHookFunc` with a single `RegisterIntEnum[zapcore.Level](...)` call, dogfooding the new enum registration infrastructure from #115/#116.

### What changed

- **New `enum_builtin.go`**: `init()` registers `zapcore.Level` via `RegisterIntEnum` with all 7 levels (debug through fatal).
- **Removed from `internal/hooks/define.go`**: `DefineZapcoreLevelHookFunc()` function and its `"zapcore.Level"` registry entry. Removed `zapcore` import.
- **Removed from `internal/hooks/decode.go`**: `StringToZapcoreLevelHookFunc()` function and its `"zapcore.Level"` registry entry. Removed `zapcore` import.
- **Updated tests**: Fuzz test and type-guard integration test now use `StringToIntEnumHookFunc` directly. Removed stale `flagcustom:"true"` from `zapcoreLevelOptions` test struct.

### Error message change

The error message for invalid zapcore levels changed from:
```
invalid string for zapcore.Level 'foo': ...
```
to:
```
invalid value "foo" for Level
```
This is user-visible for anyone matching on error strings.

### Why not slog.Level?

`slog.Level.UnmarshalText` supports arithmetic offset syntax (`DEBUG+1`, `INFO-2`) that produces arbitrary integer values. A map-based `RegisterIntEnum` cannot express this, so `slog.Level` keeps its custom hooks.

### Trade-off: hardcoded level map

The old hook delegated to `zapcore.ParseLevel()`. The new hook uses a hardcoded map of 7 levels. If a future zapcore version adds levels, `enum_builtin.go` must be updated. The level set has been stable since zapcore v1; a comment documents this.

> **Stacked on #116** → #115 → `main`.

## How to test

```sh
go test ./...
cd examples/full && go test ./...
```