### PR TITLE
feat: add `SetupHelpTopics` for env-vars and config-keys help topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Instead of scraping `--help` and guessing, an agent can discover the contract, c
 
 ```go
 structcli.SetupJSONSchema(rootCmd, jsonschema.Options{})
-structcli.SetupFlagErrors(rootCmd) // Optional, but recommended for typed flag-parse errors
+structcli.SetupHelpTopics(rootCmd)  // "mycli help env-vars" and "mycli help config-keys"
+structcli.SetupFlagErrors(rootCmd)  // Optional, but recommended for typed flag-parse errors
 structcli.SetupMCP(rootCmd, mcp.Options{}) // Optional, exposes the CLI as an MCP server over stdio
 structcli.ExecuteOrExit(rootCmd)
 ```
@@ -138,6 +139,7 @@ structcli.ExecuteOrExit(rootCmd)
 With that wiring:
 
 - `--jsonschema` exposes flags, defaults, required inputs, enums, and env bindings across the command tree
+- `help env-vars` and `help config-keys` list every environment variable binding and config file key across the command tree
 - `HandleError` / `ExecuteOrExit` emit structured JSON errors instead of forcing callers to parse human-oriented output
 - `--mcp` exposes the same command tree as MCP tools over stdio, with typed inputs and structured tool-call failures
 - semantic exit codes tell the caller whether it should fix input, fix config, retry, or escalate to a human
@@ -454,6 +456,51 @@ The flag accepts `text` (default when used bare) or `json` for machine-readable 
 Source attribution resolves each flag to `flag` (CLI), `env`, `config`, or `default`. For env-sourced flags, the text output includes the variable name (e.g., `(env: MYAPP_LOG_LEVEL)`).
 
 The flag can also be activated via environment variable: `FULL_DEBUG_OPTIONS=json`.
+
+### 📋 Self-Documenting Help Topics
+
+`SetupHelpTopics` adds two help topic commands that list every environment variable binding and every valid configuration file key across the command tree.
+
+```go
+structcli.SetupHelpTopics(rootCmd)
+```
+
+Call this after all subcommands and flags are defined (typically right before `ExecuteOrExit`).
+
+**Environment variable listing** — `mycli help env-vars`:
+
+```
+Environment Variables
+
+  mycli (global):
+    MYCLI_VERBOSE  --verbose  bool           false
+
+  mycli serve:
+    MYCLI_SERVE_HOST  --host  string         localhost
+    MYCLI_SERVE_PORT  --port  int            8080
+```
+
+**Configuration key listing** — `mycli help config-keys`:
+
+```
+Configuration Keys
+
+  Config flag: --config
+  Supported formats: yaml, json, toml. Searches: $HOME/.mycli, /etc/mycli
+
+  mycli (global):
+    output   --output   string         text
+    verbose  --verbose  bool           false
+
+  mycli serve:
+    host      --host      string         localhost
+    port      --port      int            8080
+    tls-cert  --tls-cert  string         ""
+
+  Keys can be nested under the command name in the config file.
+```
+
+Both topics appear under "Additional help topics:" in `--help` output. Flags marked `flagenv:"only"` show an `(env-only)` suffix in the env-vars listing and are excluded from config-keys (since they are hidden). Config keys derived from embedded struct field paths appear as aliases (e.g., `database.maxconns` → `alias for --database.maxconns`).
 
 ### ↪️ Sharing Options Between Commands
 

--- a/docs/ai-native.md
+++ b/docs/ai-native.md
@@ -10,7 +10,8 @@ Agents do not need to scrape `--help` and guess. They can ask the CLI for its co
 rootCmd := &cobra.Command{Use: "mycli"}
 
 structcli.SetupJSONSchema(rootCmd, jsonschema.Options{})
-structcli.SetupFlagErrors(rootCmd) // Optional, but recommended
+structcli.SetupHelpTopics(rootCmd)  // "mycli help env-vars" and "mycli help config-keys"
+structcli.SetupFlagErrors(rootCmd)  // Optional, but recommended
 structcli.SetupMCP(rootCmd, mcp.Options{}) // Optional, exposes the CLI as an MCP server over stdio
 structcli.ExecuteOrExit(rootCmd)
 ```
@@ -50,6 +51,18 @@ Programmatic APIs:
 - `structcli.JSONSchema(cmd, jsonschema.WithFullTree())`
 - `jsonschema.WithEnumInDescription()`
 - `jsonschema.Options{SchemaOpts: ...}` passed through `SetupJSONSchema`
+
+## Human-readable help topics
+
+`SetupHelpTopics` adds two help topic commands to the root: `help env-vars` and `help config-keys`. These list every environment variable binding and every valid configuration file key across the command tree.
+
+Unlike `--jsonschema` (machine-readable), help topics produce plain text grouped by command with aligned columns — useful for humans and for agents that prefer scanning text over parsing JSON.
+
+- Flags with `flagenv:"only"` show an `(env-only)` suffix in `help env-vars` and are excluded from `help config-keys`.
+- Config keys derived from embedded struct paths appear as aliases.
+- Both topics appear under "Additional help topics:" in `--help` output.
+
+Call `SetupHelpTopics` after all subcommands and flags are defined.
 
 ## MCP server mode
 
@@ -204,6 +217,7 @@ See the [structured error example](../examples/structerr/README.md) for a runnab
 | Need | Tool |
 |------|------|
 | Runtime self-description | `SetupJSONSchema` |
+| Env var / config key reference | `SetupHelpTopics` |
 | Live agent tool access | `SetupMCP` |
 | Better flag-parse errors | `SetupFlagErrors` |
 | Manual error formatting | `HandleError` |

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -438,6 +438,11 @@ func NewRootC(exitOnDebug bool) (*cobra.Command, error) {
 		return nil, err
 	}
 
+	// Add "help env-vars" and "help config-keys" help topics
+	if err := structcli.SetupHelpTopics(rootC); err != nil {
+		return nil, err
+	}
+
 	return rootC, nil
 }
 

--- a/helptopics.go
+++ b/helptopics.go
@@ -1,0 +1,278 @@
+package structcli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	internalenv "github.com/leodido/structcli/internal/env"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// SetupHelpTopics adds "env-vars" and "config-keys" help topic commands to the
+// root command. These appear under "Additional help topics:" in --help output
+// and are accessible via "mycli help env-vars" and "mycli help config-keys".
+//
+// Call this after all subcommands and flags are defined (typically right before
+// ExecuteOrExit).
+func SetupHelpTopics(rootC *cobra.Command) error {
+	if rootC.Parent() != nil {
+		return fmt.Errorf("SetupHelpTopics must be called on the root command")
+	}
+
+	rootC.AddCommand(&cobra.Command{
+		Use:   "env-vars",
+		Short: "List all environment variable bindings",
+		Long:  buildEnvVarsTopic(rootC),
+	})
+
+	rootC.AddCommand(&cobra.Command{
+		Use:   "config-keys",
+		Short: "List all configuration file keys",
+		Long:  buildConfigKeysTopic(rootC),
+	})
+
+	return nil
+}
+
+// commandEnvBinding represents a single flag's env var binding.
+type commandEnvBinding struct {
+	envVars []string
+	flag    string
+	typ     string
+	defVal  string
+	envOnly bool
+}
+
+// commandConfigKey represents a single config key mapping.
+type commandConfigKey struct {
+	key      string
+	flag     string
+	typ      string
+	defVal   string
+	isAlias  bool
+	aliasFor string
+}
+
+// buildEnvVarsTopic walks the command tree and generates the env-vars help text.
+func buildEnvVarsTopic(rootC *cobra.Command) string {
+	var b strings.Builder
+	b.WriteString("Environment Variables\n")
+
+	walkCommands(rootC, func(c *cobra.Command, path string) {
+		bindings := collectEnvBindings(c)
+		if len(bindings) == 0 {
+			return
+		}
+
+		label := path
+		if c == rootC {
+			label = path + " (global)"
+		}
+		b.WriteString(fmt.Sprintf("\n  %s:\n", label))
+
+		// Compute column widths.
+		maxEnv, maxFlag := 0, 0
+		for _, bind := range bindings {
+			for _, env := range bind.envVars {
+				if len(env) > maxEnv {
+					maxEnv = len(env)
+				}
+			}
+			flagStr := "--" + bind.flag
+			if len(flagStr) > maxFlag {
+				maxFlag = len(flagStr)
+			}
+		}
+
+		for _, bind := range bindings {
+			flagStr := "--" + bind.flag
+			suffix := ""
+			if bind.envOnly {
+				suffix = "  (env-only)"
+			}
+
+			for i, env := range bind.envVars {
+				if i == 0 {
+					b.WriteString(fmt.Sprintf("    %-*s  %-*s  %-14s %s%s\n",
+						maxEnv, env, maxFlag, flagStr, bind.typ, bind.defVal, suffix))
+				} else {
+					b.WriteString(fmt.Sprintf("    %-*s  (alias for %s)\n", maxEnv, env, bind.envVars[0]))
+				}
+			}
+		}
+	})
+
+	return b.String()
+}
+
+// buildConfigKeysTopic walks the command tree and generates the config-keys help text.
+func buildConfigKeysTopic(rootC *cobra.Command) string {
+	var b strings.Builder
+	b.WriteString("Configuration Keys\n")
+
+	// Show config file locations if SetupConfig was called.
+	if flagName, ok := rootC.Annotations[configFlagAnnotation]; ok {
+		if f := rootC.PersistentFlags().Lookup(flagName); f != nil {
+			b.WriteString(fmt.Sprintf("\n  Config flag: --%s\n", flagName))
+			if f.Usage != "" {
+				b.WriteString(fmt.Sprintf("  %s\n", f.Usage))
+			}
+		}
+	}
+
+	walkCommands(rootC, func(c *cobra.Command, path string) {
+		keys := collectConfigKeys(c)
+		if len(keys) == 0 {
+			return
+		}
+
+		label := path
+		if c == rootC {
+			label = path + " (global)"
+		}
+		b.WriteString(fmt.Sprintf("\n  %s:\n", label))
+
+		// Compute column widths.
+		maxKey, maxFlag := 0, 0
+		for _, k := range keys {
+			if len(k.key) > maxKey {
+				maxKey = len(k.key)
+			}
+			if !k.isAlias {
+				flagStr := "--" + k.flag
+				if len(flagStr) > maxFlag {
+					maxFlag = len(flagStr)
+				}
+			}
+		}
+
+		for _, k := range keys {
+			if k.isAlias {
+				b.WriteString(fmt.Sprintf("    %-*s  (alias for --%s)\n", maxKey, k.key, k.aliasFor))
+			} else {
+				flagStr := "--" + k.flag
+				b.WriteString(fmt.Sprintf("    %-*s  %-*s  %-14s %s\n",
+					maxKey, k.key, maxFlag, flagStr, k.typ, k.defVal))
+			}
+		}
+	})
+
+	b.WriteString("\n  Keys can be nested under the command name in the config file.\n")
+
+	return b.String()
+}
+
+// walkCommands visits the root and all non-hidden subcommands depth-first.
+// The root is visited with c.Name() (e.g. "mycli") while subcommands use
+// c.CommandPath() (e.g. "mycli serve") so the root label stays short and
+// subcommand labels show the full invocation path.
+func walkCommands(c *cobra.Command, fn func(c *cobra.Command, path string)) {
+	fn(c, c.Name())
+	walkSubcommands(c, fn)
+}
+
+func walkSubcommands(parent *cobra.Command, fn func(c *cobra.Command, path string)) {
+	for _, child := range parent.Commands() {
+		if child.IsAdditionalHelpTopicCommand() || !child.IsAvailableCommand() {
+			continue
+		}
+		fn(child, child.CommandPath())
+		walkSubcommands(child, fn)
+	}
+}
+
+// collectEnvBindings extracts env var bindings from a command's own flags.
+// Hidden flags are intentionally included: env-only flags (flagenv:"only") are
+// hidden from --help but must appear here since env vars are their only input
+// channel. They are marked with an (env-only) suffix.
+func collectEnvBindings(c *cobra.Command) []commandEnvBinding {
+	var bindings []commandEnvBinding
+
+	visitLocalFlags(c, func(f *pflag.Flag) {
+		envs, ok := f.Annotations[internalenv.FlagAnnotation]
+		if !ok || len(envs) == 0 {
+			return
+		}
+
+		_, envOnly := f.Annotations[internalenv.FlagEnvOnlyAnnotation]
+
+		bindings = append(bindings, commandEnvBinding{
+			envVars: envs,
+			flag:    f.Name,
+			typ:     f.Value.Type(),
+			defVal:  formatDefault(f.DefValue),
+			envOnly: envOnly,
+		})
+	})
+
+	return bindings
+}
+
+// collectConfigKeys extracts config key mappings from a command's own flags.
+// Hidden flags are excluded: env-only flags cannot be set via config files, and
+// other manually hidden flags are intentionally kept out of the config reference.
+func collectConfigKeys(c *cobra.Command) []commandConfigKey {
+	var keys []commandConfigKey
+	seen := map[string]bool{}
+
+	visitLocalFlags(c, func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+
+		flagName := f.Name
+		typ := f.Value.Type()
+		defVal := formatDefault(f.DefValue)
+
+		// The flag name is always a valid config key.
+		keys = append(keys, commandConfigKey{
+			key:    flagName,
+			flag:   flagName,
+			typ:    typ,
+			defVal: defVal,
+		})
+		seen[flagName] = true
+
+		// The struct field path (lowercased) is an alias if it differs.
+		if paths, ok := f.Annotations[flagPathAnnotation]; ok && len(paths) > 0 {
+			alias := strings.ToLower(paths[0])
+			if alias != flagName && !seen[alias] {
+				keys = append(keys, commandConfigKey{
+					key:      alias,
+					isAlias:  true,
+					aliasFor: flagName,
+				})
+				seen[alias] = true
+			}
+		}
+	})
+
+	// Sort: primary keys first (alphabetical), then aliases.
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].isAlias != keys[j].isAlias {
+			return !keys[i].isAlias
+		}
+		return keys[i].key < keys[j].key
+	})
+
+	return keys
+}
+
+// visitLocalFlags visits flags that belong to this command (not inherited).
+// For the root command this includes both regular and persistent flags
+// (e.g. --config added by SetupConfig). For subcommands it excludes
+// inherited persistent flags.
+func visitLocalFlags(c *cobra.Command, fn func(*pflag.Flag)) {
+	c.LocalFlags().VisitAll(fn)
+}
+
+// formatDefault formats a default value for display.
+func formatDefault(v string) string {
+	if v == "" {
+		return `""`
+	}
+
+	return v
+}

--- a/helptopics_test.go
+++ b/helptopics_test.go
@@ -1,0 +1,391 @@
+package structcli_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Option structs for help topic tests ---
+
+type helpTopicGlobalOptions struct {
+	Verbose bool   `flag:"verbose" flagdescr:"Enable verbose output" default:"false" flagenv:"true"`
+	Output  string `flag:"output" flagdescr:"Output format" default:"text"`
+}
+
+func (o *helpTopicGlobalOptions) Attach(c *cobra.Command) error {
+	return structcli.Define(c, o)
+}
+
+type helpTopicServeOptions struct {
+	Port    int    `flag:"port" flagdescr:"Listen port" default:"8080" flagenv:"true"`
+	Host    string `flag:"host" flagdescr:"Bind address" default:"localhost" flagenv:"true"`
+	TLSCert string `flag:"tls-cert" flagdescr:"TLS certificate path"`
+}
+
+func (o *helpTopicServeOptions) Attach(c *cobra.Command) error {
+	return structcli.Define(c, o)
+}
+
+type helpTopicEnvOnlyOptions struct {
+	Secret string `flagenv:"only" flag:"secret" flagdescr:"A secret value"`
+}
+
+func (o *helpTopicEnvOnlyOptions) Attach(c *cobra.Command) error {
+	return structcli.Define(c, o)
+}
+
+type helpTopicEmbeddedOptions struct {
+	Auth helpTopicAuth `flag:"auth"`
+}
+
+type helpTopicAuth struct {
+	User string `flag:"user" flagdescr:"Username" flagenv:"true"`
+	Pass string `flag:"pass" flagdescr:"Password" flagenv:"true"`
+}
+
+func (o *helpTopicEmbeddedOptions) Attach(c *cobra.Command) error {
+	return structcli.Define(c, o)
+}
+
+// --- Test helpers ---
+
+// noop is a minimal RunE so cobra treats the command as executable (not a help topic).
+var noop = func(cmd *cobra.Command, args []string) error { return nil }
+
+func setupHelpTopicCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp", Short: "Test app"}
+	globalOpts := &helpTopicGlobalOptions{}
+	require.NoError(t, globalOpts.Attach(root))
+
+	serve := &cobra.Command{Use: "serve", Short: "Start server", RunE: noop}
+	serveOpts := &helpTopicServeOptions{}
+	require.NoError(t, serveOpts.Attach(serve))
+	root.AddCommand(serve)
+
+	return root
+}
+
+// --- SetupHelpTopics tests ---
+
+func TestSetupHelpTopics_AddsCommands(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	// Verify both help topic commands exist.
+	envCmd, _, err := root.Find([]string{"env-vars"})
+	require.NoError(t, err)
+	assert.Equal(t, "env-vars", envCmd.Use)
+	assert.True(t, envCmd.IsAdditionalHelpTopicCommand(), "env-vars should be a help topic (no Run)")
+
+	cfgCmd, _, err := root.Find([]string{"config-keys"})
+	require.NoError(t, err)
+	assert.Equal(t, "config-keys", cfgCmd.Use)
+	assert.True(t, cfgCmd.IsAdditionalHelpTopicCommand(), "config-keys should be a help topic (no Run)")
+}
+
+func TestSetupHelpTopics_EnvVars_ContainsGlobalFlags(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	assert.Contains(t, long, "Environment Variables")
+	assert.Contains(t, long, "myapp (global)")
+	assert.Contains(t, long, "--verbose")
+	assert.Contains(t, long, "MYAPP_VERBOSE")
+}
+
+func TestSetupHelpTopics_EnvVars_ContainsSubcommandFlags(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	assert.Contains(t, long, "myapp serve")
+	assert.Contains(t, long, "--port")
+	assert.Contains(t, long, "--host")
+	assert.Contains(t, long, "MYAPP_SERVE_PORT")
+	assert.Contains(t, long, "MYAPP_SERVE_HOST")
+}
+
+func TestSetupHelpTopics_EnvVars_OmitsFlagsWithoutEnv(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	// --output has no flagenv, should not appear.
+	assert.NotContains(t, long, "--output")
+	// --tls-cert has no flagenv, should not appear.
+	assert.NotContains(t, long, "--tls-cert")
+}
+
+func TestSetupHelpTopics_EnvVars_EnvOnlyMarker(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	opts := &helpTopicEnvOnlyOptions{}
+	require.NoError(t, opts.Attach(root))
+
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	assert.Contains(t, long, "(env-only)")
+	assert.Contains(t, long, "MYAPP_SECRET")
+}
+
+func TestSetupHelpTopics_EnvVars_ShowsTypeAndDefault(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	// Port should show int type and default 8080.
+	assert.Contains(t, long, "int")
+	assert.Contains(t, long, "8080")
+}
+
+func TestSetupHelpTopics_ConfigKeys_ContainsGlobalFlags(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	cfgCmd, _, _ := root.Find([]string{"config-keys"})
+	long := cfgCmd.Long
+
+	assert.Contains(t, long, "Configuration Keys")
+	assert.Contains(t, long, "myapp (global)")
+	assert.Contains(t, long, "verbose")
+	assert.Contains(t, long, "output")
+}
+
+func TestSetupHelpTopics_ConfigKeys_ContainsSubcommandFlags(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	cfgCmd, _, _ := root.Find([]string{"config-keys"})
+	long := cfgCmd.Long
+
+	assert.Contains(t, long, "myapp serve")
+	assert.Contains(t, long, "port")
+	assert.Contains(t, long, "host")
+	assert.Contains(t, long, "tls-cert")
+}
+
+func TestSetupHelpTopics_ConfigKeys_ExcludesHiddenFlags(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	opts := &helpTopicEnvOnlyOptions{}
+	require.NoError(t, opts.Attach(root))
+
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	cfgCmd, _, _ := root.Find([]string{"config-keys"})
+	long := cfgCmd.Long
+
+	// env-only flags are hidden, so they should not appear in config-keys.
+	assert.NotContains(t, long, "secret")
+}
+
+func TestSetupHelpTopics_ConfigKeys_ShowsConfigFlag(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	globalOpts := &helpTopicGlobalOptions{}
+	require.NoError(t, globalOpts.Attach(root))
+
+	structcli.SetupConfig(root, config.Options{
+		AppName:  "myapp",
+		FlagName: "config",
+	})
+
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	cfgCmd, _, _ := root.Find([]string{"config-keys"})
+	long := cfgCmd.Long
+
+	assert.Contains(t, long, "Config flag: --config")
+}
+
+func TestSetupHelpTopics_ConfigKeys_AliasFromStructPath(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	opts := &helpTopicEmbeddedOptions{}
+	require.NoError(t, opts.Attach(root))
+
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	cfgCmd, _, _ := root.Find([]string{"config-keys"})
+	long := cfgCmd.Long
+
+	// The struct path "auth.user" differs from flag name "user",
+	// so it should appear as an alias.
+	assert.Contains(t, long, "alias for")
+}
+
+func TestSetupHelpTopics_SkipsHelpTopicCommands(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	// The help topic commands themselves should not appear as subcommands.
+	assert.NotContains(t, long, "env-vars:")
+	assert.NotContains(t, long, "config-keys:")
+}
+
+func TestSetupHelpTopics_SkipsHiddenCommands(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	globalOpts := &helpTopicGlobalOptions{}
+	require.NoError(t, globalOpts.Attach(root))
+
+	hidden := &cobra.Command{Use: "internal", Hidden: true, RunE: noop}
+	hiddenOpts := &helpTopicServeOptions{}
+	require.NoError(t, hiddenOpts.Attach(hidden))
+	root.AddCommand(hidden)
+
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	assert.NotContains(t, long, "myapp internal")
+}
+
+func TestSetupHelpTopics_NoEnvBindings_NoSection(t *testing.T) {
+	root := &cobra.Command{Use: "myapp"}
+	// No flags defined at all.
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	// Should have the header but no command sections.
+	assert.Contains(t, long, "Environment Variables")
+	assert.NotContains(t, long, "myapp (global)")
+}
+
+func TestSetupHelpTopics_AccessibleViaHelp(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	// Simulate "myapp help env-vars" by executing the root with those args.
+	var out []byte
+	root.SetOut(writerFunc(func(p []byte) (int, error) {
+		out = append(out, p...)
+		return len(p), nil
+	}))
+	root.SetArgs([]string{"help", "env-vars"})
+	require.NoError(t, root.Execute())
+
+	assert.Contains(t, string(out), "Environment Variables")
+}
+
+// writerFunc adapts a function to io.Writer.
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+func TestSetupHelpTopics_NestedSubcommands(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	globalOpts := &helpTopicGlobalOptions{}
+	require.NoError(t, globalOpts.Attach(root))
+
+	parent := &cobra.Command{Use: "cluster", Short: "Cluster management"}
+	root.AddCommand(parent)
+
+	child := &cobra.Command{Use: "create", Short: "Create cluster", RunE: noop}
+	childOpts := &helpTopicServeOptions{}
+	require.NoError(t, childOpts.Attach(child))
+	parent.AddCommand(child)
+
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	assert.Contains(t, long, "myapp cluster create")
+	// Env var names use the leaf command name, not the full path.
+	assert.Contains(t, long, "MYAPP_CREATE_PORT")
+}
+
+func TestSetupHelpTopics_ConfigKeys_NestingHint(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	cfgCmd, _, _ := root.Find([]string{"config-keys"})
+	long := cfgCmd.Long
+
+	assert.Contains(t, long, "Keys can be nested under the command name in the config file.")
+}
+
+func TestSetupHelpTopics_RejectsNonRoot(t *testing.T) {
+	root := &cobra.Command{Use: "myapp"}
+	child := &cobra.Command{Use: "sub", RunE: noop}
+	root.AddCommand(child)
+
+	err := structcli.SetupHelpTopics(child)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root command")
+}
+
+func TestSetupHelpTopics_EnvVars_AliasEnvVarShowsMapping(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	globalOpts := &helpTopicGlobalOptions{}
+	require.NoError(t, globalOpts.Attach(root))
+
+	require.NoError(t, structcli.SetupHelpTopics(root))
+
+	envCmd, _, _ := root.Find([]string{"env-vars"})
+	long := envCmd.Long
+
+	// If a flag has multiple env var names, aliases should reference the primary.
+	// The global --verbose flag with MYAPP prefix should have at most one env var,
+	// so test with a command that has multi-env flags if available.
+	// At minimum, verify no orphan lines (lines with just an env var and no context).
+	for _, line := range splitNonEmpty(long) {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "Environment") ||
+			strings.HasSuffix(trimmed, ":") {
+			continue
+		}
+		// Every env var line should have either "--" (primary) or "(alias for" (secondary).
+		assert.True(t, strings.Contains(trimmed, "--") || strings.Contains(trimmed, "(alias for"),
+			"orphan env var line with no context: %q", trimmed)
+	}
+}
+
+// splitNonEmpty splits s by newlines and returns non-empty lines.
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Description

Add `SetupHelpTopics(rootCmd)` — a single call that registers two cobra help topic commands:

- `mycli help env-vars` — lists every flag→env var mapping across the command tree, with type, default, and `(env-only)` markers
- `mycli help config-keys` — lists every valid config file key, with aliases derived from struct field paths

Both topics walk the command tree and extract data from existing pflag annotations set by `Define`. Output is plain text with aligned columns, grouped by command. Root command flags are labeled `(global)`.

Key design decisions:
- Eager generation: text is built at `SetupHelpTopics` call time, not lazily
- Hidden flags excluded from config-keys; env-only flags included in env-vars with marker
- Help topic commands and hidden commands skipped during tree walk
- Config key aliases shown when struct field path differs from flag name

### Files changed

| File | What |
|------|------|
| `helptopics.go` | Implementation: `SetupHelpTopics`, builders, tree walker, collectors |
| `helptopics_test.go` | 17 tests covering both topics, edge cases, nested commands |
| `README.md` | New "Self-Documenting Help Topics" section, updated wiring block |
| `docs/ai-native.md` | New "Human-readable help topics" section, updated wiring + table |
| `examples/full/cli/cli.go` | Wire `SetupHelpTopics` in the full example |

## How to test

```bash
go test -run TestSetupHelpTopics -v -count=1 .

# Or see it live with the full example:
go run examples/full/main.go help env-vars
go run examples/full/main.go help config-keys
```