### PR TITLE
fix: show inherited persistent flags in subcommand help

### DIFF
--- a/internal/usage/groups.go
+++ b/internal/usage/groups.go
@@ -49,5 +49,10 @@ func Groups(c *cobra.Command) map[string]*pflag.FlagSet {
 		})
 	}
 
+	// Include inherited persistent flags (from parent commands) as global flags.
+	c.InheritedFlags().VisitAll(func(f *pflag.Flag) {
+		addTo(f, globalGroupID)
+	})
+
 	return groups
 }


### PR DESCRIPTION
## Description

`Groups()` in `internal/usage/groups.go` only walked `c.PersistentFlags()` (flags defined directly on the command) but not `c.InheritedFlags()` (persistent flags from parent commands). This caused Global Flags like `--config`, `--debug-options`, and `--jsonschema` to be missing from subcommand help output (e.g., `full srv --help`).

One-line fix: add `c.InheritedFlags().VisitAll(...)` to populate the global flags group.

## How to test

```bash
go test -count=1 ./...

# Verify Global Flags appear in subcommand help
go run examples/full/main.go srv --help
```

Before:
```
# (no Global Flags section)
```

After:
```
# Global Flags:
#       --config string                   config file (...)
#       --debug-options string[=\"text\"]   debug output format (text, json)
#       --jsonschema                      output JSON Schema for this command and exit
```"