### PR TITLE
feat: add `flagkit.Output` type with `OutputFormat` enum and `RegisterOutputFormats`

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ Available types:
 | `LogLevel` | `--log-level` | `info` | Log level via zapcore (alias for `ZapLogLevel`) |
 | `ZapLogLevel` | `--log-level` | `info` | Log level backed by `zapcore.Level` |
 | `SlogLogLevel` | `--log-level` | `info` | Log level backed by `slog.Level` (stdlib) |
+| `OutputFmt` | `--output` / `-o` | `text` | Output format (string enum, user-registered) |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -27,7 +27,7 @@
 //	LogLevel       --log-level   info     available
 //	ZapLogLevel    --log-level   info     available
 //	SlogLogLevel   --log-level   info     available
-//	OutputFmt      --output/-o   text     planned (PR 3)
+//	OutputFmt      --output/-o   text     available
 //	Verbose        --verbose/-v  0        planned (PR 4)
 //	DryRun         --dry-run     false    planned (PR 4)
 //	TimeoutOpt     --timeout     30s      planned (PR 5)

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -1,0 +1,105 @@
+package flagkit
+
+import (
+	"fmt"
+
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("output")
+}
+
+// OutputFormat is a string enum for output format selection.
+//
+// flagkit provides common constants but does NOT auto-register them.
+// Call [RegisterOutputFormats] or [structcli.RegisterEnum] in your init()
+// to declare the CLI-wide format vocabulary.
+type OutputFormat string
+
+const (
+	OutputJSON  OutputFormat = "json"
+	OutputJSONL OutputFormat = "jsonl"
+	OutputText  OutputFormat = "text"
+	OutputYAML  OutputFormat = "yaml"
+)
+
+// RegisterOutputFormats registers the given output formats for use with
+// structcli's enum flag handling. Each format's string value is used as
+// both the canonical name and the only accepted alias.
+//
+// This is a process-global, one-time registration (like [database/sql.Register]).
+// Register the superset of all formats your CLI supports. For per-command
+// format subsets, use [Output.ValidFormat] in your command's RunE.
+//
+// Call this in init() before any [structcli.Define] calls:
+//
+//	func init() {
+//	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
+//	}
+//
+// For custom aliases, use [structcli.RegisterEnum] directly instead.
+func RegisterOutputFormats(formats ...OutputFormat) {
+	m := make(map[OutputFormat][]string, len(formats))
+	for _, f := range formats {
+		m[f] = []string{string(f)}
+	}
+
+	structcli.RegisterEnum[OutputFormat](m)
+}
+
+// Output provides a --output/-o flag for selecting output format.
+//
+// The default is text. You must register the supported formats before use
+// via [RegisterOutputFormats] or [structcli.RegisterEnum].
+//
+// For CLIs where different commands support different format subsets,
+// register the superset globally and use [OutputFmt.ValidFormat] per command:
+//
+//	func init() {
+//	    // Global: register all formats the CLI knows about
+//	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
+//	}
+//
+//	// Per-command: validate the subset this command supports
+//	func (o *ExportOptions) RunE(cmd *cobra.Command, args []string) error {
+//	    if err := o.ValidFormat(flagkit.OutputJSON, flagkit.OutputYAML); err != nil {
+//	        return err
+//	    }
+//	    // ...
+//	}
+type OutputFmt struct {
+	Format OutputFormat `flag:"output" flagshort:"o" flagdescr:"Output format" default:"text"`
+}
+
+// ValidFormat returns nil if the current output format is one of the allowed
+// formats, or an error describing the mismatch. Use this for per-command
+// format validation when different commands support different subsets.
+func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
+	for _, a := range allowed {
+		if o.Format == a {
+			return nil
+		}
+	}
+
+	names := make([]string, len(allowed))
+	for i, a := range allowed {
+		names[i] = string(a)
+	}
+
+	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
+}
+
+// Attach implements [structcli.Options].
+func (o *OutputFmt) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("output"); f != nil {
+		_ = c.Flags().SetAnnotation("output", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -1,0 +1,166 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	flagkit.RegisterOutputFormats(
+		flagkit.OutputJSON,
+		flagkit.OutputJSONL,
+		flagkit.OutputText,
+		flagkit.OutputYAML,
+	)
+}
+
+// --- Output tests ---
+
+func TestOutput_DefaultText(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputText, opts.Format)
+}
+
+func TestOutput_SetJSON(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--output", "json"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputJSON, opts.Format)
+}
+
+func TestOutput_SetYAML(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--output", "yaml"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputYAML, opts.Format)
+}
+
+func TestOutput_SetJSONL(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-o", "jsonl"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputJSONL, opts.Format)
+}
+
+func TestOutput_ShortFlag(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-o", "json"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputJSON, opts.Format)
+}
+
+func TestOutput_Standalone(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "o", f.Shorthand)
+	assert.Equal(t, "text", f.DefValue)
+	assert.Contains(t, f.Usage, "Output format")
+}
+
+func TestOutput_Annotation(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestOutput_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestOutput_Embedded(t *testing.T) {
+	type listOpts struct {
+		flagkit.OutputFmt
+		Limit int `flag:"limit" flagdescr:"Max results" default:"10"`
+	}
+	opts := &listOpts{}
+	cmd := &cobra.Command{Use: "list"}
+	require.NoError(t, structcli.Define(cmd, opts))
+	flagkit.AnnotateCommand(cmd)
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--output", "yaml", "--limit", "50"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputYAML, opts.OutputFmt.Format)
+	assert.Equal(t, 50, opts.Limit)
+}
+
+func TestOutput_JSONSchema(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["output"]
+	assert.True(t, ok, "JSON schema should include the output flag")
+}
+
+// --- ValidFormat tests ---
+
+func TestOutput_ValidFormat_Allowed(t *testing.T) {
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputJSON}
+	err := opts.ValidFormat(flagkit.OutputJSON, flagkit.OutputText)
+	assert.NoError(t, err)
+}
+
+func TestOutput_ValidFormat_NotAllowed(t *testing.T) {
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputYAML}
+	err := opts.ValidFormat(flagkit.OutputJSON, flagkit.OutputText)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "yaml")
+	assert.Contains(t, err.Error(), "allowed")
+}
+
+func TestOutput_ValidFormat_SingleAllowed(t *testing.T) {
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputText}
+	assert.NoError(t, opts.ValidFormat(flagkit.OutputText))
+}
+
+// --- RegisterOutputFormats tests ---
+
+func TestRegisterOutputFormats_PanicsOnDuplicate(t *testing.T) {
+	// OutputFormat is already registered in init() above.
+	// A second call should panic.
+	assert.Panics(t, func() {
+		flagkit.RegisterOutputFormats(flagkit.OutputJSON)
+	})
+}


### PR DESCRIPTION
## Description

Add output format selection to `flagkit`:

- **`OutputFormat`** — string enum type with `OutputJSON`, `OutputJSONL`, `OutputText`, `OutputYAML` constants
- **`RegisterOutputFormats`** — process-global registration (like `database/sql.Register`); register the superset, validate per-command
- **`OutputFmt`** — struct providing `--output`/`-o` (default `text`, `Format` field)
- **`ValidFormat`** — per-command format subset validation method

The struct is named `OutputFmt` (not `Output`) to avoid a mapstructure collision when embedded — the flag name `output` would match the struct name and break viper Unmarshal.

### Stacked on

- #120 (`ld/flagkit-loglevel`)
- #119 (`ld/flagkit-follow`)

## How to test

```bash
go test -v -run 'TestOutput|TestRegisterOutput' ./flagkit/...
go test -cover ./flagkit/...
```