### PR TITLE
feat: add flagkit package with `Follow` type for agent-friendly streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,37 @@ limits:
 counts: "ok=10,fail=3"
 ```
 
+### 🧰 Reusable Flag Kits
+
+The `flagkit` package provides pre-built, embeddable flag structs that standardize common CLI flag declarations. Each type encapsulates one flag with an opinionated name, type, and default matching industry conventions. This gives AI agents and scripts a consistent vocabulary across CLIs built with structcli.
+
+```go
+import "github.com/leodido/structcli/flagkit"
+
+type LogsOptions struct {
+    flagkit.Follow                                                    // --follow/-f (default: false)
+    Service string `flag:"service" flagshort:"s" flagdescr:"Service name" flagrequired:"true"`
+}
+
+func (o *LogsOptions) Attach(c *cobra.Command) error {
+    if err := structcli.Define(c, o); err != nil {
+        return err
+    }
+    flagkit.AnnotateCommand(c) // marks flagkit-owned flags for doc generation
+    return nil
+}
+```
+
+Available types:
+
+| Type | Flag | Default | Description |
+|------|------|---------|-------------|
+| `Follow` | `--follow` / `-f` | `false` | Opt-in streaming (agents won't hang) |
+
+When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
+
+See `go doc github.com/leodido/structcli/flagkit` for the full taxonomy and composition examples.
+
 ### 🎨 Beautiful, Organized Help Output
 
 Organize your `--help` output into logical groups for better readability.

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -13,6 +13,7 @@ go install github.com/leodido/structcli/examples/full@latest
 | Command | Description | Required Flags |
 |---------|-------------|---------------|
 | `full` | A demonstration of the structcli library with beautiful CLI features |  |
+| `full logs` | Display logs for a service, optionally streaming with --follow | `--service` |
 | `full preset` | Demonstrate that flagpreset aliases are syntactic sugar and still flow through Transform and Validate |  |
 | `full srv` | Start the server with the specified configuration | `--port` |
 | `full srv version` | Print version information |  |
@@ -28,6 +29,13 @@ go install github.com/leodido/structcli/examples/full@latest
 |------|------|---------|-------------|
 | `--dry` | bool | false | - |
 | `--verbose` | count | 0 | - |
+
+#### `full logs`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--follow` | bool | false | Stream output continuously |
+| `--service` | string | - | Service name to show logs for |
 
 #### `full preset`
 
@@ -109,3 +117,11 @@ Supports YAML/JSON/TOML config files. Use `--config` to specify path.
 
 - JSON Schema: `full --jsonschema`
 - Structured errors: JSON on stderr with semantic exit codes
+
+## Development Notes
+
+This CLI uses [structcli](https://github.com/leodido/structcli) with the `flagkit` package
+for common flag patterns. When extending this CLI, prefer embedding `flagkit` types over
+declaring ad-hoc flags for standard concerns (log level, output format, follow/streaming, etc.).
+
+See `go doc github.com/leodido/structcli/flagkit` for available types.

--- a/examples/full/SKILL.md
+++ b/examples/full/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: full
 description: |
-  A demonstration of the structcli library with beautiful CLI features. Use when you need to: demonstrate that flagpreset aliases are syntactic sugar and still flow through transform and validate, start the server with the specified configuration, print version information, add a new user to the system with the specified details.
+  A demonstration of the structcli library with beautiful CLI features. Use when you need to: display logs for a service, optionally streaming with --follow, demonstrate that flagpreset aliases are syntactic sugar and still flow through transform and validate, start the server with the specified configuration, print version information, add a new user to the system with the specified details.
 metadata:
   author: leodido
   version: 0.15.0
@@ -30,6 +30,25 @@ A demonstration of the structcli library with beautiful CLI features
 |----------|------|-------------|
 | `FULL_DRYRUN` | `--dry` |  |
 | `FULL_DRY` | `--dry` |  |
+
+#### `full logs`
+
+Display logs for a service, optionally streaming with --follow
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--follow` | bool | false | no | Stream output continuously |
+| `--service` | string | - | yes | Service name to show logs for |
+
+**Example:**
+
+```
+full logs --service api
+  full logs -s api --follow
+  full logs -s api -f
+```
 
 #### `full preset`
 
@@ -134,3 +153,13 @@ Add a new user to the system with the specified details
 ### Environment Variable Prefix
 
 All environment variables use the `FULL_` prefix.
+
+### Examples
+
+#### full logs
+
+```
+full logs --service api
+  full logs -s api --follow
+  full logs -s api -f
+```

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
+	"github.com/leodido/structcli/flagkit"
 	"github.com/leodido/structcli/jsonschema"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
@@ -282,6 +283,50 @@ func makePresetC() *cobra.Command {
 	return presetC
 }
 
+// LogsOptions demonstrates flagkit.Follow composition.
+type LogsOptions struct {
+	flagkit.Follow
+	Service string `flag:"service" flagshort:"s" flagdescr:"Service name to show logs for" flagrequired:"true"`
+}
+
+func (o *LogsOptions) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+	flagkit.AnnotateCommand(c)
+
+	return nil
+}
+
+func makeLogsC() *cobra.Command {
+	opts := &LogsOptions{}
+
+	logsC := &cobra.Command{
+		Use:   "logs",
+		Short: "Show service logs",
+		Long:  "Display logs for a service, optionally streaming with --follow",
+		Example: `  full logs --service api
+  full logs -s api --follow
+  full logs -s api -f`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := structcli.Unmarshal(c, opts); err != nil {
+				return err
+			}
+			if opts.Follow.Enabled {
+				fmt.Fprintf(c.OutOrStdout(), "Streaming logs for service %q...\n", opts.Service)
+			} else {
+				fmt.Fprintf(c.OutOrStdout(), "Showing recent logs for service %q\n", opts.Service)
+			}
+			fmt.Fprintln(c.OutOrStdout(), pretty(opts))
+
+			return nil
+		},
+	}
+	opts.Attach(logsC)
+
+	return logsC
+}
+
 var _ structcli.ContextOptions = (*UtilityFlags)(nil)
 
 type UtilityFlags struct {
@@ -362,6 +407,7 @@ func NewRootC(exitOnDebug bool) (*cobra.Command, error) {
 	rootC.AddCommand(makeSrvC())
 	rootC.AddCommand(makeUsrC())
 	rootC.AddCommand(makePresetC())
+	rootC.AddCommand(makeLogsC())
 
 	// This single line enables the debugging global flag
 	if err := structcli.SetupDebug(rootC, debug.Options{Exit: exitOnDebug}); err != nil {

--- a/examples/full/llms.txt
+++ b/examples/full/llms.txt
@@ -7,6 +7,7 @@ https://github.com/leodido/structcli/examples/full
 ## Commands
 
 - [full](#full): A demonstration of the structcli library with beautiful CLI features
+- [full logs](#full-logs): Display logs for a service, optionally streaming with --follow
 - [full preset](#full-preset): Demonstrate that flagpreset aliases are syntactic sugar and still flow through Transform and Validate
 - [full srv](#full-srv): Start the server with the specified configuration
 - [full srv version](#full-srv-version): Print version information
@@ -25,6 +26,15 @@ A demonstration of the structcli library with beautiful CLI features
 
 - `FULL_DRYRUN`: maps to `--dry`
 - `FULL_DRY`: maps to `--dry`
+
+## full logs
+
+Display logs for a service, optionally streaming with --follow
+
+### Flags
+
+- `--follow` (bool, default: false): Stream output continuously
+- `--service` (string, required): Service name to show logs for
 
 ## full preset
 

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -1,0 +1,52 @@
+// Package flagkit provides reusable, embeddable flag structs that standardize
+// common CLI flag declarations for use with structcli.
+//
+// Each type encapsulates a single flag with an opinionated name, type, default,
+// and description matching industry conventions. This gives CLIs a consistent
+// declaration surface — agents and scripts can rely on --follow, --output,
+// --timeout, etc. having predictable names and types across tools.
+//
+// flagkit standardizes flag declarations, not behavioral semantics. How a
+// command interprets --quiet or --dry-run is up to the consumer. The value
+// is in the shared vocabulary: consistent names, types, and defaults that
+// AI agents can recognize across CLIs built with structcli.
+//
+// # Design Principles
+//
+//   - One struct per concern — maximum composability
+//   - Sensible, agent-friendly defaults (e.g., no auto-tailing, finite timeouts)
+//   - Standard flag names matching industry conventions
+//   - Works with all structcli features: env vars, config files, JSON Schema,
+//     shell completion, and doc generation
+//
+// # Taxonomy
+//
+//	Type           Flag          Default  Status
+//	─────────────  ────────────  ───────  ────────
+//	Follow         --follow/-f   false    available
+//	LogLevel       --log-level   info     planned (PR 2)
+//	ZapLogLevel    --log-level   info     planned (PR 2)
+//	SlogLogLevel   --log-level   info     planned (PR 2)
+//	OutputFmt      --output/-o   text     planned (PR 3)
+//	Verbose        --verbose/-v  0        planned (PR 4)
+//	DryRun         --dry-run     false    planned (PR 4)
+//	TimeoutOpt     --timeout     30s      planned (PR 5)
+//	Quiet          --quiet/-q    false    planned (PR 5)
+//
+// # Composition
+//
+// Embed one or more flagkit types in your options struct:
+//
+//	type LogOptions struct {
+//	    flagkit.Follow
+//	    Service string `flag:"service" flagdescr:"Service name"`
+//	}
+//
+//	func (o *LogOptions) Attach(c *cobra.Command) error {
+//	    if err := structcli.Define(c, o); err != nil {
+//	        return err
+//	    }
+//	    flagkit.AnnotateCommand(c)
+//	    return nil
+//	}
+package flagkit

--- a/flagkit/follow.go
+++ b/flagkit/follow.go
@@ -1,0 +1,86 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+// FlagKitAnnotation is the pflag annotation key set on flags defined by
+// flagkit types. The generate package uses this to detect flagkit usage
+// and emit development guidance in generated docs.
+const FlagKitAnnotation = "___leodido_structcli_flagkit"
+
+// flagKitFlags is the registry of flag names owned by flagkit types.
+// Each type registers its flag name via registerFlag in its own file's init().
+var flagKitFlags []string
+
+// registerFlag adds a flag name to the flagkit registry.
+// Called by each type's init() function.
+func registerFlag(name string) {
+	flagKitFlags = append(flagKitFlags, name)
+}
+
+// AnnotateCommand marks all flagkit-owned flags on the command with the
+// [FlagKitAnnotation]. Call this after [structcli.Define] when embedding
+// flagkit types in a parent struct.
+//
+// When using a flagkit type standalone via its Attach method, the
+// annotation is set automatically and this call is not needed.
+// For embedded usage, [structcli.Define] traverses into the embedded
+// struct but does not call its Attach method, so AnnotateCommand
+// must be called explicitly to set the annotation.
+func AnnotateCommand(c *cobra.Command) {
+	for _, name := range flagKitFlags {
+		if f := c.Flags().Lookup(name); f != nil {
+			_ = c.Flags().SetAnnotation(name, FlagKitAnnotation, []string{"true"})
+		}
+	}
+}
+
+func init() {
+	registerFlag("follow")
+}
+
+// Follow provides a --follow/-f boolean flag for opt-in streaming.
+//
+// When false (the default), commands should print current output and exit.
+// When true, commands should stream output continuously. This default is
+// agent-friendly — AI agents and scripts won't hang on indefinite tailing.
+//
+// Usage:
+//
+//	type LogOptions struct {
+//	    flagkit.Follow
+//	    Service string `flag:"service" flagdescr:"Service name"`
+//	}
+//
+//	func (o *LogOptions) Attach(c *cobra.Command) error {
+//	    if err := structcli.Define(c, o); err != nil {
+//	        return err
+//	    }
+//	    flagkit.AnnotateCommand(c)
+//	    return nil
+//	}
+//
+//	// In RunE:
+//	if opts.Follow.Enabled {
+//	    streamLogs(ctx)
+//	} else {
+//	    printCurrentLogs()
+//	}
+type Follow struct {
+	Enabled bool `flag:"follow" flagshort:"f" flagdescr:"Stream output continuously" default:"false"`
+}
+
+// Attach implements [structcli.Options].
+func (o *Follow) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("follow"); f != nil {
+		_ = c.Flags().SetAnnotation("follow", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/follow_test.go
+++ b/flagkit/follow_test.go
@@ -1,0 +1,179 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Standalone tests (Follow used directly via Attach) ---
+
+func TestFollow_DefaultFalse(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestFollow_ExplicitTrue(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--follow"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestFollow_ShortFlag(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-f"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestFollow_ExplicitFalse(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--follow=false"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestFollow_Standalone(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("follow")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "f", f.Shorthand)
+	assert.Equal(t, "false", f.DefValue)
+	assert.Equal(t, "Stream output continuously", f.Usage)
+}
+
+func TestFollow_Standalone_Annotation(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("follow")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+// --- Embedded tests (Follow embedded in a parent struct) ---
+
+type logOptions struct {
+	flagkit.Follow
+	Service string `flag:"service" flagdescr:"Service name"`
+}
+
+func (o *logOptions) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+	flagkit.AnnotateCommand(c)
+
+	return nil
+}
+
+func TestFollow_Embedded(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--follow", "--service", "api"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Follow.Enabled)
+	assert.Equal(t, "api", opts.Service)
+}
+
+func TestFollow_Embedded_DefaultFalse(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--service", "api"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Follow.Enabled)
+	assert.Equal(t, "api", opts.Service)
+}
+
+func TestFollow_Embedded_Annotation(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("follow")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set on embedded usage")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestFollow_Embedded_BothFlagsExist(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+
+	assert.NotNil(t, cmd.Flags().Lookup("follow"), "--follow should exist")
+	assert.NotNil(t, cmd.Flags().Lookup("service"), "--service should exist")
+}
+
+// --- JSON Schema test ---
+
+func TestFollow_JSONSchema(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["follow"]
+	assert.True(t, ok, "JSON schema should include the follow flag")
+}
+
+// --- Error path ---
+
+func TestFollow_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	// Second Attach on the same command triggers a Define validation error
+	// because the "follow" flag is already registered.
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+// --- AnnotateCommand on command without flagkit flags ---
+
+func TestAnnotateCommand_NoFlagKitFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().Bool("other", false, "some other flag")
+
+	// Should not panic when no flagkit flags exist
+	flagkit.AnnotateCommand(cmd)
+
+	f := cmd.Flags().Lookup("other")
+	require.NotNil(t, f)
+	_, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.False(t, ok, "non-flagkit flag should not be annotated")
+}

--- a/generate/agents.go
+++ b/generate/agents.go
@@ -9,7 +9,12 @@ import (
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/jsonschema"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// flagKitAnnotation mirrors [flagkit.FlagKitAnnotation] to avoid a dependency
+// from the generate package on the flagkit package.
+const flagKitAnnotation = "___leodido_structcli_flagkit"
 
 // AgentsOptions configures the AGENTS.md generator.
 type AgentsOptions struct {
@@ -129,6 +134,16 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 	if opts.IncludeMCP {
 		fmt.Fprintf(&buf, "- MCP server: `%s --mcp`\n", cliName)
 	}
+	buf.WriteString("\n")
+
+	// Development Notes — emitted when flagkit types are detected
+	if hasFlagKitFlags(rootCmd) {
+		buf.WriteString("## Development Notes\n\n")
+		buf.WriteString("This CLI uses [structcli](https://github.com/leodido/structcli) with the `flagkit` package\n")
+		buf.WriteString("for common flag patterns. When extending this CLI, prefer embedding `flagkit` types over\n")
+		buf.WriteString("declaring ad-hoc flags for standard concerns (log level, output format, follow/streaming, etc.).\n\n")
+		buf.WriteString("See `go doc github.com/leodido/structcli/flagkit` for available types.\n")
+	}
 
 	return buf.Bytes(), nil
 }
@@ -169,6 +184,30 @@ func requiredFlags(s *structcli.CommandSchema) string {
 		return ""
 	}
 	return strings.Join(req, ", ")
+}
+
+// hasFlagKitFlags walks the command tree and returns true if any flag carries
+// the flagkit annotation, indicating the CLI uses flagkit types.
+func hasFlagKitFlags(root *cobra.Command) bool {
+	found := false
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if found {
+			return
+		}
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			if f.Annotations != nil {
+				if _, ok := f.Annotations[flagKitAnnotation]; ok {
+					found = true
+				}
+			}
+		})
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(root)
+	return found
 }
 
 // findConfigFlagName checks if the root command has a config flag registered

--- a/generate/agents_test.go
+++ b/generate/agents_test.go
@@ -210,6 +210,44 @@ func TestAgents_ZeroFlagCommand(t *testing.T) {
 	assert.NotContains(t, content, "#### `app ping`")
 }
 
+func TestAgents_FlagKitDevNotes(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}
+	root.Flags().Bool("follow", false, "Stream output continuously")
+	// Simulate flagkit annotation
+	require.NoError(t, root.Flags().SetAnnotation("follow", "___leodido_structcli_flagkit", []string{"true"}))
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+	assert.Contains(t, content, "## Development Notes")
+	assert.Contains(t, content, "flagkit")
+	assert.Contains(t, content, "go doc github.com/leodido/structcli/flagkit")
+}
+
+func TestAgents_NoFlagKitDevNotes(t *testing.T) {
+	root := buildTestTree()
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "## Development Notes")
+}
+
+func TestAgents_FlagKitDevNotesOnSubcommand(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{Use: "app", Short: "A CLI"}
+	sub := &cobra.Command{Use: "logs", Short: "Show logs", RunE: noop}
+	sub.Flags().Bool("follow", false, "Stream output continuously")
+	require.NoError(t, sub.Flags().SetAnnotation("follow", "___leodido_structcli_flagkit", []string{"true"}))
+	root.AddCommand(sub)
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "## Development Notes")
+}
+
 // --- helpers ---
 
 func extractSection(content, heading string) string {


### PR DESCRIPTION
## Description

Introduce the `flagkit/` sub-package providing reusable, embeddable flag structs that standardize common CLI flag declarations for agent-friendly CLIs.

The first type is `Follow` (`--follow`/`-f`, default `false`) so AI agents and scripts don't hang on indefinite tailing.

### What's included

- **`flagkit/doc.go`** — Package doc with design philosophy, taxonomy table, and composition example
- **`flagkit/follow.go`** — `Follow` struct (`Enabled` field), `Attach`, `AnnotateCommand`, `FlagKitAnnotation`, `registerFlag` registry
- **`flagkit/follow_test.go`** — 13 tests, 100% statement coverage
- **`generate/agents.go`** — Detect flagkit annotation in the command tree; emit "Development Notes" section in AGENTS.md (uses local constant, no flagkit import)
- **`examples/full`** — New `logs` subcommand demonstrating `Follow` composition
- **README.md** — New "Reusable Flag Kits" section

### Design decisions

- **Narrowed positioning**: flagkit standardizes flag *declarations* (names, types, defaults), not behavioral semantics. Docs are explicit about this.
- **Self-registering types**: Each type calls `registerFlag()` in its own `init()` — no central list to maintain when adding types.
- **`generate` decoupled from `flagkit`**: Uses a local string constant mirroring `FlagKitAnnotation` to avoid import dependency.
- **Field naming**: `Follow.Enabled` (not `Follow.Follow`) for clean embedded access.

## How to test

```bash
go test -v -cover ./flagkit/...
go test -v ./generate/...
go test ./...
cd examples/full && go run main.go logs -s api --follow
```