### PR TITLE
chore: clean up pre-existing leftovers

### DIFF
--- a/define_test.go
+++ b/define_test.go
@@ -436,7 +436,7 @@ const (
 )
 
 type comprehensiveCustomOptions struct {
-	LogLevel   zapcore.Level `flagcustom:"true" flagdescr:"log level"`
+	LogLevel   zapcore.Level `flagdescr:"log level"`
 	ServerMode serverMode    `flagcustom:"true" flag:"server-mode" flagshort:"m" flagdescr:"set server mode"`
 	SomeConfig string        `flagcustom:"true" flag:"some-config" flagshort:"c" flagdescr:"config file path"`
 	NormalFlag string        `flag:"normal-flag" flagdescr:"normal description"`
@@ -3530,14 +3530,14 @@ func (suite *structcliSuite) TestDefine_EnumAnnotation_BuiltInZapcoreLevel() {
 }
 
 type enumCustomHookOptions struct {
-	LogLevel zapcore.Level `flagcustom:"true" flagdescr:"log level"`
+	LogLevel zapcore.Level `flagdescr:"log level"`
 }
 
 func (o *enumCustomHookOptions) Attach(c *cobra.Command) error { return nil }
 
-func (suite *structcliSuite) TestDefine_EnumAnnotation_CustomHookFallbackToBuiltIn() {
-	// When flagcustom:"true" is set but no DefineLogLevel method exists,
-	// the built-in zapcore.Level hook is used (which adds the enum pattern).
+func (suite *structcliSuite) TestDefine_EnumAnnotation_BuiltInHook() {
+	// zapcore.Level is registered via RegisterEnum, so the built-in hook
+	// handles it without flagcustom:"true".
 	opts := &enumCustomHookOptions{}
 	cmd := &cobra.Command{Use: "test"}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/thediveo/enumflag/v2 v2.0.7
 	go.uber.org/zap v1.27.0
+	pgregory.net/rapid v1.2.0
 )
 
 require (
@@ -40,5 +41,4 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	pgregory.net/rapid v1.2.0 // indirect
 )

--- a/integration_test.go
+++ b/integration_test.go
@@ -2258,7 +2258,7 @@ func (o *customDecodeHookOptions) Attach(c *cobra.Command) error { return struct
 type mixedHooksOptions struct {
 	ServerMode ServerMode1   `flagcustom:"true" flag:"server-mode" flagdescr:"Server mode"`
 	Timeout    time.Duration `flag:"timeout" flagdescr:"Request timeout"`
-	LogLevel   zapcore.Level `flagcustom:"true" flag:"log-level" flagdescr:"Log level"`
+	LogLevel   zapcore.Level `flag:"log-level" flagdescr:"Log level"`
 }
 
 // Implement the custom methods for ServerMode


### PR DESCRIPTION
## Description

Two minor leftovers found during post-merge review of the flagkit stack. Neither was introduced by PRs #119–#124.

1. **`go.mod`**: `pgregory.net/rapid` was marked `// indirect` but is imported directly by `internal/proptest/gen/generators.go`. `go mod tidy` promotes it.

2. **Test structs**: Three test structs had `flagcustom:"true"` on `zapcore.Level` fields. The tag is unnecessary since `zapcore.Level` is registered via `RegisterEnum` (PR #117) and the built-in hook handles it. Removed the tag and updated the test name/comment.

## How to test

```bash
go test ./... -count=1
```