### PR TITLE
feat: add `flagkit.Verbose` and `flagkit.DryRun` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,8 @@ Available types:
 | `ZapLogLevel` | `--log-level` | `info` | Log level backed by `zapcore.Level` |
 | `SlogLogLevel` | `--log-level` | `info` | Log level backed by `slog.Level` (stdlib) |
 | `OutputFmt` | `--output` / `-o` | `text` | Output format (string enum, user-registered) |
+| `Verbose` | `--verbose` / `-v` | `0` | Verbosity count (`-v`, `-vv`, `-vvv`) |
+| `DryRun` | `--dry-run` | `false` | Preview without making changes |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -28,8 +28,8 @@
 //	ZapLogLevel    --log-level   info     available
 //	SlogLogLevel   --log-level   info     available
 //	OutputFmt      --output/-o   text     available
-//	Verbose        --verbose/-v  0        planned (PR 4)
-//	DryRun         --dry-run     false    planned (PR 4)
+//	Verbose        --verbose/-v  0        available
+//	DryRun         --dry-run     false    available
 //	TimeoutOpt     --timeout     30s      planned (PR 5)
 //	Quiet          --quiet/-q    false    planned (PR 5)
 //

--- a/flagkit/dryrun.go
+++ b/flagkit/dryrun.go
@@ -1,0 +1,44 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("dry-run")
+}
+
+// DryRun provides a --dry-run flag for safe previewing of operations.
+//
+// The default is false. When true, commands should describe what they
+// would do without making changes. This is agent-friendly — AI agents
+// can preview destructive operations before committing.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.DryRun
+//	}
+//
+//	// In RunE:
+//	if opts.DryRun.Enabled {
+//	    fmt.Println("would delete", target)
+//	    return nil
+//	}
+type DryRun struct {
+	Enabled bool `flag:"dry-run" flagdescr:"Preview without making changes" default:"false" flagenv:"true"`
+}
+
+// Attach implements [structcli.Options].
+func (o *DryRun) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("dry-run"); f != nil {
+		_ = c.Flags().SetAnnotation("dry-run", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/dryrun_test.go
+++ b/flagkit/dryrun_test.go
@@ -1,0 +1,105 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- DryRun tests ---
+
+func TestDryRun_DefaultFalse(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestDryRun_ExplicitTrue(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--dry-run"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestDryRun_ExplicitFalse(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--dry-run=false"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestDryRun_Standalone(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "false", f.DefValue)
+	assert.Equal(t, "Preview without making changes", f.Usage)
+}
+
+func TestDryRun_Annotation(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestDryRun_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestDryRun_Embedded(t *testing.T) {
+	type deployOpts struct {
+		flagkit.DryRun
+		Target string `flag:"target" flagdescr:"Deploy target" default:"staging"`
+	}
+	opts := &deployOpts{}
+	cmd := &cobra.Command{Use: "deploy"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--dry-run", "--target", "prod"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.DryRun.Enabled)
+	assert.Equal(t, "prod", opts.Target)
+}
+
+func TestDryRun_JSONSchema(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["dry-run"]
+	assert.True(t, ok, "JSON schema should include the dry-run flag")
+}

--- a/flagkit/verbose.go
+++ b/flagkit/verbose.go
@@ -1,0 +1,42 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("verbose")
+}
+
+// Verbose provides a --verbose/-v count flag for verbosity levels.
+//
+// The default is 0 (quiet). Each -v increments the count: -v is 1, -vv is 2,
+// -vvv is 3. This is the standard Unix convention for verbosity.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.Verbose
+//	}
+//
+//	// In RunE:
+//	if opts.Verbose.Level > 1 {
+//	    // extra debug output
+//	}
+type Verbose struct {
+	Level int `flag:"verbose" flagshort:"v" flagtype:"count" flagdescr:"Increase verbosity (-v, -vv, -vvv)" default:"0"`
+}
+
+// Attach implements [structcli.Options].
+func (o *Verbose) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("verbose"); f != nil {
+		_ = c.Flags().SetAnnotation("verbose", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/verbose_test.go
+++ b/flagkit/verbose_test.go
@@ -1,0 +1,101 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Verbose tests ---
+
+func TestVerbose_DefaultZero(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 0, opts.Level)
+}
+
+func TestVerbose_SingleV(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-v"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 1, opts.Level)
+}
+
+func TestVerbose_DoubleV(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-v", "-v"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 2, opts.Level)
+}
+
+func TestVerbose_LongFlag(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--verbose", "--verbose", "--verbose"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 3, opts.Level)
+}
+
+func TestVerbose_Standalone(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("verbose")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "v", f.Shorthand)
+	assert.Contains(t, f.Usage, "Increase verbosity")
+}
+
+func TestVerbose_Annotation(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("verbose")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestVerbose_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestVerbose_Embedded(t *testing.T) {
+	type deployOpts struct {
+		flagkit.Verbose
+		Target string `flag:"target" flagdescr:"Deploy target" default:"staging"`
+	}
+	opts := &deployOpts{}
+	cmd := &cobra.Command{Use: "deploy"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"-v", "-v", "--target", "prod"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 2, opts.Verbose.Level)
+	assert.Equal(t, "prod", opts.Target)
+}


### PR DESCRIPTION
## Description

Add two utility flag types to `flagkit`:

- **`Verbose`** — `--verbose`/`-v` count flag (`Level` field, default 0). Each `-v` increments: `-v` is 1, `-vv` is 2, `-vvv` is 3.
- **`DryRun`** — `--dry-run` bool flag (`Enabled` field, default false, env-bindable). Commands should preview without making changes.

Field names avoid struct-name collision for clean embedded access: `opts.Verbose.Level`, `opts.DryRun.Enabled`.

### Stacked on

- #121 (`ld/flagkit-output`)
- #120 (`ld/flagkit-loglevel`)
- #119 (`ld/flagkit-follow`)

## How to test

```bash
go test -v -run 'TestVerbose|TestDryRun' ./flagkit/...
go test -cover ./flagkit/...
```