### PR TITLE
feat: add `flagkit.Timeout` and `flagkit.Quiet` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,8 @@ Available types:
 | `ZapLogLevel` | `--log-level` | `info` | Log level backed by `zapcore.Level` |
 | `SlogLogLevel` | `--log-level` | `info` | Log level backed by `slog.Level` (stdlib) |
 | `OutputFmt` | `--output` / `-o` | `text` | Output format (string enum, user-registered) |
+| `Verbose` | `--verbose` / `-v` | `0` | Verbosity count (`-v`, `-vv`, `-vvv`) |
+| `DryRun` | `--dry-run` | `false` | Preview without making changes |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/README.md
+++ b/README.md
@@ -633,6 +633,9 @@ Available types:
 | Type | Flag | Default | Description |
 |------|------|---------|-------------|
 | `Follow` | `--follow` / `-f` | `false` | Opt-in streaming (agents won't hang) |
+| `LogLevel` | `--log-level` | `info` | Log level via zapcore (alias for `ZapLogLevel`) |
+| `ZapLogLevel` | `--log-level` | `info` | Log level backed by `zapcore.Level` |
+| `SlogLogLevel` | `--log-level` | `info` | Log level backed by `slog.Level` (stdlib) |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ Available types:
 | `LogLevel` | `--log-level` | `info` | Log level via zapcore (alias for `ZapLogLevel`) |
 | `ZapLogLevel` | `--log-level` | `info` | Log level backed by `zapcore.Level` |
 | `SlogLogLevel` | `--log-level` | `info` | Log level backed by `slog.Level` (stdlib) |
+| `OutputFmt` | `--output` / `-o` | `text` | Output format (string enum, user-registered) |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/README.md
+++ b/README.md
@@ -639,6 +639,8 @@ Available types:
 | `OutputFmt` | `--output` / `-o` | `text` | Output format (string enum, user-registered) |
 | `Verbose` | `--verbose` / `-v` | `0` | Verbosity count (`-v`, `-vv`, `-vvv`) |
 | `DryRun` | `--dry-run` | `false` | Preview without making changes |
+| `TimeoutOpt` | `--timeout` | `30s` | Operation timeout (`time.Duration`) |
+| `Quiet` | `--quiet` / `-q` | `false` | Suppress non-essential output |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/README.md
+++ b/README.md
@@ -607,6 +607,37 @@ limits:
 counts: "ok=10,fail=3"
 ```
 
+### 🧰 Reusable Flag Kits
+
+The `flagkit` package provides pre-built, embeddable flag structs that standardize common CLI flag declarations. Each type encapsulates one flag with an opinionated name, type, and default matching industry conventions. This gives AI agents and scripts a consistent vocabulary across CLIs built with structcli.
+
+```go
+import "github.com/leodido/structcli/flagkit"
+
+type LogsOptions struct {
+    flagkit.Follow                                                    // --follow/-f (default: false)
+    Service string `flag:"service" flagshort:"s" flagdescr:"Service name" flagrequired:"true"`
+}
+
+func (o *LogsOptions) Attach(c *cobra.Command) error {
+    if err := structcli.Define(c, o); err != nil {
+        return err
+    }
+    flagkit.AnnotateCommand(c) // marks flagkit-owned flags for doc generation
+    return nil
+}
+```
+
+Available types:
+
+| Type | Flag | Default | Description |
+|------|------|---------|-------------|
+| `Follow` | `--follow` / `-f` | `false` | Opt-in streaming (agents won't hang) |
+
+When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
+
+See `go doc github.com/leodido/structcli/flagkit` for the full taxonomy and composition examples.
+
 ### 🎨 Beautiful, Organized Help Output
 
 Organize your `--help` output into logical groups for better readability.

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -35,7 +35,7 @@ go install github.com/leodido/structcli/examples/full@latest
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--follow` | bool | false | Stream output continuously |
-| `--output` | string | text | Output format |
+| `--output` | string | text | Output format (text, json) |
 | `--quiet` | bool | false | Suppress non-essential output |
 | `--service` | string | - | Service name to show logs for |
 | `--timeout` | duration | 30s | Operation timeout |
@@ -62,9 +62,9 @@ go install github.com/leodido/structcli/examples/full@latest
 | `--deeper-setting` | string | default-deeper-setting | - |
 | `--host` | string | localhost | Server host |
 | `--log-file` | string | - | Log file path |
-| `--log-level` | zapcore.Level | info | Set log level |
+| `--log-level` | zapcore.Level | info | Set log level (debug, info, warn, error, dpanic, panic, fatal) |
 | `--port` | int | 0 | Server port |
-| `--target-env` | string | dev | Set the target environment |
+| `--target-env` | string | dev | Set the target environment (dev, prod, staging) |
 | `--token-base64` | bytesBase64 | aGVsbG8= | Token bytes encoded as base64 |
 | `--token-hex` | bytesHex | 68656c6c6f | Token bytes encoded as hex |
 | `--trusted-peers` | ipSlice | 127.0.0.2,127.0.0.3 | Trusted peer IPs (comma separated) |

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -13,6 +13,7 @@ go install github.com/leodido/structcli/examples/full@latest
 | Command | Description | Required Flags |
 |---------|-------------|---------------|
 | `full` | A demonstration of the structcli library with beautiful CLI features |  |
+| `full logs` | Display logs for a service, optionally streaming with --follow | `--service` |
 | `full preset` | Demonstrate that flagpreset aliases are syntactic sugar and still flow through Transform and Validate |  |
 | `full srv` | Start the server with the specified configuration | `--port` |
 | `full srv version` | Print version information |  |
@@ -28,6 +29,13 @@ go install github.com/leodido/structcli/examples/full@latest
 |------|------|---------|-------------|
 | `--dry` | bool | false | - |
 | `--verbose` | count | 0 | - |
+
+#### `full logs`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--follow` | bool | false | Stream output continuously |
+| `--service` | string | - | Service name to show logs for |
 
 #### `full preset`
 
@@ -109,3 +117,11 @@ Supports YAML/JSON/TOML config files. Use `--config` to specify path.
 
 - JSON Schema: `full --jsonschema`
 - Structured errors: JSON on stderr with semantic exit codes
+
+## Development Notes
+
+This CLI uses [structcli](https://github.com/leodido/structcli) with the `flagkit` package
+for common flag patterns. When extending this CLI, prefer embedding `flagkit` types over
+declaring ad-hoc flags for standard concerns (log level, output format, follow/streaming, etc.).
+
+See `go doc github.com/leodido/structcli/flagkit` for available types.

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -35,7 +35,10 @@ go install github.com/leodido/structcli/examples/full@latest
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--follow` | bool | false | Stream output continuously |
+| `--output` | string | text | Output format |
+| `--quiet` | bool | false | Suppress non-essential output |
 | `--service` | string | - | Service name to show logs for |
+| `--timeout` | duration | 30s | Operation timeout |
 
 #### `full preset`
 
@@ -89,6 +92,8 @@ go install github.com/leodido/structcli/examples/full@latest
 |----------|------|---------|
 | `FULL_DRY` | `--dry` | false |
 | `FULL_DRYRUN` | `--dry` | false |
+| `FULL_LOGS_TIMEOUT` | `--timeout` | 30s |
+| `FULL_LOGS_TIMEOUTOPT_DURATION` | `--timeout` | 30s |
 | `FULL_SRV_ADVERTISECIDR` | `--advertise-cidr` | 127.0.0.0/24 |
 | `FULL_SRV_ADVERTISE_CIDR` | `--advertise-cidr` | 127.0.0.0/24 |
 | `FULL_SRV_APIKEY` | `--apikey` | - |

--- a/examples/full/SKILL.md
+++ b/examples/full/SKILL.md
@@ -40,14 +40,25 @@ Display logs for a service, optionally streaming with --follow
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
 | `--follow` | bool | false | no | Stream output continuously |
+| `--output` | string | text | no | Output format |
+| `--quiet` | bool | false | no | Suppress non-essential output |
 | `--service` | string | - | yes | Service name to show logs for |
+| `--timeout` | duration | 30s | no | Operation timeout |
+
+**Environment Variables:**
+
+| Variable | Flag | Description |
+|----------|------|-------------|
+| `FULL_LOGS_TIMEOUTOPT_DURATION` | `--timeout` | Operation timeout |
+| `FULL_LOGS_TIMEOUT` | `--timeout` | Operation timeout |
 
 **Example:**
 
 ```
 full logs --service api
   full logs -s api --follow
-  full logs -s api -f
+  full logs -s api -f -o json --timeout 10s
+  full logs -s api --quiet
 ```
 
 #### `full preset`
@@ -161,5 +172,6 @@ All environment variables use the `FULL_` prefix.
 ```
 full logs --service api
   full logs -s api --follow
-  full logs -s api -f
+  full logs -s api -f -o json --timeout 10s
+  full logs -s api --quiet
 ```

--- a/examples/full/SKILL.md
+++ b/examples/full/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: full
 description: |
-  A demonstration of the structcli library with beautiful CLI features. Use when you need to: demonstrate that flagpreset aliases are syntactic sugar and still flow through transform and validate, start the server with the specified configuration, print version information, add a new user to the system with the specified details.
+  A demonstration of the structcli library with beautiful CLI features. Use when you need to: display logs for a service, optionally streaming with --follow, demonstrate that flagpreset aliases are syntactic sugar and still flow through transform and validate, start the server with the specified configuration, print version information, add a new user to the system with the specified details.
 metadata:
   author: leodido
   version: 0.15.0
@@ -30,6 +30,25 @@ A demonstration of the structcli library with beautiful CLI features
 |----------|------|-------------|
 | `FULL_DRYRUN` | `--dry` |  |
 | `FULL_DRY` | `--dry` |  |
+
+#### `full logs`
+
+Display logs for a service, optionally streaming with --follow
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--follow` | bool | false | no | Stream output continuously |
+| `--service` | string | - | yes | Service name to show logs for |
+
+**Example:**
+
+```
+full logs --service api
+  full logs -s api --follow
+  full logs -s api -f
+```
 
 #### `full preset`
 
@@ -134,3 +153,13 @@ Add a new user to the system with the specified details
 ### Environment Variable Prefix
 
 All environment variables use the `FULL_` prefix.
+
+### Examples
+
+#### full logs
+
+```
+full logs --service api
+  full logs -s api --follow
+  full logs -s api -f
+```

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
+	"github.com/leodido/structcli/flagkit"
 	"github.com/leodido/structcli/jsonschema"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
@@ -282,6 +283,50 @@ func makePresetC() *cobra.Command {
 	return presetC
 }
 
+// LogsOptions demonstrates flagkit.Follow composition.
+type LogsOptions struct {
+	flagkit.Follow
+	Service string `flag:"service" flagshort:"s" flagdescr:"Service name to show logs for" flagrequired:"true"`
+}
+
+func (o *LogsOptions) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+	flagkit.AnnotateCommand(c)
+
+	return nil
+}
+
+func makeLogsC() *cobra.Command {
+	opts := &LogsOptions{}
+
+	logsC := &cobra.Command{
+		Use:   "logs",
+		Short: "Show service logs",
+		Long:  "Display logs for a service, optionally streaming with --follow",
+		Example: `  full logs --service api
+  full logs -s api --follow
+  full logs -s api -f`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := structcli.Unmarshal(c, opts); err != nil {
+				return err
+			}
+			if opts.Follow.Enabled {
+				fmt.Fprintf(c.OutOrStdout(), "Streaming logs for service %q...\n", opts.Service)
+			} else {
+				fmt.Fprintf(c.OutOrStdout(), "Showing recent logs for service %q\n", opts.Service)
+			}
+			fmt.Fprintln(c.OutOrStdout(), pretty(opts))
+
+			return nil
+		},
+	}
+	opts.Attach(logsC)
+
+	return logsC
+}
+
 var _ structcli.ContextOptions = (*UtilityFlags)(nil)
 
 type UtilityFlags struct {
@@ -362,6 +407,7 @@ func NewRootC(exitOnDebug bool) (*cobra.Command, error) {
 	rootC.AddCommand(makeSrvC())
 	rootC.AddCommand(makeUsrC())
 	rootC.AddCommand(makePresetC())
+	rootC.AddCommand(makeLogsC())
 
 	// This single line enables the debugging global flag
 	if err := structcli.SetupDebug(rootC, debug.Options{Exit: exitOnDebug}); err != nil {

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -32,6 +32,10 @@ func init() {
 		EnvStaging:    {"staging", "stage"},
 		EnvProduction: {"prod", "production"},
 	})
+
+	// Register the output formats this CLI supports (superset across all commands).
+	// Individual commands use ValidFormat() to restrict to their subset.
+	flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
 }
 
 type EvenDeeper struct {
@@ -283,9 +287,13 @@ func makePresetC() *cobra.Command {
 	return presetC
 }
 
-// LogsOptions demonstrates flagkit.Follow composition.
+// LogsOptions demonstrates flagkit composition with multiple types.
+// Combines Follow, OutputFmt, TimeoutOpt, and Quiet with an app-specific Service flag.
 type LogsOptions struct {
 	flagkit.Follow
+	flagkit.OutputFmt
+	flagkit.TimeoutOpt
+	flagkit.Quiet
 	Service string `flag:"service" flagshort:"s" flagdescr:"Service name to show logs for" flagrequired:"true"`
 }
 
@@ -307,15 +315,24 @@ func makeLogsC() *cobra.Command {
 		Long:  "Display logs for a service, optionally streaming with --follow",
 		Example: `  full logs --service api
   full logs -s api --follow
-  full logs -s api -f`,
+  full logs -s api -f -o json --timeout 10s
+  full logs -s api --quiet`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := structcli.Unmarshal(c, opts); err != nil {
 				return err
 			}
-			if opts.Follow.Enabled {
-				fmt.Fprintf(c.OutOrStdout(), "Streaming logs for service %q...\n", opts.Service)
-			} else {
-				fmt.Fprintf(c.OutOrStdout(), "Showing recent logs for service %q\n", opts.Service)
+			// Per-command format validation: logs only supports text and json
+			if err := opts.OutputFmt.ValidFormat(flagkit.OutputText, flagkit.OutputJSON); err != nil {
+				return err
+			}
+			if !opts.Quiet.Enabled {
+				if opts.Follow.Enabled {
+					fmt.Fprintf(c.OutOrStdout(), "Streaming logs for service %q (timeout %s, format %s)...\n",
+						opts.Service, opts.TimeoutOpt.Duration, opts.OutputFmt.Format)
+				} else {
+					fmt.Fprintf(c.OutOrStdout(), "Showing recent logs for service %q (format %s)\n",
+						opts.Service, opts.OutputFmt.Format)
+				}
 			}
 			fmt.Fprintln(c.OutOrStdout(), pretty(opts))
 

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -321,8 +321,8 @@ func makeLogsC() *cobra.Command {
 			if err := structcli.Unmarshal(c, opts); err != nil {
 				return err
 			}
-			// Per-command format validation: logs only supports text and json
-			if err := opts.OutputFmt.ValidFormat(flagkit.OutputText, flagkit.OutputJSON); err != nil {
+			// Per-command format validation — uses the set from RestrictFormats
+			if err := opts.OutputFmt.ValidFormat(); err != nil {
 				return err
 			}
 			if !opts.Quiet.Enabled {

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -340,6 +340,8 @@ func makeLogsC() *cobra.Command {
 		},
 	}
 	opts.Attach(logsC)
+	// Narrow help/completion/schema to the formats this command supports.
+	opts.OutputFmt.RestrictFormats(logsC, flagkit.OutputText, flagkit.OutputJSON)
 
 	return logsC
 }

--- a/examples/full/llms.txt
+++ b/examples/full/llms.txt
@@ -34,7 +34,15 @@ Display logs for a service, optionally streaming with --follow
 ### Flags
 
 - `--follow` (bool, default: false): Stream output continuously
+- `--output` (string, default: text): Output format
+- `--quiet` (bool, default: false): Suppress non-essential output
 - `--service` (string, required): Service name to show logs for
+- `--timeout` (duration, default: 30s): Operation timeout
+
+### Environment Variables
+
+- `FULL_LOGS_TIMEOUTOPT_DURATION`: maps to `--timeout`
+- `FULL_LOGS_TIMEOUT`: maps to `--timeout`
 
 ## full preset
 

--- a/examples/full/llms.txt
+++ b/examples/full/llms.txt
@@ -7,6 +7,7 @@ https://github.com/leodido/structcli/examples/full
 ## Commands
 
 - [full](#full): A demonstration of the structcli library with beautiful CLI features
+- [full logs](#full-logs): Display logs for a service, optionally streaming with --follow
 - [full preset](#full-preset): Demonstrate that flagpreset aliases are syntactic sugar and still flow through Transform and Validate
 - [full srv](#full-srv): Start the server with the specified configuration
 - [full srv version](#full-srv-version): Print version information
@@ -25,6 +26,15 @@ A demonstration of the structcli library with beautiful CLI features
 
 - `FULL_DRYRUN`: maps to `--dry`
 - `FULL_DRY`: maps to `--dry`
+
+## full logs
+
+Display logs for a service, optionally streaming with --follow
+
+### Flags
+
+- `--follow` (bool, default: false): Stream output continuously
+- `--service` (string, required): Service name to show logs for
 
 ## full preset
 

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -27,7 +27,7 @@
 //	LogLevel       --log-level   info     available
 //	ZapLogLevel    --log-level   info     available
 //	SlogLogLevel   --log-level   info     available
-//	OutputFmt      --output/-o   text     planned (PR 3)
+//	OutputFmt      --output/-o   text     available
 //	Verbose        --verbose/-v  0        planned (PR 4)
 //	DryRun         --dry-run     false    planned (PR 4)
 //	TimeoutOpt     --timeout     30s      planned (PR 5)

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -24,9 +24,9 @@
 //	Type           Flag          Default  Status
 //	─────────────  ────────────  ───────  ────────
 //	Follow         --follow/-f   false    available
-//	LogLevel       --log-level   info     planned (PR 2)
-//	ZapLogLevel    --log-level   info     planned (PR 2)
-//	SlogLogLevel   --log-level   info     planned (PR 2)
+//	LogLevel       --log-level   info     available
+//	ZapLogLevel    --log-level   info     available
+//	SlogLogLevel   --log-level   info     available
 //	OutputFmt      --output/-o   text     planned (PR 3)
 //	Verbose        --verbose/-v  0        planned (PR 4)
 //	DryRun         --dry-run     false    planned (PR 4)

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -1,0 +1,52 @@
+// Package flagkit provides reusable, embeddable flag structs that standardize
+// common CLI flag declarations for use with structcli.
+//
+// Each type encapsulates a single flag with an opinionated name, type, default,
+// and description matching industry conventions. This gives CLIs a consistent
+// declaration surface — agents and scripts can rely on --follow, --output,
+// --timeout, etc. having predictable names and types across tools.
+//
+// flagkit standardizes flag declarations, not behavioral semantics. How a
+// command interprets --quiet or --dry-run is up to the consumer. The value
+// is in the shared vocabulary: consistent names, types, and defaults that
+// AI agents can recognize across CLIs built with structcli.
+//
+// # Design Principles
+//
+//   - One struct per concern — maximum composability
+//   - Sensible, agent-friendly defaults (e.g., no auto-tailing, finite timeouts)
+//   - Standard flag names matching industry conventions
+//   - Works with all structcli features: env vars, config files, JSON Schema,
+//     shell completion, and doc generation
+//
+// # Taxonomy
+//
+//	Type           Flag          Default  Status
+//	─────────────  ────────────  ───────  ────────
+//	Follow         --follow/-f   false    available
+//	LogLevel       --log-level   info     planned (PR 2)
+//	ZapLogLevel    --log-level   info     planned (PR 2)
+//	SlogLogLevel   --log-level   info     planned (PR 2)
+//	OutputFmt      --output/-o   text     planned (PR 3)
+//	Verbose        --verbose/-v  0        planned (PR 4)
+//	DryRun         --dry-run     false    planned (PR 4)
+//	TimeoutOpt     --timeout     30s      planned (PR 5)
+//	Quiet          --quiet/-q    false    planned (PR 5)
+//
+// # Composition
+//
+// Embed one or more flagkit types in your options struct:
+//
+//	type LogOptions struct {
+//	    flagkit.Follow
+//	    Service string `flag:"service" flagdescr:"Service name"`
+//	}
+//
+//	func (o *LogOptions) Attach(c *cobra.Command) error {
+//	    if err := structcli.Define(c, o); err != nil {
+//	        return err
+//	    }
+//	    flagkit.AnnotateCommand(c)
+//	    return nil
+//	}
+package flagkit

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -52,4 +52,19 @@
 //	    flagkit.AnnotateCommand(c)
 //	    return nil
 //	}
+//
+// # Naming Convention
+//
+// Most types use the flag name as the struct name (Follow, Quiet, DryRun, Verbose).
+// Two types use suffixed names to avoid a mapstructure decoding collision when
+// embedded — the flag name would match the struct name (case-insensitive) and
+// break viper Unmarshal for non-primitive field types:
+//
+//   - [OutputFmt] (not Output) — flag "output", field Format
+//   - [TimeoutOpt] (not Timeout) — flag "timeout", field Duration
+//
+// This also means generated env var names include the struct name
+// (e.g., APP_TIMEOUTOPT_DURATION). A future structcli Unmarshal fix will
+// allow natural wrapper names; see https://github.com/leodido/structcli/issues
+// for tracking.
 package flagkit

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -28,8 +28,8 @@
 //	ZapLogLevel    --log-level   info     available
 //	SlogLogLevel   --log-level   info     available
 //	OutputFmt      --output/-o   text     available
-//	Verbose        --verbose/-v  0        planned (PR 4)
-//	DryRun         --dry-run     false    planned (PR 4)
+//	Verbose        --verbose/-v  0        available
+//	DryRun         --dry-run     false    available
 //	TimeoutOpt     --timeout     30s      planned (PR 5)
 //	Quiet          --quiet/-q    false    planned (PR 5)
 //

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -30,8 +30,8 @@
 //	OutputFmt      --output/-o   text     available
 //	Verbose        --verbose/-v  0        available
 //	DryRun         --dry-run     false    available
-//	TimeoutOpt     --timeout     30s      planned (PR 5)
-//	Quiet          --quiet/-q    false    planned (PR 5)
+//	TimeoutOpt     --timeout     30s      available
+//	Quiet          --quiet/-q    false    available
 //
 // # Composition
 //
@@ -39,6 +39,9 @@
 //
 //	type LogOptions struct {
 //	    flagkit.Follow
+//	    flagkit.LogLevel
+//	    flagkit.OutputFmt
+//	    flagkit.Quiet
 //	    Service string `flag:"service" flagdescr:"Service name"`
 //	}
 //

--- a/flagkit/dryrun.go
+++ b/flagkit/dryrun.go
@@ -1,0 +1,44 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("dry-run")
+}
+
+// DryRun provides a --dry-run flag for safe previewing of operations.
+//
+// The default is false. When true, commands should describe what they
+// would do without making changes. This is agent-friendly — AI agents
+// can preview destructive operations before committing.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.DryRun
+//	}
+//
+//	// In RunE:
+//	if opts.DryRun.Enabled {
+//	    fmt.Println("would delete", target)
+//	    return nil
+//	}
+type DryRun struct {
+	Enabled bool `flag:"dry-run" flagdescr:"Preview without making changes" default:"false" flagenv:"true"`
+}
+
+// Attach implements [structcli.Options].
+func (o *DryRun) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("dry-run"); f != nil {
+		_ = c.Flags().SetAnnotation("dry-run", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/dryrun_test.go
+++ b/flagkit/dryrun_test.go
@@ -1,0 +1,105 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- DryRun tests ---
+
+func TestDryRun_DefaultFalse(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestDryRun_ExplicitTrue(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--dry-run"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestDryRun_ExplicitFalse(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--dry-run=false"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestDryRun_Standalone(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "false", f.DefValue)
+	assert.Equal(t, "Preview without making changes", f.Usage)
+}
+
+func TestDryRun_Annotation(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestDryRun_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestDryRun_Embedded(t *testing.T) {
+	type deployOpts struct {
+		flagkit.DryRun
+		Target string `flag:"target" flagdescr:"Deploy target" default:"staging"`
+	}
+	opts := &deployOpts{}
+	cmd := &cobra.Command{Use: "deploy"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--dry-run", "--target", "prod"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.DryRun.Enabled)
+	assert.Equal(t, "prod", opts.Target)
+}
+
+func TestDryRun_JSONSchema(t *testing.T) {
+	opts := &flagkit.DryRun{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["dry-run"]
+	assert.True(t, ok, "JSON schema should include the dry-run flag")
+}

--- a/flagkit/follow.go
+++ b/flagkit/follow.go
@@ -1,0 +1,86 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+// FlagKitAnnotation is the pflag annotation key set on flags defined by
+// flagkit types. The generate package uses this to detect flagkit usage
+// and emit development guidance in generated docs.
+const FlagKitAnnotation = "___leodido_structcli_flagkit"
+
+// flagKitFlags is the registry of flag names owned by flagkit types.
+// Each type registers its flag name via registerFlag in its own file's init().
+var flagKitFlags []string
+
+// registerFlag adds a flag name to the flagkit registry.
+// Called by each type's init() function.
+func registerFlag(name string) {
+	flagKitFlags = append(flagKitFlags, name)
+}
+
+// AnnotateCommand marks all flagkit-owned flags on the command with the
+// [FlagKitAnnotation]. Call this after [structcli.Define] when embedding
+// flagkit types in a parent struct.
+//
+// When using a flagkit type standalone via its Attach method, the
+// annotation is set automatically and this call is not needed.
+// For embedded usage, [structcli.Define] traverses into the embedded
+// struct but does not call its Attach method, so AnnotateCommand
+// must be called explicitly to set the annotation.
+func AnnotateCommand(c *cobra.Command) {
+	for _, name := range flagKitFlags {
+		if f := c.Flags().Lookup(name); f != nil {
+			_ = c.Flags().SetAnnotation(name, FlagKitAnnotation, []string{"true"})
+		}
+	}
+}
+
+func init() {
+	registerFlag("follow")
+}
+
+// Follow provides a --follow/-f boolean flag for opt-in streaming.
+//
+// When false (the default), commands should print current output and exit.
+// When true, commands should stream output continuously. This default is
+// agent-friendly — AI agents and scripts won't hang on indefinite tailing.
+//
+// Usage:
+//
+//	type LogOptions struct {
+//	    flagkit.Follow
+//	    Service string `flag:"service" flagdescr:"Service name"`
+//	}
+//
+//	func (o *LogOptions) Attach(c *cobra.Command) error {
+//	    if err := structcli.Define(c, o); err != nil {
+//	        return err
+//	    }
+//	    flagkit.AnnotateCommand(c)
+//	    return nil
+//	}
+//
+//	// In RunE:
+//	if opts.Follow.Enabled {
+//	    streamLogs(ctx)
+//	} else {
+//	    printCurrentLogs()
+//	}
+type Follow struct {
+	Enabled bool `flag:"follow" flagshort:"f" flagdescr:"Stream output continuously" default:"false"`
+}
+
+// Attach implements [structcli.Options].
+func (o *Follow) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("follow"); f != nil {
+		_ = c.Flags().SetAnnotation("follow", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/follow.go
+++ b/flagkit/follow.go
@@ -29,6 +29,11 @@ func registerFlag(name string) {
 // For embedded usage, [structcli.Define] traverses into the embedded
 // struct but does not call its Attach method, so AnnotateCommand
 // must be called explicitly to set the annotation.
+//
+// Matching is by flag name, not by type. If the command defines a
+// non-flagkit flag whose name collides with a flagkit flag name
+// (e.g. a custom --follow), it will be incorrectly annotated.
+// Only call this on commands that embed flagkit types.
 func AnnotateCommand(c *cobra.Command) {
 	for _, name := range flagKitFlags {
 		if f := c.Flags().Lookup(name); f != nil {

--- a/flagkit/follow_test.go
+++ b/flagkit/follow_test.go
@@ -1,0 +1,179 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Standalone tests (Follow used directly via Attach) ---
+
+func TestFollow_DefaultFalse(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestFollow_ExplicitTrue(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--follow"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestFollow_ShortFlag(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-f"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestFollow_ExplicitFalse(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--follow=false"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestFollow_Standalone(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("follow")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "f", f.Shorthand)
+	assert.Equal(t, "false", f.DefValue)
+	assert.Equal(t, "Stream output continuously", f.Usage)
+}
+
+func TestFollow_Standalone_Annotation(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("follow")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+// --- Embedded tests (Follow embedded in a parent struct) ---
+
+type logOptions struct {
+	flagkit.Follow
+	Service string `flag:"service" flagdescr:"Service name"`
+}
+
+func (o *logOptions) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+	flagkit.AnnotateCommand(c)
+
+	return nil
+}
+
+func TestFollow_Embedded(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--follow", "--service", "api"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Follow.Enabled)
+	assert.Equal(t, "api", opts.Service)
+}
+
+func TestFollow_Embedded_DefaultFalse(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--service", "api"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Follow.Enabled)
+	assert.Equal(t, "api", opts.Service)
+}
+
+func TestFollow_Embedded_Annotation(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("follow")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set on embedded usage")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestFollow_Embedded_BothFlagsExist(t *testing.T) {
+	opts := &logOptions{}
+	cmd := &cobra.Command{Use: "logs"}
+	require.NoError(t, opts.Attach(cmd))
+
+	assert.NotNil(t, cmd.Flags().Lookup("follow"), "--follow should exist")
+	assert.NotNil(t, cmd.Flags().Lookup("service"), "--service should exist")
+}
+
+// --- JSON Schema test ---
+
+func TestFollow_JSONSchema(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["follow"]
+	assert.True(t, ok, "JSON schema should include the follow flag")
+}
+
+// --- Error path ---
+
+func TestFollow_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.Follow{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	// Second Attach on the same command triggers a Define validation error
+	// because the "follow" flag is already registered.
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+// --- AnnotateCommand on command without flagkit flags ---
+
+func TestAnnotateCommand_NoFlagKitFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().Bool("other", false, "some other flag")
+
+	// Should not panic when no flagkit flags exist
+	flagkit.AnnotateCommand(cmd)
+
+	f := cmd.Flags().Lookup("other")
+	require.NotNil(t, f)
+	_, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.False(t, ok, "non-flagkit flag should not be annotated")
+}

--- a/flagkit/loglevel.go
+++ b/flagkit/loglevel.go
@@ -1,0 +1,74 @@
+package flagkit
+
+import (
+	"log/slog"
+
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+)
+
+func init() {
+	registerFlag("log-level")
+}
+
+// ZapLogLevel provides a --log-level flag backed by [zapcore.Level].
+//
+// The default is info. zapcore.Level is registered as an integer enum
+// by structcli's built-in init(), so no additional registration is needed.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.ZapLogLevel
+//	    Host string `flag:"host" flagdescr:"Server host"`
+//	}
+type ZapLogLevel struct {
+	LogLevel zapcore.Level `flag:"log-level" flagdescr:"Set log level" default:"info" flagenv:"true" flaggroup:"Logging"`
+}
+
+// Attach implements [structcli.Options].
+func (o *ZapLogLevel) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("log-level"); f != nil {
+		_ = c.Flags().SetAnnotation("log-level", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}
+
+// LogLevel is the recommended log level type. It is an alias for [ZapLogLevel].
+//
+// Embed this in your options struct for the standard --log-level flag backed
+// by zapcore.Level. Use [SlogLogLevel] if you prefer the stdlib slog package.
+type LogLevel = ZapLogLevel
+
+// SlogLogLevel provides a --log-level flag backed by [slog.Level] (stdlib).
+//
+// The default is info. slog.Level is handled by structcli's built-in hooks,
+// so no additional registration is needed.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.SlogLogLevel
+//	}
+type SlogLogLevel struct {
+	LogLevel slog.Level `flag:"log-level" flagdescr:"Set log level" default:"info" flagenv:"true" flaggroup:"Logging"`
+}
+
+// Attach implements [structcli.Options].
+func (o *SlogLogLevel) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("log-level"); f != nil {
+		_ = c.Flags().SetAnnotation("log-level", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/loglevel_test.go
+++ b/flagkit/loglevel_test.go
@@ -1,0 +1,185 @@
+package flagkit_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+// --- ZapLogLevel tests ---
+
+func TestZapLogLevel_DefaultInfo(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.InfoLevel, opts.LogLevel)
+}
+
+func TestZapLogLevel_SetDebug(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "debug"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.DebugLevel, opts.LogLevel)
+}
+
+func TestZapLogLevel_SetError(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "error"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.ErrorLevel, opts.LogLevel)
+}
+
+func TestZapLogLevel_Standalone(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "info", f.DefValue)
+	assert.Contains(t, f.Usage, "Set log level")
+}
+
+func TestZapLogLevel_Annotation(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestZapLogLevel_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestZapLogLevel_Embedded(t *testing.T) {
+	type serverOpts struct {
+		flagkit.ZapLogLevel
+		Host string `flag:"host" flagdescr:"Server host" default:"localhost"`
+	}
+	opts := &serverOpts{}
+	cmd := &cobra.Command{Use: "srv"}
+	require.NoError(t, structcli.Define(cmd, opts))
+	flagkit.AnnotateCommand(cmd)
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "warn", "--host", "0.0.0.0"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, zapcore.WarnLevel, opts.LogLevel)
+	assert.Equal(t, "0.0.0.0", opts.Host)
+}
+
+func TestZapLogLevel_JSONSchema(t *testing.T) {
+	opts := &flagkit.ZapLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["log-level"]
+	assert.True(t, ok, "JSON schema should include the log-level flag")
+}
+
+// --- SlogLogLevel tests ---
+
+func TestSlogLogLevel_DefaultInfo(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, slog.LevelInfo, opts.LogLevel)
+}
+
+func TestSlogLogLevel_SetDebug(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "debug"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, slog.LevelDebug, opts.LogLevel)
+}
+
+func TestSlogLogLevel_SetWarn(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--log-level", "warn"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, slog.LevelWarn, opts.LogLevel)
+}
+
+func TestSlogLogLevel_Standalone(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "info", f.DefValue)
+	assert.Contains(t, f.Usage, "Set log level")
+}
+
+func TestSlogLogLevel_Annotation(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("log-level")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestSlogLogLevel_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.SlogLogLevel{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+// --- LogLevel alias test ---
+
+func TestLogLevel_IsZapLogLevel(t *testing.T) {
+	var ll flagkit.LogLevel
+	var zll flagkit.ZapLogLevel
+
+	// LogLevel is a type alias for ZapLogLevel — assignment must compile.
+	ll = zll
+	zll = ll
+	_ = zll
+}

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -2,10 +2,14 @@ package flagkit
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
 )
+
+// flagEnumAnnotation mirrors the structcli annotation key for enum values.
+const flagEnumAnnotation = "___leodido_structcli_flagenum"
 
 func init() {
 	registerFlag("output")
@@ -55,14 +59,18 @@ func RegisterOutputFormats(formats ...OutputFormat) {
 // via [RegisterOutputFormats] or [structcli.RegisterEnum].
 //
 // For CLIs where different commands support different format subsets,
-// register the superset globally and use [OutputFmt.ValidFormat] per command:
+// register the superset globally, then call [OutputFmt.RestrictFormats] after
+// Attach to narrow help/completion/schema, and [OutputFmt.ValidFormat] in RunE:
 //
 //	func init() {
 //	    // Global: register all formats the CLI knows about
 //	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
 //	}
 //
-//	// Per-command: validate the subset this command supports
+//	// Per-command: restrict help/completion/schema, then validate at runtime
+//	opts.Attach(cmd)
+//	opts.OutputFmt.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputYAML)
+//
 //	func (o *ExportOptions) RunE(cmd *cobra.Command, args []string) error {
 //	    if err := o.ValidFormat(flagkit.OutputJSON, flagkit.OutputYAML); err != nil {
 //	        return err
@@ -89,6 +97,34 @@ func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
 	}
 
 	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
+}
+
+// RestrictFormats narrows the --output flag's help text and enum annotation
+// to only the given formats. Call this after [Attach] or [structcli.Define]
+// to make the command's declared contract (help, JSON Schema) match what
+// [ValidFormat] will accept at runtime.
+//
+// Shell completion may still show the globally registered superset because
+// cobra does not support overriding completion functions after registration.
+//
+//	opts.Attach(cmd)
+//	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+func (o *OutputFmt) RestrictFormats(c *cobra.Command, allowed ...OutputFormat) {
+	f := c.Flags().Lookup("output")
+	if f == nil {
+		return
+	}
+
+	names := make([]string, len(allowed))
+	for i, a := range allowed {
+		names[i] = string(a)
+	}
+
+	// Update the usage string to show only the allowed subset.
+	f.Usage = fmt.Sprintf("Output format {%s}", strings.Join(names, ","))
+
+	// Update the enum annotation used by JSON Schema generation.
+	_ = c.Flags().SetAnnotation("output", flagEnumAnnotation, names)
 }
 
 // Attach implements [structcli.Options].

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -1,0 +1,105 @@
+package flagkit
+
+import (
+	"fmt"
+
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("output")
+}
+
+// OutputFormat is a string enum for output format selection.
+//
+// flagkit provides common constants but does NOT auto-register them.
+// Call [RegisterOutputFormats] or [structcli.RegisterEnum] in your init()
+// to declare the CLI-wide format vocabulary.
+type OutputFormat string
+
+const (
+	OutputJSON  OutputFormat = "json"
+	OutputJSONL OutputFormat = "jsonl"
+	OutputText  OutputFormat = "text"
+	OutputYAML  OutputFormat = "yaml"
+)
+
+// RegisterOutputFormats registers the given output formats for use with
+// structcli's enum flag handling. Each format's string value is used as
+// both the canonical name and the only accepted alias.
+//
+// This is a process-global, one-time registration (like [database/sql.Register]).
+// Register the superset of all formats your CLI supports. For per-command
+// format subsets, use [Output.ValidFormat] in your command's RunE.
+//
+// Call this in init() before any [structcli.Define] calls:
+//
+//	func init() {
+//	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
+//	}
+//
+// For custom aliases, use [structcli.RegisterEnum] directly instead.
+func RegisterOutputFormats(formats ...OutputFormat) {
+	m := make(map[OutputFormat][]string, len(formats))
+	for _, f := range formats {
+		m[f] = []string{string(f)}
+	}
+
+	structcli.RegisterEnum[OutputFormat](m)
+}
+
+// Output provides a --output/-o flag for selecting output format.
+//
+// The default is text. You must register the supported formats before use
+// via [RegisterOutputFormats] or [structcli.RegisterEnum].
+//
+// For CLIs where different commands support different format subsets,
+// register the superset globally and use [OutputFmt.ValidFormat] per command:
+//
+//	func init() {
+//	    // Global: register all formats the CLI knows about
+//	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
+//	}
+//
+//	// Per-command: validate the subset this command supports
+//	func (o *ExportOptions) RunE(cmd *cobra.Command, args []string) error {
+//	    if err := o.ValidFormat(flagkit.OutputJSON, flagkit.OutputYAML); err != nil {
+//	        return err
+//	    }
+//	    // ...
+//	}
+type OutputFmt struct {
+	Format OutputFormat `flag:"output" flagshort:"o" flagdescr:"Output format" default:"text"`
+}
+
+// ValidFormat returns nil if the current output format is one of the allowed
+// formats, or an error describing the mismatch. Use this for per-command
+// format validation when different commands support different subsets.
+func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
+	for _, a := range allowed {
+		if o.Format == a {
+			return nil
+		}
+	}
+
+	names := make([]string, len(allowed))
+	for i, a := range allowed {
+		names[i] = string(a)
+	}
+
+	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
+}
+
+// Attach implements [structcli.Options].
+func (o *OutputFmt) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("output"); f != nil {
+		_ = c.Flags().SetAnnotation("output", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -144,14 +144,21 @@ func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
 }
 
 // Attach implements [structcli.Options].
+//
+// Returns an error if the --output flag was not created, which typically
+// means [RegisterOutputFormats] (or [structcli.RegisterEnum]) was not
+// called before Attach.
 func (o *OutputFmt) Attach(c *cobra.Command) error {
 	if err := structcli.Define(c, o); err != nil {
 		return err
 	}
 
-	if f := c.Flags().Lookup("output"); f != nil {
-		_ = c.Flags().SetAnnotation("output", FlagKitAnnotation, []string{"true"})
+	f := c.Flags().Lookup("output")
+	if f == nil {
+		return fmt.Errorf("flagkit: --output flag not created; call RegisterOutputFormats in init() before Attach")
 	}
+
+	_ = c.Flags().SetAnnotation("output", FlagKitAnnotation, []string{"true"})
 
 	return nil
 }

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -53,63 +53,48 @@ func RegisterOutputFormats(formats ...OutputFormat) {
 	structcli.RegisterEnum[OutputFormat](m)
 }
 
-// Output provides a --output/-o flag for selecting output format.
+// OutputFmt provides a --output/-o flag for selecting output format.
 //
 // The default is text. You must register the supported formats before use
 // via [RegisterOutputFormats] or [structcli.RegisterEnum].
 //
 // For CLIs where different commands support different format subsets,
 // register the superset globally, then call [OutputFmt.RestrictFormats] after
-// Attach to narrow help/completion/schema, and [OutputFmt.ValidFormat] in RunE:
+// Attach. RestrictFormats is the single source of truth — it narrows help,
+// JSON Schema, and runtime validation in one call:
 //
 //	func init() {
-//	    // Global: register all formats the CLI knows about
 //	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
 //	}
 //
-//	// Per-command: restrict help/completion/schema, then validate at runtime
 //	opts.Attach(cmd)
 //	opts.OutputFmt.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputYAML)
 //
-//	func (o *ExportOptions) RunE(cmd *cobra.Command, args []string) error {
-//	    if err := o.ValidFormat(flagkit.OutputJSON, flagkit.OutputYAML); err != nil {
-//	        return err
-//	    }
-//	    // ...
+//	// In RunE — no args needed, uses the set from RestrictFormats:
+//	if err := opts.OutputFmt.ValidFormat(); err != nil {
+//	    return err
 //	}
 type OutputFmt struct {
-	Format OutputFormat `flag:"output" flagshort:"o" flagdescr:"Output format" default:"text"`
+	Format  OutputFormat `flag:"output" flagshort:"o" flagdescr:"Output format" default:"text"`
+	allowed []OutputFormat
 }
 
-// ValidFormat returns nil if the current output format is one of the allowed
-// formats, or an error describing the mismatch. Use this for per-command
-// format validation when different commands support different subsets.
-func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
-	for _, a := range allowed {
-		if o.Format == a {
-			return nil
-		}
-	}
-
-	names := make([]string, len(allowed))
-	for i, a := range allowed {
-		names[i] = string(a)
-	}
-
-	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
-}
-
-// RestrictFormats narrows the --output flag's help text and enum annotation
-// to only the given formats. Call this after [Attach] or [structcli.Define]
-// to make the command's declared contract (help, JSON Schema) match what
-// [ValidFormat] will accept at runtime.
+// RestrictFormats narrows the --output flag's help text, enum annotation,
+// and runtime validation to only the given formats. Call this after [Attach]
+// or [structcli.Define].
+//
+// This is the single source of truth for per-command format subsets.
+// After calling RestrictFormats, [ValidFormat] with no arguments enforces
+// the same set, eliminating the need to repeat the allowed list.
 //
 // Shell completion may still show the globally registered superset because
 // cobra does not support overriding completion functions after registration.
 //
 //	opts.Attach(cmd)
-//	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+//	opts.OutputFmt.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
 func (o *OutputFmt) RestrictFormats(c *cobra.Command, allowed ...OutputFormat) {
+	o.allowed = allowed
+
 	f := c.Flags().Lookup("output")
 	if f == nil {
 		return
@@ -125,6 +110,37 @@ func (o *OutputFmt) RestrictFormats(c *cobra.Command, allowed ...OutputFormat) {
 
 	// Update the enum annotation used by JSON Schema generation.
 	_ = c.Flags().SetAnnotation("output", flagEnumAnnotation, names)
+}
+
+// ValidFormat returns nil if the current output format is allowed, or an
+// error describing the mismatch.
+//
+// When called with no arguments, it validates against the set stored by
+// [RestrictFormats]. When called with explicit arguments, it validates
+// against those instead (and ignores any stored restriction).
+//
+// If neither RestrictFormats was called nor explicit arguments are provided,
+// ValidFormat returns nil (all formats accepted).
+func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
+	if len(allowed) == 0 {
+		allowed = o.allowed
+	}
+	if len(allowed) == 0 {
+		return nil // no restriction
+	}
+
+	for _, a := range allowed {
+		if o.Format == a {
+			return nil
+		}
+	}
+
+	names := make([]string, len(allowed))
+	for i, a := range allowed {
+		names[i] = string(a)
+	}
+
+	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
 }
 
 // Attach implements [structcli.Options].

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -155,6 +155,57 @@ func TestOutput_ValidFormat_SingleAllowed(t *testing.T) {
 	assert.NoError(t, opts.ValidFormat(flagkit.OutputText))
 }
 
+// --- RestrictFormats tests ---
+
+func TestOutputFmt_RestrictFormats_Usage(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	assert.Equal(t, "Output format {json,text}", f.Usage)
+}
+
+func TestOutputFmt_RestrictFormats_Annotation(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations["___leodido_structcli_flagenum"]
+	assert.True(t, ok, "enum annotation should be set")
+	assert.Equal(t, []string{"json", "text"}, ann)
+}
+
+func TestOutputFmt_RestrictFormats_JSONSchema(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	fs, ok := schemas[0].Flags["output"]
+	require.True(t, ok)
+	assert.Equal(t, []string{"json", "text"}, fs.Enum)
+}
+
+func TestOutputFmt_RestrictFormats_NoFlag(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	// Don't call Attach — no flag registered
+	opts.RestrictFormats(cmd, flagkit.OutputJSON) // should not panic
+}
+
 // --- RegisterOutputFormats tests ---
 
 func TestRegisterOutputFormats_PanicsOnDuplicate(t *testing.T) {

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -155,6 +155,48 @@ func TestOutput_ValidFormat_SingleAllowed(t *testing.T) {
 	assert.NoError(t, opts.ValidFormat(flagkit.OutputText))
 }
 
+func TestOutput_ValidFormat_NoRestriction(t *testing.T) {
+	// No RestrictFormats called, no explicit args — all formats accepted.
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputYAML}
+	assert.NoError(t, opts.ValidFormat())
+}
+
+func TestOutput_ValidFormat_UsesRestrictFormats(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	// Set format to an allowed value — should pass with no args.
+	opts.Format = flagkit.OutputJSON
+	assert.NoError(t, opts.ValidFormat())
+
+	// Set format to a disallowed value — should fail with no args.
+	opts.Format = flagkit.OutputYAML
+	err := opts.ValidFormat()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "yaml")
+}
+
+func TestOutput_ValidFormat_ExplicitOverridesStored(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	// Restrict to json+text via RestrictFormats.
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	// Explicit args override the stored set — yaml is allowed here.
+	opts.Format = flagkit.OutputYAML
+	assert.NoError(t, opts.ValidFormat(flagkit.OutputYAML, flagkit.OutputJSON))
+
+	// But text is not in the explicit set.
+	opts.Format = flagkit.OutputText
+	err := opts.ValidFormat(flagkit.OutputYAML, flagkit.OutputJSON)
+	assert.Error(t, err)
+}
+
 // --- RestrictFormats tests ---
 
 func TestOutputFmt_RestrictFormats_Usage(t *testing.T) {

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -1,0 +1,166 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	flagkit.RegisterOutputFormats(
+		flagkit.OutputJSON,
+		flagkit.OutputJSONL,
+		flagkit.OutputText,
+		flagkit.OutputYAML,
+	)
+}
+
+// --- Output tests ---
+
+func TestOutput_DefaultText(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputText, opts.Format)
+}
+
+func TestOutput_SetJSON(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--output", "json"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputJSON, opts.Format)
+}
+
+func TestOutput_SetYAML(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--output", "yaml"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputYAML, opts.Format)
+}
+
+func TestOutput_SetJSONL(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-o", "jsonl"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputJSONL, opts.Format)
+}
+
+func TestOutput_ShortFlag(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-o", "json"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputJSON, opts.Format)
+}
+
+func TestOutput_Standalone(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "o", f.Shorthand)
+	assert.Equal(t, "text", f.DefValue)
+	assert.Contains(t, f.Usage, "Output format")
+}
+
+func TestOutput_Annotation(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestOutput_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestOutput_Embedded(t *testing.T) {
+	type listOpts struct {
+		flagkit.OutputFmt
+		Limit int `flag:"limit" flagdescr:"Max results" default:"10"`
+	}
+	opts := &listOpts{}
+	cmd := &cobra.Command{Use: "list"}
+	require.NoError(t, structcli.Define(cmd, opts))
+	flagkit.AnnotateCommand(cmd)
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--output", "yaml", "--limit", "50"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, flagkit.OutputYAML, opts.OutputFmt.Format)
+	assert.Equal(t, 50, opts.Limit)
+}
+
+func TestOutput_JSONSchema(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["output"]
+	assert.True(t, ok, "JSON schema should include the output flag")
+}
+
+// --- ValidFormat tests ---
+
+func TestOutput_ValidFormat_Allowed(t *testing.T) {
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputJSON}
+	err := opts.ValidFormat(flagkit.OutputJSON, flagkit.OutputText)
+	assert.NoError(t, err)
+}
+
+func TestOutput_ValidFormat_NotAllowed(t *testing.T) {
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputYAML}
+	err := opts.ValidFormat(flagkit.OutputJSON, flagkit.OutputText)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "yaml")
+	assert.Contains(t, err.Error(), "allowed")
+}
+
+func TestOutput_ValidFormat_SingleAllowed(t *testing.T) {
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputText}
+	assert.NoError(t, opts.ValidFormat(flagkit.OutputText))
+}
+
+// --- RegisterOutputFormats tests ---
+
+func TestRegisterOutputFormats_PanicsOnDuplicate(t *testing.T) {
+	// OutputFormat is already registered in init() above.
+	// A second call should panic.
+	assert.Panics(t, func() {
+		flagkit.RegisterOutputFormats(flagkit.OutputJSON)
+	})
+}

--- a/flagkit/quiet.go
+++ b/flagkit/quiet.go
@@ -1,0 +1,43 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("quiet")
+}
+
+// Quiet provides a --quiet/-q flag for suppressing non-essential output.
+//
+// The default is false. When true, commands should only emit machine-readable
+// output (e.g., IDs, status codes) and suppress progress messages, banners,
+// and decorative formatting.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.Quiet
+//	}
+//
+//	// In RunE:
+//	if !opts.Quiet.Enabled {
+//	    fmt.Println("Deploying to production...")
+//	}
+type Quiet struct {
+	Enabled bool `flag:"quiet" flagshort:"q" flagdescr:"Suppress non-essential output" default:"false"`
+}
+
+// Attach implements [structcli.Options].
+func (o *Quiet) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("quiet"); f != nil {
+		_ = c.Flags().SetAnnotation("quiet", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/quiet_test.go
+++ b/flagkit/quiet_test.go
@@ -1,0 +1,115 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Quiet tests ---
+
+func TestQuiet_DefaultFalse(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestQuiet_ExplicitTrue(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--quiet"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestQuiet_ShortFlag(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-q"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestQuiet_ExplicitFalse(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--quiet=false"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestQuiet_Standalone(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("quiet")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "q", f.Shorthand)
+	assert.Equal(t, "false", f.DefValue)
+	assert.Equal(t, "Suppress non-essential output", f.Usage)
+}
+
+func TestQuiet_Annotation(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("quiet")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestQuiet_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestQuiet_Embedded(t *testing.T) {
+	type buildOpts struct {
+		flagkit.Quiet
+		Target string `flag:"target" flagdescr:"Build target" default:"all"`
+	}
+	opts := &buildOpts{}
+	cmd := &cobra.Command{Use: "build"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"-q", "--target", "linux"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Quiet.Enabled)
+	assert.Equal(t, "linux", opts.Target)
+}
+
+func TestQuiet_JSONSchema(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["quiet"]
+	assert.True(t, ok, "JSON schema should include the quiet flag")
+}

--- a/flagkit/timeout.go
+++ b/flagkit/timeout.go
@@ -1,0 +1,43 @@
+package flagkit
+
+import (
+	"time"
+
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("timeout")
+}
+
+// Timeout provides a --timeout flag for operation deadlines.
+//
+// The default is 30s. Accepts any value parseable by [time.ParseDuration].
+// This is agent-friendly — operations won't hang indefinitely.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.TimeoutOpt
+//	}
+//
+//	// In RunE:
+//	ctx, cancel := context.WithTimeout(ctx, opts.TimeoutOpt.Duration)
+//	defer cancel()
+type TimeoutOpt struct {
+	Duration time.Duration `flag:"timeout" flagdescr:"Operation timeout" default:"30s" flagenv:"true"`
+}
+
+// Attach implements [structcli.Options].
+func (o *TimeoutOpt) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("timeout"); f != nil {
+		_ = c.Flags().SetAnnotation("timeout", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/timeout_test.go
+++ b/flagkit/timeout_test.go
@@ -1,0 +1,106 @@
+package flagkit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Timeout tests ---
+
+func TestTimeout_Default30s(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 30*time.Second, opts.Duration)
+}
+
+func TestTimeout_Set10s(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--timeout", "10s"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 10*time.Second, opts.Duration)
+}
+
+func TestTimeout_Set5m(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--timeout", "5m"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 5*time.Minute, opts.Duration)
+}
+
+func TestTimeout_Standalone(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("timeout")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "30s", f.DefValue)
+	assert.Equal(t, "Operation timeout", f.Usage)
+}
+
+func TestTimeout_Annotation(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("timeout")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestTimeout_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestTimeout_Embedded(t *testing.T) {
+	type fetchOpts struct {
+		flagkit.TimeoutOpt
+		URL string `flag:"url" flagdescr:"URL to fetch" flagrequired:"true"`
+	}
+	opts := &fetchOpts{}
+	cmd := &cobra.Command{Use: "fetch"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--timeout", "2m", "--url", "https://example.com"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 2*time.Minute, opts.TimeoutOpt.Duration)
+	assert.Equal(t, "https://example.com", opts.URL)
+}
+
+func TestTimeout_JSONSchema(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["timeout"]
+	assert.True(t, ok, "JSON schema should include the timeout flag")
+}

--- a/flagkit/verbose.go
+++ b/flagkit/verbose.go
@@ -1,0 +1,42 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("verbose")
+}
+
+// Verbose provides a --verbose/-v count flag for verbosity levels.
+//
+// The default is 0 (quiet). Each -v increments the count: -v is 1, -vv is 2,
+// -vvv is 3. This is the standard Unix convention for verbosity.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.Verbose
+//	}
+//
+//	// In RunE:
+//	if opts.Verbose.Level > 1 {
+//	    // extra debug output
+//	}
+type Verbose struct {
+	Level int `flag:"verbose" flagshort:"v" flagtype:"count" flagdescr:"Increase verbosity (-v, -vv, -vvv)" default:"0"`
+}
+
+// Attach implements [structcli.Options].
+func (o *Verbose) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("verbose"); f != nil {
+		_ = c.Flags().SetAnnotation("verbose", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/verbose_test.go
+++ b/flagkit/verbose_test.go
@@ -1,0 +1,101 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Verbose tests ---
+
+func TestVerbose_DefaultZero(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 0, opts.Level)
+}
+
+func TestVerbose_SingleV(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-v"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 1, opts.Level)
+}
+
+func TestVerbose_DoubleV(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-v", "-v"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 2, opts.Level)
+}
+
+func TestVerbose_LongFlag(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--verbose", "--verbose", "--verbose"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 3, opts.Level)
+}
+
+func TestVerbose_Standalone(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("verbose")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "v", f.Shorthand)
+	assert.Contains(t, f.Usage, "Increase verbosity")
+}
+
+func TestVerbose_Annotation(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("verbose")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestVerbose_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.Verbose{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestVerbose_Embedded(t *testing.T) {
+	type deployOpts struct {
+		flagkit.Verbose
+		Target string `flag:"target" flagdescr:"Deploy target" default:"staging"`
+	}
+	opts := &deployOpts{}
+	cmd := &cobra.Command{Use: "deploy"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"-v", "-v", "--target", "prod"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 2, opts.Verbose.Level)
+	assert.Equal(t, "prod", opts.Target)
+}

--- a/generate/agents.go
+++ b/generate/agents.go
@@ -96,6 +96,9 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 			if desc == "" {
 				desc = "-"
 			}
+			if len(f.Enum) > 0 {
+				desc += fmt.Sprintf(" (%s)", strings.Join(f.Enum, ", "))
+			}
 			fmt.Fprintf(&buf, "| `--%s` | %s | %s | %s |\n", f.Name, f.Type, def, desc)
 		}
 		buf.WriteString("\n")

--- a/generate/agents.go
+++ b/generate/agents.go
@@ -9,7 +9,12 @@ import (
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/jsonschema"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// flagKitAnnotation mirrors [flagkit.FlagKitAnnotation] to avoid a dependency
+// from the generate package on the flagkit package.
+const flagKitAnnotation = "___leodido_structcli_flagkit"
 
 // AgentsOptions configures the AGENTS.md generator.
 type AgentsOptions struct {
@@ -129,6 +134,16 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 	if opts.IncludeMCP {
 		fmt.Fprintf(&buf, "- MCP server: `%s --mcp`\n", cliName)
 	}
+	buf.WriteString("\n")
+
+	// Development Notes — emitted when flagkit types are detected
+	if hasFlagKitFlags(rootCmd) {
+		buf.WriteString("## Development Notes\n\n")
+		buf.WriteString("This CLI uses [structcli](https://github.com/leodido/structcli) with the `flagkit` package\n")
+		buf.WriteString("for common flag patterns. When extending this CLI, prefer embedding `flagkit` types over\n")
+		buf.WriteString("declaring ad-hoc flags for standard concerns (log level, output format, follow/streaming, etc.).\n\n")
+		buf.WriteString("See `go doc github.com/leodido/structcli/flagkit` for available types.\n")
+	}
 
 	return buf.Bytes(), nil
 }
@@ -169,6 +184,30 @@ func requiredFlags(s *structcli.CommandSchema) string {
 		return ""
 	}
 	return strings.Join(req, ", ")
+}
+
+// hasFlagKitFlags walks the command tree and returns true if any flag carries
+// the flagkit annotation, indicating the CLI uses flagkit types.
+func hasFlagKitFlags(root *cobra.Command) bool {
+	found := false
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if found {
+			return
+		}
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			if f.Annotations != nil {
+				if _, ok := f.Annotations[flagKitAnnotation]; ok {
+					found = true
+				}
+			}
+		})
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(root)
+	return found
 }
 
 // findConfigFlagName checks if the root command has a config flag registered

--- a/generate/agents_test.go
+++ b/generate/agents_test.go
@@ -210,6 +210,44 @@ func TestAgents_ZeroFlagCommand(t *testing.T) {
 	assert.NotContains(t, content, "#### `app ping`")
 }
 
+func TestAgents_FlagKitDevNotes(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}
+	root.Flags().Bool("follow", false, "Stream output continuously")
+	// Simulate flagkit annotation
+	require.NoError(t, root.Flags().SetAnnotation("follow", "___leodido_structcli_flagkit", []string{"true"}))
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+	assert.Contains(t, content, "## Development Notes")
+	assert.Contains(t, content, "flagkit")
+	assert.Contains(t, content, "go doc github.com/leodido/structcli/flagkit")
+}
+
+func TestAgents_NoFlagKitDevNotes(t *testing.T) {
+	root := buildTestTree()
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "## Development Notes")
+}
+
+func TestAgents_FlagKitDevNotesOnSubcommand(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{Use: "app", Short: "A CLI"}
+	sub := &cobra.Command{Use: "logs", Short: "Show logs", RunE: noop}
+	sub.Flags().Bool("follow", false, "Stream output continuously")
+	require.NoError(t, sub.Flags().SetAnnotation("follow", "___leodido_structcli_flagkit", []string{"true"}))
+	root.AddCommand(sub)
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "## Development Notes")
+}
+
 // --- helpers ---
 
 func extractSection(content, heading string) string {

--- a/generate/agents_test.go
+++ b/generate/agents_test.go
@@ -210,6 +210,20 @@ func TestAgents_ZeroFlagCommand(t *testing.T) {
 	assert.NotContains(t, content, "#### `app ping`")
 }
 
+func TestAgents_EnumValuesInDescription(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}
+	root.Flags().String("output", "text", "Output format")
+	// Simulate enum annotation (as structcli sets it for registered enums)
+	require.NoError(t, root.Flags().SetAnnotation("output", "___leodido_structcli_flagenum", []string{"json", "text", "yaml"}))
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+	assert.Contains(t, content, "Output format (json, text, yaml)")
+}
+
 func TestAgents_FlagKitDevNotes(t *testing.T) {
 	noop := func(cmd *cobra.Command, args []string) error { return nil }
 	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}


### PR DESCRIPTION
## Description

Add the final two flagkit types, completing the planned taxonomy:

- **`TimeoutOpt`** — `--timeout` duration flag (`Duration` field, default 30s, env-bindable). Named `TimeoutOpt` to avoid mapstructure collision (same pattern as `OutputFmt`).
- **`Quiet`** — `--quiet`/`-q` bool flag (`Enabled` field, default false). Suppresses non-essential output.

### End-to-end example

Upgrades `examples/full` logs subcommand to demonstrate multi-type composition:
- `Follow` + `OutputFmt` + `TimeoutOpt` + `Quiet` + app-specific `Service`
- Per-command format restriction via `RestrictFormats` (narrows help/JSON Schema to text+json)
- Per-command runtime validation via `ValidFormat`
- `RegisterOutputFormats` in `init()` for CLI-wide format vocabulary

```bash
full logs -s api                                 # defaults: text, 30s, no follow
full logs -s api --follow -o json --timeout 10s  # streaming, json, 10s
full logs -s api -q                              # quiet mode
full logs -s api -o yaml                         # error: unsupported format
full logs --help                                 # shows {text,json}, not {json,text,yaml}
```

### Review follow-up commits

- `903566f` — `RestrictFormats` method on `OutputFmt`: narrows help text and enum annotation per-command so the declared contract matches `ValidFormat`. Shell completion still shows the superset (cobra limitation).
- `095a125` — Documents the `OutputFmt`/`TimeoutOpt` naming convention and the underlying Unmarshal limitation in `doc.go`.

### Known limitation

`OutputFmt` and `TimeoutOpt` use suffixed names because mapstructure decodes the flag value string into the embedded struct when the struct name matches the flag name (case-insensitive). This also affects generated env var names (e.g., `APP_TIMEOUTOPT_DURATION`). A future structcli Unmarshal fix will allow natural wrapper names.

All 9 flagkit types now available. 79 tests, 100% coverage across all types.

### Stacked on

- #122 (`ld/flagkit-verbose-dryrun`)
- #121 (`ld/flagkit-output`)
- #120 (`ld/flagkit-loglevel`)
- #119 (`ld/flagkit-follow`)

## How to test

```bash
# Full flagkit suite (79 tests, 100% coverage)
go test -v -cover ./flagkit/...

# Full suite
go test ./...

# End-to-end example
cd examples/full
go run main.go logs --help           # should show {text,json}
go run main.go logs --jsonschema     # enum should be ["text","json"]
go run main.go logs -s api
go run main.go logs -s api --follow -o json --timeout 10s
go run main.go logs -s api -o yaml   # should error
```