### PR TITLE
feat: add flagkit.Timeout and flagkit.Quiet types

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,8 @@ Available types:
 | `OutputFmt` | `--output` / `-o` | `text` | Output format (string enum, user-registered) |
 | `Verbose` | `--verbose` / `-v` | `0` | Verbosity count (`-v`, `-vv`, `-vvv`) |
 | `DryRun` | `--dry-run` | `false` | Preview without making changes |
+| `TimeoutOpt` | `--timeout` | `30s` | Operation timeout (`time.Duration`) |
+| `Quiet` | `--quiet` / `-q` | `false` | Suppress non-essential output |
 
 When the `generate` package detects flagkit annotations, it emits a "Development Notes" section in AGENTS.md guiding AI coding agents to prefer flagkit types over ad-hoc flag declarations.
 

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -35,7 +35,7 @@ go install github.com/leodido/structcli/examples/full@latest
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--follow` | bool | false | Stream output continuously |
-| `--output` | string | text | Output format |
+| `--output` | string | text | Output format (text, json) |
 | `--quiet` | bool | false | Suppress non-essential output |
 | `--service` | string | - | Service name to show logs for |
 | `--timeout` | duration | 30s | Operation timeout |
@@ -62,9 +62,9 @@ go install github.com/leodido/structcli/examples/full@latest
 | `--deeper-setting` | string | default-deeper-setting | - |
 | `--host` | string | localhost | Server host |
 | `--log-file` | string | - | Log file path |
-| `--log-level` | zapcore.Level | info | Set log level |
+| `--log-level` | zapcore.Level | info | Set log level (debug, info, warn, error, dpanic, panic, fatal) |
 | `--port` | int | 0 | Server port |
-| `--target-env` | string | dev | Set the target environment |
+| `--target-env` | string | dev | Set the target environment (dev, prod, staging) |
 | `--token-base64` | bytesBase64 | aGVsbG8= | Token bytes encoded as base64 |
 | `--token-hex` | bytesHex | 68656c6c6f | Token bytes encoded as hex |
 | `--trusted-peers` | ipSlice | 127.0.0.2,127.0.0.3 | Trusted peer IPs (comma separated) |

--- a/examples/full/AGENTS.md
+++ b/examples/full/AGENTS.md
@@ -35,7 +35,10 @@ go install github.com/leodido/structcli/examples/full@latest
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--follow` | bool | false | Stream output continuously |
+| `--output` | string | text | Output format |
+| `--quiet` | bool | false | Suppress non-essential output |
 | `--service` | string | - | Service name to show logs for |
+| `--timeout` | duration | 30s | Operation timeout |
 
 #### `full preset`
 
@@ -89,6 +92,8 @@ go install github.com/leodido/structcli/examples/full@latest
 |----------|------|---------|
 | `FULL_DRY` | `--dry` | false |
 | `FULL_DRYRUN` | `--dry` | false |
+| `FULL_LOGS_TIMEOUT` | `--timeout` | 30s |
+| `FULL_LOGS_TIMEOUTOPT_DURATION` | `--timeout` | 30s |
 | `FULL_SRV_ADVERTISECIDR` | `--advertise-cidr` | 127.0.0.0/24 |
 | `FULL_SRV_ADVERTISE_CIDR` | `--advertise-cidr` | 127.0.0.0/24 |
 | `FULL_SRV_APIKEY` | `--apikey` | - |

--- a/examples/full/SKILL.md
+++ b/examples/full/SKILL.md
@@ -40,14 +40,25 @@ Display logs for a service, optionally streaming with --follow
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
 | `--follow` | bool | false | no | Stream output continuously |
+| `--output` | string | text | no | Output format |
+| `--quiet` | bool | false | no | Suppress non-essential output |
 | `--service` | string | - | yes | Service name to show logs for |
+| `--timeout` | duration | 30s | no | Operation timeout |
+
+**Environment Variables:**
+
+| Variable | Flag | Description |
+|----------|------|-------------|
+| `FULL_LOGS_TIMEOUTOPT_DURATION` | `--timeout` | Operation timeout |
+| `FULL_LOGS_TIMEOUT` | `--timeout` | Operation timeout |
 
 **Example:**
 
 ```
 full logs --service api
   full logs -s api --follow
-  full logs -s api -f
+  full logs -s api -f -o json --timeout 10s
+  full logs -s api --quiet
 ```
 
 #### `full preset`
@@ -161,5 +172,6 @@ All environment variables use the `FULL_` prefix.
 ```
 full logs --service api
   full logs -s api --follow
-  full logs -s api -f
+  full logs -s api -f -o json --timeout 10s
+  full logs -s api --quiet
 ```

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -32,6 +32,10 @@ func init() {
 		EnvStaging:    {"staging", "stage"},
 		EnvProduction: {"prod", "production"},
 	})
+
+	// Register the output formats this CLI supports (superset across all commands).
+	// Individual commands use ValidFormat() to restrict to their subset.
+	flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
 }
 
 type EvenDeeper struct {
@@ -283,9 +287,13 @@ func makePresetC() *cobra.Command {
 	return presetC
 }
 
-// LogsOptions demonstrates flagkit.Follow composition.
+// LogsOptions demonstrates flagkit composition with multiple types.
+// Combines Follow, OutputFmt, TimeoutOpt, and Quiet with an app-specific Service flag.
 type LogsOptions struct {
 	flagkit.Follow
+	flagkit.OutputFmt
+	flagkit.TimeoutOpt
+	flagkit.Quiet
 	Service string `flag:"service" flagshort:"s" flagdescr:"Service name to show logs for" flagrequired:"true"`
 }
 
@@ -307,15 +315,24 @@ func makeLogsC() *cobra.Command {
 		Long:  "Display logs for a service, optionally streaming with --follow",
 		Example: `  full logs --service api
   full logs -s api --follow
-  full logs -s api -f`,
+  full logs -s api -f -o json --timeout 10s
+  full logs -s api --quiet`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := structcli.Unmarshal(c, opts); err != nil {
 				return err
 			}
-			if opts.Follow.Enabled {
-				fmt.Fprintf(c.OutOrStdout(), "Streaming logs for service %q...\n", opts.Service)
-			} else {
-				fmt.Fprintf(c.OutOrStdout(), "Showing recent logs for service %q\n", opts.Service)
+			// Per-command format validation: logs only supports text and json
+			if err := opts.OutputFmt.ValidFormat(flagkit.OutputText, flagkit.OutputJSON); err != nil {
+				return err
+			}
+			if !opts.Quiet.Enabled {
+				if opts.Follow.Enabled {
+					fmt.Fprintf(c.OutOrStdout(), "Streaming logs for service %q (timeout %s, format %s)...\n",
+						opts.Service, opts.TimeoutOpt.Duration, opts.OutputFmt.Format)
+				} else {
+					fmt.Fprintf(c.OutOrStdout(), "Showing recent logs for service %q (format %s)\n",
+						opts.Service, opts.OutputFmt.Format)
+				}
 			}
 			fmt.Fprintln(c.OutOrStdout(), pretty(opts))
 

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -321,8 +321,8 @@ func makeLogsC() *cobra.Command {
 			if err := structcli.Unmarshal(c, opts); err != nil {
 				return err
 			}
-			// Per-command format validation: logs only supports text and json
-			if err := opts.OutputFmt.ValidFormat(flagkit.OutputText, flagkit.OutputJSON); err != nil {
+			// Per-command format validation — uses the set from RestrictFormats
+			if err := opts.OutputFmt.ValidFormat(); err != nil {
 				return err
 			}
 			if !opts.Quiet.Enabled {

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -340,6 +340,8 @@ func makeLogsC() *cobra.Command {
 		},
 	}
 	opts.Attach(logsC)
+	// Narrow help/completion/schema to the formats this command supports.
+	opts.OutputFmt.RestrictFormats(logsC, flagkit.OutputText, flagkit.OutputJSON)
 
 	return logsC
 }

--- a/examples/full/llms.txt
+++ b/examples/full/llms.txt
@@ -34,7 +34,15 @@ Display logs for a service, optionally streaming with --follow
 ### Flags
 
 - `--follow` (bool, default: false): Stream output continuously
+- `--output` (string, default: text): Output format
+- `--quiet` (bool, default: false): Suppress non-essential output
 - `--service` (string, required): Service name to show logs for
+- `--timeout` (duration, default: 30s): Operation timeout
+
+### Environment Variables
+
+- `FULL_LOGS_TIMEOUTOPT_DURATION`: maps to `--timeout`
+- `FULL_LOGS_TIMEOUT`: maps to `--timeout`
 
 ## full preset
 

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -52,4 +52,19 @@
 //	    flagkit.AnnotateCommand(c)
 //	    return nil
 //	}
+//
+// # Naming Convention
+//
+// Most types use the flag name as the struct name (Follow, Quiet, DryRun, Verbose).
+// Two types use suffixed names to avoid a mapstructure decoding collision when
+// embedded — the flag name would match the struct name (case-insensitive) and
+// break viper Unmarshal for non-primitive field types:
+//
+//   - [OutputFmt] (not Output) — flag "output", field Format
+//   - [TimeoutOpt] (not Timeout) — flag "timeout", field Duration
+//
+// This also means generated env var names include the struct name
+// (e.g., APP_TIMEOUTOPT_DURATION). A future structcli Unmarshal fix will
+// allow natural wrapper names; see https://github.com/leodido/structcli/issues
+// for tracking.
 package flagkit

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -30,8 +30,8 @@
 //	OutputFmt      --output/-o   text     available
 //	Verbose        --verbose/-v  0        available
 //	DryRun         --dry-run     false    available
-//	TimeoutOpt     --timeout     30s      planned (PR 5)
-//	Quiet          --quiet/-q    false    planned (PR 5)
+//	TimeoutOpt     --timeout     30s      available
+//	Quiet          --quiet/-q    false    available
 //
 // # Composition
 //
@@ -39,6 +39,9 @@
 //
 //	type LogOptions struct {
 //	    flagkit.Follow
+//	    flagkit.LogLevel
+//	    flagkit.OutputFmt
+//	    flagkit.Quiet
 //	    Service string `flag:"service" flagdescr:"Service name"`
 //	}
 //

--- a/flagkit/follow.go
+++ b/flagkit/follow.go
@@ -29,6 +29,11 @@ func registerFlag(name string) {
 // For embedded usage, [structcli.Define] traverses into the embedded
 // struct but does not call its Attach method, so AnnotateCommand
 // must be called explicitly to set the annotation.
+//
+// Matching is by flag name, not by type. If the command defines a
+// non-flagkit flag whose name collides with a flagkit flag name
+// (e.g. a custom --follow), it will be incorrectly annotated.
+// Only call this on commands that embed flagkit types.
 func AnnotateCommand(c *cobra.Command) {
 	for _, name := range flagKitFlags {
 		if f := c.Flags().Lookup(name); f != nil {

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -2,10 +2,14 @@ package flagkit
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
 )
+
+// flagEnumAnnotation mirrors the structcli annotation key for enum values.
+const flagEnumAnnotation = "___leodido_structcli_flagenum"
 
 func init() {
 	registerFlag("output")
@@ -55,14 +59,18 @@ func RegisterOutputFormats(formats ...OutputFormat) {
 // via [RegisterOutputFormats] or [structcli.RegisterEnum].
 //
 // For CLIs where different commands support different format subsets,
-// register the superset globally and use [OutputFmt.ValidFormat] per command:
+// register the superset globally, then call [OutputFmt.RestrictFormats] after
+// Attach to narrow help/completion/schema, and [OutputFmt.ValidFormat] in RunE:
 //
 //	func init() {
 //	    // Global: register all formats the CLI knows about
 //	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
 //	}
 //
-//	// Per-command: validate the subset this command supports
+//	// Per-command: restrict help/completion/schema, then validate at runtime
+//	opts.Attach(cmd)
+//	opts.OutputFmt.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputYAML)
+//
 //	func (o *ExportOptions) RunE(cmd *cobra.Command, args []string) error {
 //	    if err := o.ValidFormat(flagkit.OutputJSON, flagkit.OutputYAML); err != nil {
 //	        return err
@@ -89,6 +97,34 @@ func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
 	}
 
 	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
+}
+
+// RestrictFormats narrows the --output flag's help text and enum annotation
+// to only the given formats. Call this after [Attach] or [structcli.Define]
+// to make the command's declared contract (help, JSON Schema) match what
+// [ValidFormat] will accept at runtime.
+//
+// Shell completion may still show the globally registered superset because
+// cobra does not support overriding completion functions after registration.
+//
+//	opts.Attach(cmd)
+//	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+func (o *OutputFmt) RestrictFormats(c *cobra.Command, allowed ...OutputFormat) {
+	f := c.Flags().Lookup("output")
+	if f == nil {
+		return
+	}
+
+	names := make([]string, len(allowed))
+	for i, a := range allowed {
+		names[i] = string(a)
+	}
+
+	// Update the usage string to show only the allowed subset.
+	f.Usage = fmt.Sprintf("Output format {%s}", strings.Join(names, ","))
+
+	// Update the enum annotation used by JSON Schema generation.
+	_ = c.Flags().SetAnnotation("output", flagEnumAnnotation, names)
 }
 
 // Attach implements [structcli.Options].

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -144,14 +144,21 @@ func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
 }
 
 // Attach implements [structcli.Options].
+//
+// Returns an error if the --output flag was not created, which typically
+// means [RegisterOutputFormats] (or [structcli.RegisterEnum]) was not
+// called before Attach.
 func (o *OutputFmt) Attach(c *cobra.Command) error {
 	if err := structcli.Define(c, o); err != nil {
 		return err
 	}
 
-	if f := c.Flags().Lookup("output"); f != nil {
-		_ = c.Flags().SetAnnotation("output", FlagKitAnnotation, []string{"true"})
+	f := c.Flags().Lookup("output")
+	if f == nil {
+		return fmt.Errorf("flagkit: --output flag not created; call RegisterOutputFormats in init() before Attach")
 	}
+
+	_ = c.Flags().SetAnnotation("output", FlagKitAnnotation, []string{"true"})
 
 	return nil
 }

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -53,63 +53,48 @@ func RegisterOutputFormats(formats ...OutputFormat) {
 	structcli.RegisterEnum[OutputFormat](m)
 }
 
-// Output provides a --output/-o flag for selecting output format.
+// OutputFmt provides a --output/-o flag for selecting output format.
 //
 // The default is text. You must register the supported formats before use
 // via [RegisterOutputFormats] or [structcli.RegisterEnum].
 //
 // For CLIs where different commands support different format subsets,
 // register the superset globally, then call [OutputFmt.RestrictFormats] after
-// Attach to narrow help/completion/schema, and [OutputFmt.ValidFormat] in RunE:
+// Attach. RestrictFormats is the single source of truth — it narrows help,
+// JSON Schema, and runtime validation in one call:
 //
 //	func init() {
-//	    // Global: register all formats the CLI knows about
 //	    flagkit.RegisterOutputFormats(flagkit.OutputJSON, flagkit.OutputText, flagkit.OutputYAML)
 //	}
 //
-//	// Per-command: restrict help/completion/schema, then validate at runtime
 //	opts.Attach(cmd)
 //	opts.OutputFmt.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputYAML)
 //
-//	func (o *ExportOptions) RunE(cmd *cobra.Command, args []string) error {
-//	    if err := o.ValidFormat(flagkit.OutputJSON, flagkit.OutputYAML); err != nil {
-//	        return err
-//	    }
-//	    // ...
+//	// In RunE — no args needed, uses the set from RestrictFormats:
+//	if err := opts.OutputFmt.ValidFormat(); err != nil {
+//	    return err
 //	}
 type OutputFmt struct {
-	Format OutputFormat `flag:"output" flagshort:"o" flagdescr:"Output format" default:"text"`
+	Format  OutputFormat `flag:"output" flagshort:"o" flagdescr:"Output format" default:"text"`
+	allowed []OutputFormat
 }
 
-// ValidFormat returns nil if the current output format is one of the allowed
-// formats, or an error describing the mismatch. Use this for per-command
-// format validation when different commands support different subsets.
-func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
-	for _, a := range allowed {
-		if o.Format == a {
-			return nil
-		}
-	}
-
-	names := make([]string, len(allowed))
-	for i, a := range allowed {
-		names[i] = string(a)
-	}
-
-	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
-}
-
-// RestrictFormats narrows the --output flag's help text and enum annotation
-// to only the given formats. Call this after [Attach] or [structcli.Define]
-// to make the command's declared contract (help, JSON Schema) match what
-// [ValidFormat] will accept at runtime.
+// RestrictFormats narrows the --output flag's help text, enum annotation,
+// and runtime validation to only the given formats. Call this after [Attach]
+// or [structcli.Define].
+//
+// This is the single source of truth for per-command format subsets.
+// After calling RestrictFormats, [ValidFormat] with no arguments enforces
+// the same set, eliminating the need to repeat the allowed list.
 //
 // Shell completion may still show the globally registered superset because
 // cobra does not support overriding completion functions after registration.
 //
 //	opts.Attach(cmd)
-//	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+//	opts.OutputFmt.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
 func (o *OutputFmt) RestrictFormats(c *cobra.Command, allowed ...OutputFormat) {
+	o.allowed = allowed
+
 	f := c.Flags().Lookup("output")
 	if f == nil {
 		return
@@ -125,6 +110,37 @@ func (o *OutputFmt) RestrictFormats(c *cobra.Command, allowed ...OutputFormat) {
 
 	// Update the enum annotation used by JSON Schema generation.
 	_ = c.Flags().SetAnnotation("output", flagEnumAnnotation, names)
+}
+
+// ValidFormat returns nil if the current output format is allowed, or an
+// error describing the mismatch.
+//
+// When called with no arguments, it validates against the set stored by
+// [RestrictFormats]. When called with explicit arguments, it validates
+// against those instead (and ignores any stored restriction).
+//
+// If neither RestrictFormats was called nor explicit arguments are provided,
+// ValidFormat returns nil (all formats accepted).
+func (o *OutputFmt) ValidFormat(allowed ...OutputFormat) error {
+	if len(allowed) == 0 {
+		allowed = o.allowed
+	}
+	if len(allowed) == 0 {
+		return nil // no restriction
+	}
+
+	for _, a := range allowed {
+		if o.Format == a {
+			return nil
+		}
+	}
+
+	names := make([]string, len(allowed))
+	for i, a := range allowed {
+		names[i] = string(a)
+	}
+
+	return fmt.Errorf("unsupported output format %q (allowed: %v)", o.Format, names)
 }
 
 // Attach implements [structcli.Options].

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -155,6 +155,57 @@ func TestOutput_ValidFormat_SingleAllowed(t *testing.T) {
 	assert.NoError(t, opts.ValidFormat(flagkit.OutputText))
 }
 
+// --- RestrictFormats tests ---
+
+func TestOutputFmt_RestrictFormats_Usage(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	assert.Equal(t, "Output format {json,text}", f.Usage)
+}
+
+func TestOutputFmt_RestrictFormats_Annotation(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations["___leodido_structcli_flagenum"]
+	assert.True(t, ok, "enum annotation should be set")
+	assert.Equal(t, []string{"json", "text"}, ann)
+}
+
+func TestOutputFmt_RestrictFormats_JSONSchema(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	fs, ok := schemas[0].Flags["output"]
+	require.True(t, ok)
+	assert.Equal(t, []string{"json", "text"}, fs.Enum)
+}
+
+func TestOutputFmt_RestrictFormats_NoFlag(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	// Don't call Attach — no flag registered
+	opts.RestrictFormats(cmd, flagkit.OutputJSON) // should not panic
+}
+
 // --- RegisterOutputFormats tests ---
 
 func TestRegisterOutputFormats_PanicsOnDuplicate(t *testing.T) {

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -155,6 +155,48 @@ func TestOutput_ValidFormat_SingleAllowed(t *testing.T) {
 	assert.NoError(t, opts.ValidFormat(flagkit.OutputText))
 }
 
+func TestOutput_ValidFormat_NoRestriction(t *testing.T) {
+	// No RestrictFormats called, no explicit args — all formats accepted.
+	opts := &flagkit.OutputFmt{Format: flagkit.OutputYAML}
+	assert.NoError(t, opts.ValidFormat())
+}
+
+func TestOutput_ValidFormat_UsesRestrictFormats(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	// Set format to an allowed value — should pass with no args.
+	opts.Format = flagkit.OutputJSON
+	assert.NoError(t, opts.ValidFormat())
+
+	// Set format to a disallowed value — should fail with no args.
+	opts.Format = flagkit.OutputYAML
+	err := opts.ValidFormat()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "yaml")
+}
+
+func TestOutput_ValidFormat_ExplicitOverridesStored(t *testing.T) {
+	opts := &flagkit.OutputFmt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	// Restrict to json+text via RestrictFormats.
+	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
+
+	// Explicit args override the stored set — yaml is allowed here.
+	opts.Format = flagkit.OutputYAML
+	assert.NoError(t, opts.ValidFormat(flagkit.OutputYAML, flagkit.OutputJSON))
+
+	// But text is not in the explicit set.
+	opts.Format = flagkit.OutputText
+	err := opts.ValidFormat(flagkit.OutputYAML, flagkit.OutputJSON)
+	assert.Error(t, err)
+}
+
 // --- RestrictFormats tests ---
 
 func TestOutputFmt_RestrictFormats_Usage(t *testing.T) {

--- a/flagkit/quiet.go
+++ b/flagkit/quiet.go
@@ -1,0 +1,43 @@
+package flagkit
+
+import (
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("quiet")
+}
+
+// Quiet provides a --quiet/-q flag for suppressing non-essential output.
+//
+// The default is false. When true, commands should only emit machine-readable
+// output (e.g., IDs, status codes) and suppress progress messages, banners,
+// and decorative formatting.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.Quiet
+//	}
+//
+//	// In RunE:
+//	if !opts.Quiet.Enabled {
+//	    fmt.Println("Deploying to production...")
+//	}
+type Quiet struct {
+	Enabled bool `flag:"quiet" flagshort:"q" flagdescr:"Suppress non-essential output" default:"false"`
+}
+
+// Attach implements [structcli.Options].
+func (o *Quiet) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("quiet"); f != nil {
+		_ = c.Flags().SetAnnotation("quiet", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/quiet_test.go
+++ b/flagkit/quiet_test.go
@@ -1,0 +1,115 @@
+package flagkit_test
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Quiet tests ---
+
+func TestQuiet_DefaultFalse(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestQuiet_ExplicitTrue(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--quiet"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestQuiet_ShortFlag(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"-q"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Enabled)
+}
+
+func TestQuiet_ExplicitFalse(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--quiet=false"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.False(t, opts.Enabled)
+}
+
+func TestQuiet_Standalone(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("quiet")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "q", f.Shorthand)
+	assert.Equal(t, "false", f.DefValue)
+	assert.Equal(t, "Suppress non-essential output", f.Usage)
+}
+
+func TestQuiet_Annotation(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("quiet")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestQuiet_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestQuiet_Embedded(t *testing.T) {
+	type buildOpts struct {
+		flagkit.Quiet
+		Target string `flag:"target" flagdescr:"Build target" default:"all"`
+	}
+	opts := &buildOpts{}
+	cmd := &cobra.Command{Use: "build"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"-q", "--target", "linux"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.True(t, opts.Quiet.Enabled)
+	assert.Equal(t, "linux", opts.Target)
+}
+
+func TestQuiet_JSONSchema(t *testing.T) {
+	opts := &flagkit.Quiet{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["quiet"]
+	assert.True(t, ok, "JSON schema should include the quiet flag")
+}

--- a/flagkit/timeout.go
+++ b/flagkit/timeout.go
@@ -1,0 +1,43 @@
+package flagkit
+
+import (
+	"time"
+
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerFlag("timeout")
+}
+
+// Timeout provides a --timeout flag for operation deadlines.
+//
+// The default is 30s. Accepts any value parseable by [time.ParseDuration].
+// This is agent-friendly — operations won't hang indefinitely.
+//
+// Usage:
+//
+//	type Options struct {
+//	    flagkit.TimeoutOpt
+//	}
+//
+//	// In RunE:
+//	ctx, cancel := context.WithTimeout(ctx, opts.TimeoutOpt.Duration)
+//	defer cancel()
+type TimeoutOpt struct {
+	Duration time.Duration `flag:"timeout" flagdescr:"Operation timeout" default:"30s" flagenv:"true"`
+}
+
+// Attach implements [structcli.Options].
+func (o *TimeoutOpt) Attach(c *cobra.Command) error {
+	if err := structcli.Define(c, o); err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup("timeout"); f != nil {
+		_ = c.Flags().SetAnnotation("timeout", FlagKitAnnotation, []string{"true"})
+	}
+
+	return nil
+}

--- a/flagkit/timeout_test.go
+++ b/flagkit/timeout_test.go
@@ -1,0 +1,106 @@
+package flagkit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/flagkit"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Timeout tests ---
+
+func TestTimeout_Default30s(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 30*time.Second, opts.Duration)
+}
+
+func TestTimeout_Set10s(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--timeout", "10s"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 10*time.Second, opts.Duration)
+}
+
+func TestTimeout_Set5m(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+	require.NoError(t, cmd.Flags().Parse([]string{"--timeout", "5m"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 5*time.Minute, opts.Duration)
+}
+
+func TestTimeout_Standalone(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("timeout")
+	require.NotNil(t, f, "flag should be registered")
+	assert.Equal(t, "", f.Shorthand)
+	assert.Equal(t, "30s", f.DefValue)
+	assert.Equal(t, "Operation timeout", f.Usage)
+}
+
+func TestTimeout_Annotation(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	f := cmd.Flags().Lookup("timeout")
+	require.NotNil(t, f)
+	ann, ok := f.Annotations[flagkit.FlagKitAnnotation]
+	assert.True(t, ok, "flagkit annotation should be set")
+	assert.Equal(t, []string{"true"}, ann)
+}
+
+func TestTimeout_Attach_ErrorOnDuplicate(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	err := opts.Attach(cmd)
+	assert.Error(t, err)
+}
+
+func TestTimeout_Embedded(t *testing.T) {
+	type fetchOpts struct {
+		flagkit.TimeoutOpt
+		URL string `flag:"url" flagdescr:"URL to fetch" flagrequired:"true"`
+	}
+	opts := &fetchOpts{}
+	cmd := &cobra.Command{Use: "fetch"}
+	require.NoError(t, structcli.Define(cmd, opts))
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--timeout", "2m", "--url", "https://example.com"}))
+	require.NoError(t, structcli.Unmarshal(cmd, opts))
+
+	assert.Equal(t, 2*time.Minute, opts.TimeoutOpt.Duration)
+	assert.Equal(t, "https://example.com", opts.URL)
+}
+
+func TestTimeout_JSONSchema(t *testing.T) {
+	opts := &flagkit.TimeoutOpt{}
+	cmd := &cobra.Command{Use: "app"}
+	require.NoError(t, opts.Attach(cmd))
+
+	schemas, err := structcli.JSONSchema(cmd)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	_, ok := schemas[0].Flags["timeout"]
+	assert.True(t, ok, "JSON schema should include the timeout flag")
+}

--- a/generate/agents.go
+++ b/generate/agents.go
@@ -96,6 +96,9 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 			if desc == "" {
 				desc = "-"
 			}
+			if len(f.Enum) > 0 {
+				desc += fmt.Sprintf(" (%s)", strings.Join(f.Enum, ", "))
+			}
 			fmt.Fprintf(&buf, "| `--%s` | %s | %s | %s |\n", f.Name, f.Type, def, desc)
 		}
 		buf.WriteString("\n")

--- a/generate/agents_test.go
+++ b/generate/agents_test.go
@@ -210,6 +210,20 @@ func TestAgents_ZeroFlagCommand(t *testing.T) {
 	assert.NotContains(t, content, "#### `app ping`")
 }
 
+func TestAgents_EnumValuesInDescription(t *testing.T) {
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}
+	root.Flags().String("output", "text", "Output format")
+	// Simulate enum annotation (as structcli sets it for registered enums)
+	require.NoError(t, root.Flags().SetAnnotation("output", "___leodido_structcli_flagenum", []string{"json", "text", "yaml"}))
+
+	out, err := generate.Agents(root, generate.AgentsOptions{})
+	require.NoError(t, err)
+
+	content := string(out)
+	assert.Contains(t, content, "Output format (json, text, yaml)")
+}
+
 func TestAgents_FlagKitDevNotes(t *testing.T) {
 	noop := func(cmd *cobra.Command, args []string) error { return nil }
 	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}


### PR DESCRIPTION
## Description

Add the final two flagkit types, completing the taxonomy:

- **`TimeoutOpt`** — `--timeout` duration flag (`Duration` field, default 30s, env-bindable)
- **`Quiet`** — `--quiet`/`-q` bool flag (`Enabled` field, default false)

Includes end-to-end example in `examples/full` logs subcommand, `RestrictFormats`/`ValidFormat` unification, review fixes, and AGENTS.md enum values.

Replaces #123 (closed when base branch was deleted during stack merge).

## How to test

```bash
go test -v -cover ./flagkit/...
go test ./...
```