### PR TITLE
feat: add JSON debug output and source attribution for `UseDebug`

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -47,8 +47,11 @@ func SetupDebug(rootC *cobra.Command, debugOpts debug.Options) error {
 	}
 	rootC.Annotations[internaldebug.FlagAnnotation] = flagName
 
-	// Add persistent flag to root command
-	rootC.PersistentFlags().Bool(flagName, false, "enable debug output for options")
+	// Add persistent flag to root command.
+	// NoOptDefVal makes bare --debug-options (no value) default to "text",
+	// preserving backward compatibility with the old bool flag.
+	rootC.PersistentFlags().String(flagName, "", "debug output format (text, json)")
+	rootC.PersistentFlags().Lookup(flagName).NoOptDefVal = "text"
 
 	// Add environment annotation
 	mustSetAnnotation(rootC.PersistentFlags(), flagName, internalenv.FlagAnnotation, []string{envvName})

--- a/debug.go
+++ b/debug.go
@@ -1,15 +1,20 @@
 package structcli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/leodido/structcli/debug"
 	internalcmd "github.com/leodido/structcli/internal/cmd"
 	internaldebug "github.com/leodido/structcli/internal/debug"
 	internalenv "github.com/leodido/structcli/internal/env"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 // SetupDebug creates the --debug-options global flag and sets up debug behavior.
@@ -87,20 +92,136 @@ func IsDebugActive(c *cobra.Command) bool {
 
 // UseDebug manually triggers debug output for the given options.
 //
+// When --debug-options=json, output goes to w as a JSON object.
+// When --debug-options or --debug-options=text, output goes to w
+// as a human-readable table.
+//
 // Debug output is automatically triggered when the debug flag is enabled.
 func UseDebug(c *cobra.Command, w io.Writer) {
-	if !IsDebugActive(c) {
+	format := internaldebug.GetFormat(c)
+	if format == "" {
 		return
 	}
 
-	var dest io.Writer
-	dest = os.Stdout
-	if w != nil {
-		dest = w
+	v := GetViper(c)
+	configV := GetConfigViper(c)
+
+	switch format {
+	case "json":
+		writeDebugJSON(c, v, configV, w)
+	default:
+		writeDebugText(c, v, configV, w)
+	}
+}
+
+// debugFlagState represents a single flag's resolved state.
+type debugFlagState struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	Default string `json:"default"`
+	Changed bool   `json:"changed"`
+	Source  string `json:"source"`
+}
+
+// debugOutput is the top-level JSON structure for debug output.
+type debugOutput struct {
+	Command string            `json:"command"`
+	Flags   []debugFlagState  `json:"flags"`
+	Values  map[string]any    `json:"values"`
+}
+
+func collectFlagStates(c *cobra.Command, configV *viper.Viper) []debugFlagState {
+	var states []debugFlagState
+
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		source := internaldebug.ResolveFlagSource(f, configV)
+		states = append(states, debugFlagState{
+			Name:    f.Name,
+			Value:   f.Value.String(),
+			Default: f.DefValue,
+			Changed: f.Changed,
+			Source:  string(source),
+		})
+	})
+
+	// Sort by name for deterministic output.
+	sort.Slice(states, func(i, j int) bool {
+		return states[i].Name < states[j].Name
+	})
+
+	return states
+}
+
+func writeDebugJSON(c *cobra.Command, v *viper.Viper, configV *viper.Viper, w io.Writer) {
+	out := debugOutput{
+		Command: c.CommandPath(),
+		Flags:   collectFlagStates(c, configV),
+		Values:  v.AllSettings(),
 	}
 
-	// The action of printing debug info is local
-	v := GetViper(c)
-	v.DebugTo(dest)
-	fmt.Fprintf(dest, "Values:\n%#v\n", v.AllSettings())
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
+}
+
+func writeDebugText(c *cobra.Command, v *viper.Viper, configV *viper.Viper, w io.Writer) {
+	fmt.Fprintf(w, "Command: %s\n\n", c.CommandPath())
+
+	states := collectFlagStates(c, configV)
+
+	if len(states) > 0 {
+		// Compute column widths for alignment.
+		maxName, maxVal := 0, 0
+		for _, s := range states {
+			flagStr := "--" + s.Name
+			if len(flagStr) > maxName {
+				maxName = len(flagStr)
+			}
+			if len(s.Value) > maxVal {
+				maxVal = len(s.Value)
+			}
+		}
+
+		fmt.Fprintln(w, "Flags:")
+		for _, s := range states {
+			flagStr := "--" + s.Name
+			sourceStr := formatSource(s, c)
+			fmt.Fprintf(w, "  %-*s  %-*s  (%s)\n", maxName, flagStr, maxVal, s.Value, sourceStr)
+		}
+		fmt.Fprintln(w)
+	}
+
+	settings := v.AllSettings()
+	if len(settings) > 0 {
+		keys := make([]string, 0, len(settings))
+		for k := range settings {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		fmt.Fprintln(w, "Values:")
+		for _, k := range keys {
+			fmt.Fprintf(w, "  %s: %v\n", k, settings[k])
+		}
+	}
+}
+
+// formatSource returns a human-readable source label for text output.
+// For env sources, it includes the env var name.
+func formatSource(s debugFlagState, c *cobra.Command) string {
+	if s.Source != "env" {
+		return s.Source
+	}
+
+	// Look up the env var name from the flag annotation.
+	if f := c.Flags().Lookup(s.Name); f != nil {
+		if envs, ok := f.Annotations[internalenv.FlagAnnotation]; ok && len(envs) > 0 {
+			return "env: " + strings.Join(envs, ", ")
+		}
+	}
+
+	return "env"
 }

--- a/debug_test.go
+++ b/debug_test.go
@@ -1,0 +1,166 @@
+package structcli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/debug"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type debugTestOptions struct {
+	Port    int    `flag:"port" flagdescr:"Listen port" default:"8080" flagenv:"true"`
+	Verbose bool   `flag:"verbose" flagdescr:"Verbose output" default:"false"`
+	Level   string `flag:"log-level" flagdescr:"Log level" default:"info" flagenv:"true"`
+}
+
+func (o *debugTestOptions) Attach(c *cobra.Command) error {
+	return structcli.Define(c, o)
+}
+
+func setupDebugCmd(t *testing.T, args []string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	opts := &debugTestOptions{}
+
+	root := &cobra.Command{Use: "testapp"}
+	cmd := &cobra.Command{
+		Use: "serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Unmarshal triggers UseDebug automatically.
+			return structcli.Unmarshal(cmd, opts)
+		},
+	}
+	root.AddCommand(cmd)
+
+	structcli.SetupDebug(root, debug.Options{AppName: "testapp"})
+	require.NoError(t, opts.Attach(cmd))
+
+	root.SetOut(&buf)
+	root.SetArgs(args)
+
+	return root, &buf
+}
+
+func TestUseDebug_TextOutput(t *testing.T) {
+	root, buf := setupDebugCmd(t, []string{"serve", "--debug-options", "--port", "9090"})
+
+	require.NoError(t, root.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "Command: testapp serve")
+	assert.Contains(t, output, "Flags:")
+	assert.Contains(t, output, "--port")
+	assert.Contains(t, output, "9090")
+	assert.Contains(t, output, "(flag)")
+	assert.Contains(t, output, "Values:")
+}
+
+func TestUseDebug_TextOutput_DefaultSource(t *testing.T) {
+	root, buf := setupDebugCmd(t, []string{"serve", "--debug-options"})
+
+	require.NoError(t, root.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "(default)")
+}
+
+func TestUseDebug_TextOutput_EnvSource(t *testing.T) {
+	t.Setenv("TESTAPP_SERVE_PORT", "7070")
+
+	root, buf := setupDebugCmd(t, []string{"serve", "--debug-options"})
+
+	require.NoError(t, root.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "(env: TESTAPP_SERVE_PORT)")
+}
+
+func TestUseDebug_JSONOutput(t *testing.T) {
+	root, buf := setupDebugCmd(t, []string{"serve", "--debug-options=json", "--port", "9090"})
+	require.NoError(t, root.Execute())
+
+	// Verify valid JSON.
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+
+	// Verify structure.
+	assert.Equal(t, "testapp serve", result["command"])
+	assert.Contains(t, result, "flags")
+	assert.Contains(t, result, "values")
+
+	// Verify flags array.
+	flags, ok := result["flags"].([]any)
+	require.True(t, ok)
+
+	// Find the port flag.
+	var portFlag map[string]any
+	for _, f := range flags {
+		fm := f.(map[string]any)
+		if fm["name"] == "port" {
+			portFlag = fm
+			break
+		}
+	}
+	require.NotNil(t, portFlag, "port flag should be in output")
+	assert.Equal(t, "9090", portFlag["value"])
+	assert.Equal(t, "8080", portFlag["default"])
+	assert.Equal(t, true, portFlag["changed"])
+	assert.Equal(t, "flag", portFlag["source"])
+}
+
+func TestUseDebug_JSONOutput_SourceAttribution(t *testing.T) {
+	t.Setenv("TESTAPP_SERVE_LOG_LEVEL", "debug")
+
+	root, buf := setupDebugCmd(t, []string{"serve", "--debug-options=json", "--port", "9090"})
+	require.NoError(t, root.Execute())
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+
+	flags := result["flags"].([]any)
+
+	sources := map[string]string{}
+	for _, f := range flags {
+		fm := f.(map[string]any)
+		sources[fm["name"].(string)] = fm["source"].(string)
+	}
+
+	assert.Equal(t, "flag", sources["port"], "port was set via --port")
+	assert.Equal(t, "env", sources["log-level"], "log-level was set via TESTAPP_SERVE_LOG_LEVEL")
+	assert.Equal(t, "default", sources["verbose"], "verbose was not set")
+}
+
+func TestUseDebug_EnvVarActivation_JSON(t *testing.T) {
+	t.Setenv("TESTAPP_DEBUG_OPTIONS", "json")
+
+	root, buf := setupDebugCmd(t, []string{"serve"})
+	require.NoError(t, root.Execute())
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Equal(t, "testapp serve", result["command"])
+}
+
+func TestUseDebug_EnvVarActivation_TruthyText(t *testing.T) {
+	t.Setenv("TESTAPP_DEBUG_OPTIONS", "1")
+
+	root, buf := setupDebugCmd(t, []string{"serve"})
+	require.NoError(t, root.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "Command: testapp serve")
+	assert.Contains(t, output, "Flags:")
+}
+
+func TestUseDebug_Inactive(t *testing.T) {
+	root, buf := setupDebugCmd(t, []string{"serve"})
+	require.NoError(t, root.Execute())
+
+	assert.Empty(t, buf.String(), "no debug output when flag not set")
+}

--- a/debug_test.go
+++ b/debug_test.go
@@ -164,3 +164,85 @@ func TestUseDebug_Inactive(t *testing.T) {
 
 	assert.Empty(t, buf.String(), "no debug output when flag not set")
 }
+
+func TestIsDebugActive(t *testing.T) {
+	root, _ := setupDebugCmd(t, []string{"serve", "--debug-options"})
+	require.NoError(t, root.Execute())
+
+	// The public wrapper should reflect the internal state.
+	cmd, _, _ := root.Find([]string{"serve"})
+	assert.True(t, structcli.IsDebugActive(cmd))
+}
+
+func TestIsDebugActive_False(t *testing.T) {
+	root, _ := setupDebugCmd(t, []string{"serve"})
+	require.NoError(t, root.Execute())
+
+	cmd, _, _ := root.Find([]string{"serve"})
+	assert.False(t, structcli.IsDebugActive(cmd))
+}
+
+func TestUseDebug_HiddenFlagsExcluded(t *testing.T) {
+	var buf bytes.Buffer
+	opts := &debugTestOptions{}
+
+	root := &cobra.Command{Use: "testapp"}
+	cmd := &cobra.Command{
+		Use: "serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return structcli.Unmarshal(cmd, opts)
+		},
+	}
+	root.AddCommand(cmd)
+
+	structcli.SetupDebug(root, debug.Options{AppName: "testapp"})
+	require.NoError(t, opts.Attach(cmd))
+
+	// Add a hidden flag after Define.
+	cmd.Flags().String("internal-token", "", "internal use only")
+	cmd.Flags().MarkHidden("internal-token")
+
+	root.SetOut(&buf)
+	root.SetArgs([]string{"serve", "--debug-options", "--internal-token", "secret"})
+	require.NoError(t, root.Execute())
+
+	output := buf.String()
+	assert.NotContains(t, output, "internal-token", "hidden flags should not appear in debug output")
+	assert.NotContains(t, output, "secret", "hidden flag values should not appear in debug output")
+	// Non-hidden flags should still be present.
+	assert.Contains(t, output, "--port")
+}
+
+func TestUseDebug_JSONOutput_HiddenFlagsExcluded(t *testing.T) {
+	// Verify hidden flags are also excluded from JSON output.
+	var buf bytes.Buffer
+	opts := &debugTestOptions{}
+
+	root := &cobra.Command{Use: "testapp"}
+	cmd := &cobra.Command{
+		Use: "serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return structcli.Unmarshal(cmd, opts)
+		},
+	}
+	root.AddCommand(cmd)
+
+	structcli.SetupDebug(root, debug.Options{AppName: "testapp"})
+	require.NoError(t, opts.Attach(cmd))
+
+	cmd.Flags().String("internal-token", "", "internal use only")
+	require.NoError(t, cmd.Flags().MarkHidden("internal-token"))
+
+	root.SetOut(&buf)
+	root.SetArgs([]string{"serve", "--debug-options=json", "--internal-token", "secret"})
+	require.NoError(t, root.Execute())
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+
+	flags := result["flags"].([]any)
+	for _, f := range flags {
+		fm := f.(map[string]any)
+		assert.NotEqual(t, "internal-token", fm["name"], "hidden flags should not appear in JSON output")
+	}
+}

--- a/examples/full/cli/cli_test.go
+++ b/examples/full/cli/cli_test.go
@@ -98,12 +98,10 @@ func TestFullApplication(t *testing.T) {
 			args: []string{"srv", "--debug-options", "-p", "3333"},
 			assertFunc: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
-				assert.Contains(t, output, "Aliases:")
-				assert.Contains(t, output, "PFlags:")
-				assert.Contains(t, output, "Env:")
-				assert.Contains(t, output, "Config:")
-				assert.Contains(t, output, "Defaults:")
+				assert.Contains(t, output, "Command: full srv")
+				assert.Contains(t, output, "Flags:")
 				assert.Contains(t, output, "Values:")
+				assert.Contains(t, output, "--port")
 			},
 		},
 		{
@@ -112,7 +110,7 @@ func TestFullApplication(t *testing.T) {
 			envs: map[string]string{"FULL_DEBUG_OPTIONS": "true"},
 			assertFunc: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
-				assert.Contains(t, output, "Aliases:")
+				assert.Contains(t, output, "Command: full srv")
 				assert.Contains(t, output, "Values:")
 			},
 		},

--- a/integration_test.go
+++ b/integration_test.go
@@ -1857,7 +1857,7 @@ func TestSetupOrdering_CustomOptions(t *testing.T) {
 	assert.NotNil(t, persistentFlags.Lookup("debug-mode"))
 	assert.NotNil(t, persistentFlags.Lookup("settings"))
 
-	assert.True(t, v.GetBool("debug-mode"), "The 'debug-mode' flag should be true because of CUSTOM_DEBUG env var")
+	assert.NotEmpty(t, v.GetString("debug-mode"), "The 'debug-mode' flag should be set because of CUSTOM_DEBUG env var")
 
 	assert.Equal(t, "test-level", v.GetString("log-level"), "Viper should load the value from the config file given via CUSTOM_CONFIG env var")
 }
@@ -2005,7 +2005,7 @@ verbose: false`
 
 		// Verify descriptions are present
 		assert.Contains(t, usageString, "config file", "Usage should contain config flag description")
-		assert.Contains(t, usageString, "enable debug output", "Usage should contain debug flag description")
+		assert.Contains(t, usageString, "debug output format", "Usage should contain debug flag description")
 
 		// Verify persistent flags appear in Global Flags section
 		assert.Contains(t, usageString, "Global Flags:", "Usage should contain Global Flags section")

--- a/integration_test.go
+++ b/integration_test.go
@@ -1987,12 +1987,13 @@ verbose: false`
 
 	t.Run("debug_functionality", func(t *testing.T) {
 		// Debug output should be present since TESTAPP_DEBUG_OPTIONS=true
-		assert.Contains(t, output, "Values:", "Debug output should be triggered by environment variable and show final values")
-		assert.Contains(t, output, "Env:", "Debug output should contain env information")
-		assert.Contains(t, output, "\"timeout\":[]string{\"TESTAPP_TIMEOUT\"}", "Debug output should contain timeout env information")
-		assert.Contains(t, output, "\"log-level\":[]string{\"TESTAPP_LOGLEVEL\", \"TESTAPP_LOG_LEVEL\"}", "Debug output should contain log-level env information")
-		assert.Contains(t, output, "\"log-level\":\"debug\"", "Debug output should contain log-level final value")
-		assert.Contains(t, output, "\"debug-options\":\"true\"", "Debug output should contain debug-options final value")
+		assert.Contains(t, output, "Command: testapp", "Debug output should show command path")
+		assert.Contains(t, output, "Flags:", "Debug output should contain flags section")
+		assert.Contains(t, output, "Values:", "Debug output should contain values section")
+		assert.Contains(t, output, "(env: TESTAPP_TIMEOUT)", "Debug output should show timeout env source")
+		assert.Contains(t, output, "(env: TESTAPP_LOGLEVEL, TESTAPP_LOG_LEVEL)", "Debug output should show log-level env source")
+		assert.Contains(t, output, "log-level: debug", "Debug output should contain log-level final value")
+		assert.Contains(t, output, "debug-options: true", "Debug output should contain debug-options final value")
 	})
 
 	t.Run("usage_contains_persistent_flags", func(t *testing.T) {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -21,7 +21,7 @@ func TestRecursivelyWrapRun_SkipsRunWhenDebugActive(t *testing.T) {
 		},
 	}
 	root.AddCommand(run)
-	internalscope.Get(root).Viper().Set("debug-options", true)
+	internalscope.Get(root).Viper().Set("debug-options", "text")
 
 	RecursivelyWrapRun(root)
 	root.SetArgs([]string{"run"})
@@ -41,7 +41,7 @@ func TestRecursivelyWrapRun_SkipsRunEWhenDebugActive(t *testing.T) {
 		},
 	}
 	root.AddCommand(run)
-	internalscope.Get(root).Viper().Set("debug-options", true)
+	internalscope.Get(root).Viper().Set("debug-options", "text")
 
 	RecursivelyWrapRun(root)
 	root.SetArgs([]string{"run"})

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,6 +1,10 @@
 package internaldebug
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
 	internalscope "github.com/leodido/structcli/internal/scope"
 	"github.com/spf13/cobra"
 )
@@ -9,31 +13,53 @@ const (
 	FlagAnnotation = "___leodido_structcli_debugflagname"
 )
 
-// IsDebugActive checks if the debug option is set for the command c, either through a command-line flag or an environment variable.
-func IsDebugActive(c *cobra.Command) bool {
+// normalizeFormat converts a raw debug flag/env value to "text", "json", or "".
+// Truthy values like "true", "1", "yes" are treated as "text" for backward
+// compatibility with the old bool flag.
+func normalizeFormat(raw string) string {
+	v := strings.TrimSpace(strings.ToLower(raw))
+	switch v {
+	case "json":
+		return "json"
+	case "text":
+		return "text"
+	case "true", "1", "yes":
+		return "text"
+	case "", "false", "0", "no":
+		return ""
+	default:
+		fmt.Fprintf(os.Stderr, "structcli: unrecognized debug format %q, falling back to text\n", raw)
+		return "text"
+	}
+}
+
+// GetFormat returns the active debug format ("text" or "json") for the
+// command, or "" if debug is not active.
+func GetFormat(c *cobra.Command) string {
 	debugFlagName := "debug-options"
 	if currentFlagName, ok := c.Annotations[FlagAnnotation]; ok {
 		debugFlagName = currentFlagName
 	}
 
-	isActive := false
 	rootC := c.Root()
 
-	// Let's first check the flag directly
-	if debugFlag := rootC.PersistentFlags().Lookup(debugFlagName); debugFlag != nil {
-		if debugFlag.Changed {
-			isActive = true
-		}
+	// Check the flag directly first.
+	if debugFlag := rootC.PersistentFlags().Lookup(debugFlagName); debugFlag != nil && debugFlag.Changed {
+		return normalizeFormat(debugFlag.Value.String())
 	}
 
-	// Check viper for other sources (eg, environment variable)
-	if !isActive {
-		rootS := internalscope.Get(rootC)
-		rootV := rootS.Viper()
-		if rootV.GetBool(debugFlagName) {
-			isActive = true
-		}
+	// Check viper for other sources (env var, config).
+	rootS := internalscope.Get(rootC)
+	rootV := rootS.Viper()
+	if raw := rootV.GetString(debugFlagName); raw != "" {
+		return normalizeFormat(raw)
 	}
 
-	return isActive
+	return ""
+}
+
+// IsDebugActive checks if the debug option is set for the command c,
+// either through a command-line flag or an environment variable.
+func IsDebugActive(c *cobra.Command) bool {
+	return GetFormat(c) != ""
 }

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -13,9 +13,19 @@ func TestIsDebugActive_DefaultFlag(t *testing.T) {
 	root := &cobra.Command{Use: "app"}
 	run := &cobra.Command{Use: "run"}
 	root.AddCommand(run)
-	root.PersistentFlags().Bool("debug-options", false, "")
+	root.PersistentFlags().String("debug-options", "", "")
 
-	require.NoError(t, root.PersistentFlags().Set("debug-options", "true"))
+	require.NoError(t, root.PersistentFlags().Set("debug-options", "text"))
+	assert.True(t, IsDebugActive(run))
+}
+
+func TestIsDebugActive_JSON(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	run := &cobra.Command{Use: "run"}
+	root.AddCommand(run)
+	root.PersistentFlags().String("debug-options", "", "")
+
+	require.NoError(t, root.PersistentFlags().Set("debug-options", "json"))
 	assert.True(t, IsDebugActive(run))
 }
 
@@ -26,9 +36,9 @@ func TestIsDebugActive_CustomFlagAnnotation(t *testing.T) {
 		Annotations: map[string]string{FlagAnnotation: "debug-mode"},
 	}
 	root.AddCommand(run)
-	root.PersistentFlags().Bool("debug-mode", false, "")
+	root.PersistentFlags().String("debug-mode", "", "")
 
-	require.NoError(t, root.PersistentFlags().Set("debug-mode", "true"))
+	require.NoError(t, root.PersistentFlags().Set("debug-mode", "text"))
 	assert.True(t, IsDebugActive(run))
 }
 
@@ -37,7 +47,7 @@ func TestIsDebugActive_FromScopedViper(t *testing.T) {
 	run := &cobra.Command{Use: "run"}
 	root.AddCommand(run)
 
-	internalscope.Get(root).Viper().Set("debug-options", true)
+	internalscope.Get(root).Viper().Set("debug-options", "true")
 	assert.True(t, IsDebugActive(run))
 }
 
@@ -47,4 +57,60 @@ func TestIsDebugActive_FalseWhenUnset(t *testing.T) {
 	root.AddCommand(run)
 
 	assert.False(t, IsDebugActive(run))
+}
+
+func TestGetFormat_Text(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	root.PersistentFlags().String("debug-options", "", "")
+	require.NoError(t, root.PersistentFlags().Set("debug-options", "text"))
+	assert.Equal(t, "text", GetFormat(root))
+}
+
+func TestGetFormat_JSON(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	root.PersistentFlags().String("debug-options", "", "")
+	require.NoError(t, root.PersistentFlags().Set("debug-options", "json"))
+	assert.Equal(t, "json", GetFormat(root))
+}
+
+func TestGetFormat_TruthyBackwardCompat(t *testing.T) {
+	for _, val := range []string{"true", "1", "yes"} {
+		t.Run(val, func(t *testing.T) {
+			root := &cobra.Command{Use: "app"}
+			root.PersistentFlags().String("debug-options", "", "")
+			require.NoError(t, root.PersistentFlags().Set("debug-options", val))
+			assert.Equal(t, "text", GetFormat(root))
+		})
+	}
+}
+
+func TestGetFormat_Empty(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	root.PersistentFlags().String("debug-options", "", "")
+	assert.Equal(t, "", GetFormat(root))
+}
+
+func TestNormalizeFormat(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"json", "json"},
+		{"JSON", "json"},
+		{"text", "text"},
+		{"TEXT", "text"},
+		{"true", "text"},
+		{"1", "text"},
+		{"yes", "text"},
+		{"", ""},
+		{"false", ""},
+		{"0", ""},
+		{"no", ""},
+		{"anything", "text"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeFormat(tt.input))
+		})
+	}
 }

--- a/internal/debug/source.go
+++ b/internal/debug/source.go
@@ -1,0 +1,47 @@
+package internaldebug
+
+import (
+	"os"
+
+	internalenv "github.com/leodido/structcli/internal/env"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// FlagSource identifies where a flag's resolved value came from.
+type FlagSource string
+
+const (
+	SourceFlag    FlagSource = "flag"
+	SourceEnv     FlagSource = "env"
+	SourceConfig  FlagSource = "config"
+	SourceDefault FlagSource = "default"
+)
+
+// ResolveFlagSource determines where a flag's value came from.
+//
+// Priority: flag (explicitly set on CLI) > env > config > default.
+func ResolveFlagSource(f *pflag.Flag, configViper *viper.Viper) FlagSource {
+	if f.Changed {
+		return SourceFlag
+	}
+
+	// Check if a bound env var is present in the environment.
+	// This checks presence (os.LookupEnv), not whether viper actually used it,
+	// which is correct given structcli's priority order: when an env var is set
+	// and the flag wasn't explicitly passed, the env var is the effective source.
+	if envs, ok := f.Annotations[internalenv.FlagAnnotation]; ok {
+		for _, envVar := range envs {
+			if _, set := os.LookupEnv(envVar); set {
+				return SourceEnv
+			}
+		}
+	}
+
+	// Check if the config viper has this key.
+	if configViper != nil && configViper.IsSet(f.Name) {
+		return SourceConfig
+	}
+
+	return SourceDefault
+}

--- a/internal/debug/source_test.go
+++ b/internal/debug/source_test.go
@@ -1,0 +1,76 @@
+package internaldebug
+
+import (
+	"testing"
+
+	internalenv "github.com/leodido/structcli/internal/env"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveFlagSource_Flag(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().String("port", "8080", "listen port")
+	require.NoError(t, cmd.Flags().Set("port", "9090"))
+
+	f := cmd.Flags().Lookup("port")
+	assert.Equal(t, SourceFlag, ResolveFlagSource(f, nil))
+}
+
+func TestResolveFlagSource_Env(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().String("timeout", "30s", "timeout")
+	_ = cmd.Flags().SetAnnotation("timeout", internalenv.FlagAnnotation, []string{"APP_TIMEOUT"})
+
+	t.Setenv("APP_TIMEOUT", "60s")
+
+	f := cmd.Flags().Lookup("timeout")
+	assert.Equal(t, SourceEnv, ResolveFlagSource(f, nil))
+}
+
+func TestResolveFlagSource_Config(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().String("log-level", "info", "log level")
+
+	configV := viper.New()
+	configV.Set("log-level", "debug")
+
+	f := cmd.Flags().Lookup("log-level")
+	assert.Equal(t, SourceConfig, ResolveFlagSource(f, configV))
+}
+
+func TestResolveFlagSource_Default(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().String("verbose", "false", "verbose")
+
+	f := cmd.Flags().Lookup("verbose")
+	assert.Equal(t, SourceDefault, ResolveFlagSource(f, nil))
+}
+
+func TestResolveFlagSource_FlagOverridesEnv(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().String("port", "8080", "port")
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"APP_PORT"})
+	require.NoError(t, cmd.Flags().Set("port", "9090"))
+
+	t.Setenv("APP_PORT", "7070")
+
+	f := cmd.Flags().Lookup("port")
+	assert.Equal(t, SourceFlag, ResolveFlagSource(f, nil))
+}
+
+func TestResolveFlagSource_EnvOverridesConfig(t *testing.T) {
+	cmd := &cobra.Command{Use: "app"}
+	cmd.Flags().String("port", "8080", "port")
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"APP_PORT"})
+
+	t.Setenv("APP_PORT", "7070")
+
+	configV := viper.New()
+	configV.Set("port", "6060")
+
+	f := cmd.Flags().Lookup("port")
+	assert.Equal(t, SourceEnv, ResolveFlagSource(f, configV))
+}


### PR DESCRIPTION
## Description

Add machine-readable JSON output to `UseDebug` so AI agents can programmatically consume resolved CLI state.

`--debug-options` changes from a bool flag to a string flag accepting `text` or `json`. Bare `--debug-options` (no value) defaults to `text` via `NoOptDefVal`, so existing usage is unaffected. Truthy values (`true`, `1`, `yes`) normalize to `text` for backward compatibility.

**JSON output** (`--debug-options=json`) writes to stdout:
```json
{
  "command": "myapp serve",
  "flags": [
    {"name": "port", "value": "8080", "default": "8080", "changed": false, "source": "default"},
    {"name": "log-level", "value": "debug", "default": "info", "changed": false, "source": "env"}
  ],
  "values": {"port": 8080, "log-level": "debug"}
}
```

**Source attribution** resolves each flag to one of `flag`, `env`, `config`, or `default` by checking pflag's `Changed` bit, env var annotations via `os.LookupEnv`, and the config viper.

**Text output** is an aligned table with source labels (including env var names for env-sourced flags):
```
Command: myapp serve

Flags:
  --port       8080   (default)
  --log-level  debug  (env: MYAPP_SERVE_LOG_LEVEL)

Values:
  log-level: debug
  port: 8080
```

**Env var activation** works without any CLI flag: `MYAPP_DEBUG_OPTIONS=json` produces JSON output.

### Key changes

- `debug.go`: `writeDebugJSON` and `writeDebugText` with `collectFlagStates` walking all flags
- `internal/debug/debug.go`: `GetFormat` replaces bool-based detection; `normalizeFormat` handles all input variants
- `internal/debug/source.go`: New `ResolveFlagSource` with priority flag > env > config > default
- Updated all existing tests for the bool→string flag change

## How to test

```bash
# Run all tests
go test -count=1 ./...

# Run only the new tests
go test -run "TestUseDebug|TestResolveFlagSource|TestGetFormat|TestNormalizeFormat" -v -count=1 ./...
```

New test coverage:
- `debug_test.go` — 8 integration tests: text output, JSON output, source attribution, env var activation, inactive state
- `internal/debug/source_test.go` — 6 unit tests: all source types and priority ordering
- `internal/debug/debug_test.go` — extended with `TestGetFormat_*` and `TestNormalizeFormat` tests