### PR TITLE
feat: add `flagkit.LogLevel` types (`ZapLogLevel`, `SlogLogLevel`, `LogLevel` alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,9 @@ Available types:
 | Type | Flag | Default | Description |
 |------|------|---------|-------------|
 | `Follow` | `--follow` / `-f` | `false` | Opt-in streaming (agents won't hang) |
+| `LogLevel` | `--log-level` | `info` | Log level via zapcore (alias for `ZapLogLevel`) |
+| `ZapLogLevel` | `--log-level` | `info` | Log level backed by `zapcore.Level` |
+| `SlogLogLevel` | `--log-level` | `info` | Log level backed by `slog.Level` (stdlib) |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -24,9 +24,9 @@
 //	Type           Flag          Default  Status
 //	─────────────  ────────────  ───────  ────────
 //	Follow         --follow/-f   false    available
-//	LogLevel       --log-level   info     planned (PR 2)
-//	ZapLogLevel    --log-level   info     planned (PR 2)
-//	SlogLogLevel   --log-level   info     planned (PR 2)
+//	LogLevel       --log-level   info     available
+//	ZapLogLevel    --log-level   info     available
+//	SlogLogLevel   --log-level   info     available
 //	OutputFmt      --output/-o   text     planned (PR 3)
 //	Verbose        --verbose/-v  0        planned (PR 4)
 //	DryRun         --dry-run     false    planned (PR 4)

--- a/flagkit/loglevel.go
+++ b/flagkit/loglevel.go
@@ -1,0 +1,74 @@
+package flagkit
+
+import (
+	"log/slog"
+
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+)
+
+func init() {
+	registerFlag("log-level")
+}
+
+// ZapLogLevel provides a --log-level flag backed by [zapcore.Level].
+//
+// The default is info. zapcore.Level is registered as an integer enum
+// by structcli's built-in init(), so no additional registration is needed.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.ZapLogLevel
+//	    Host string `flag:"host" flagdescr:"Server host"`
+//	}
+type ZapLogLevel struct {
+	LogLevel zapcore.Level `flag:"log-level" flagdescr:"Set log level" default:"info" flagenv:"true" flaggroup:"Logging"`
+}
+
+// Attach implements [structcli.Options].
+func (o *ZapLogLevel) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("log-level"); f != nil {
+		_ = c.Flags().SetAnnotation("log-level", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}
+
+// LogLevel is the recommended log level type. It is an alias for [ZapLogLevel].
+//
+// Embed this in your options struct for the standard --log-level flag backed
+// by zapcore.Level. Use [SlogLogLevel] if you prefer the stdlib slog package.
+type LogLevel = ZapLogLevel
+
+// SlogLogLevel provides a --log-level flag backed by [slog.Level] (stdlib).
+//
+// The default is info. slog.Level is handled by structcli's built-in hooks,
+// so no additional registration is needed.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.SlogLogLevel
+//	}
+type SlogLogLevel struct {
+	LogLevel slog.Level `flag:"log-level" flagdescr:"Set log level" default:"info" flagenv:"true" flaggroup:"Logging"`
+}
+
+// Attach implements [structcli.Options].
+func (o *SlogLogLevel) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("log-level"); f != nil {
+		_ = c.Flags().SetAnnotation("log-level", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/loglevel_test.go
+++ b/flagkit/loglevel_test.go
@@ -1,0 +1,185 @@
+package flagkit_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+// --- ZapLogLevel tests ---
+
+func TestZapLogLevel_DefaultInfo(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.InfoLevel, opts.LogLevel)
+}
+
+func TestZapLogLevel_SetDebug(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "debug"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.DebugLevel, opts.LogLevel)
+}
+
+func TestZapLogLevel_SetError(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "error"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.ErrorLevel, opts.LogLevel)
+}
+
+func TestZapLogLevel_Standalone(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "info", f.DefValue)
+	assert.Contains(t, f.Usage, "Set log level")
+}
+
+func TestZapLogLevel_Annotation(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestZapLogLevel_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestZapLogLevel_Embedded(t *testing.T) {
+	type serverOpts struct {
+		flagkit.ZapLogLevel
+		Host string `flag:"host" flagdescr:"Server host" default:"localhost"`
+	}
+	opts := &serverOpts{}
+	cmd := &cobra.Command{Use: "srv"}
+	require.NoError(t, structcli.Define(cmd, opts))
+	flagkit.AnnotateCommand(cmd)
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "warn", "--host", "0.0.0.0"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.WarnLevel, opts.LogLevel)
+	assert.Equal(t, "0.0.0.0", opts.Host)
+}
+
+func TestZapLogLevel_JSONSchema(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["log-level"]
+	assert.True(t, ok, "JSON schema should include the log-level flag")
+}
+
+// --- SlogLogLevel tests ---
+
+func TestSlogLogLevel_DefaultInfo(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, slog.LevelInfo, opts.LogLevel)
+}
+
+func TestSlogLogLevel_SetDebug(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "debug"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, slog.LevelDebug, opts.LogLevel)
+}
+
+func TestSlogLogLevel_SetWarn(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "warn"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, slog.LevelWarn, opts.LogLevel)
+}
+
+func TestSlogLogLevel_Standalone(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "info", f.DefValue)
+	assert.Contains(t, f.Usage, "Set log level")
+}
+
+func TestSlogLogLevel_Annotation(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestSlogLogLevel_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+// --- LogLevel alias test ---
+
+func TestLogLevel_IsZapLogLevel(t *testing.T) {
+	var ll flagkit.LogLevel
+	var zll flagkit.ZapLogLevel
+
+	// LogLevel is a type alias for ZapLogLevel — assignment must compile.
+	ll = zll
+	zll = ll
+	_ = zll
+}


### PR DESCRIPTION
## Description

Add three log level types to the `flagkit` package:

- **`ZapLogLevel`** — `--log-level` backed by `zapcore.Level` (registered by structcli's built-in init)
- **`SlogLogLevel`** — `--log-level` backed by `slog.Level` (handled by structcli's built-in hooks)
- **`LogLevel`** — type alias for `ZapLogLevel` (the recommended default)

Both variants share the same tag defaults: `flag:"log-level" flagdescr:"Set log level" default:"info" flagenv:"true" flaggroup:"Logging"`.

Each `Attach` method sets the `FlagKitAnnotation` directly on the `log-level` flag (since the annotation list in `follow.go` is updated incrementally per PR).

### Stacked on

- #119 (`ld/flagkit-follow`)

## How to test

```bash
go test -v -run 'TestZapLogLevel|TestSlogLogLevel|TestLogLevel' ./flagkit/...
go test -cover ./flagkit/...
```