### PR TITLE
docs: fix non-compiling minimal example and stale flagcustom tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ type Options struct {
 	Port     int
 }
 
+func (o *Options) Attach(c *cobra.Command) error {
+	return structcli.Define(c, o)
+}
+
 func main() {
 	opts := &Options{}
 	cli := &cobra.Command{Use: "myapp"}
 
-	if err := structcli.Define(cli, opts); err != nil {
+	if err := opts.Attach(cli); err != nil {
 		log.Fatalln(err)
 	}
 
@@ -201,8 +205,8 @@ type ServerOptions struct {
 	// Nested structs for organization
 	Database DatabaseConfig `flaggroup:"Database"`
 
-	// Custom type
-	TargetEnv Environment `flagcustom:"true" flag:"target-env" flagdescr:"Set the target environment"`
+	// Enum type (registered via RegisterEnum)
+	TargetEnv Environment `flag:"target-env" flagdescr:"Set the target environment" default:"dev"`
 }
 
 type DatabaseConfig struct {


### PR DESCRIPTION
## Description

Two code block fixes found during a full README audit:

1. **Minimal example (line ~19)**: Missing `Attach` method on `Options` struct. `structcli.Define` and `structcli.Unmarshal` require the `Options` interface which mandates `Attach(*cobra.Command) error`. The example didn't compile.

2. **ServerOptions showcase (line ~186)**: `TargetEnv` field used `flagcustom:\"true\"` but the actual code (`examples/full/cli/cli.go`) uses `RegisterEnum` without `flagcustom`. This contradicted the `RegisterEnum` section later in the same README.

## How to test

Extract the minimal example and compile it:

```bash
awk 'NR>=20 && NR<=61' README.md > /tmp/main.go
# Should compile without errors against the structcli module
```"