### PR TITLE
feat: close `--jsonschema` gaps and add cross-tree CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ type Options struct {
 #   -p, --port int              Server port (default 3000)
 #
 # Global Flags:
-#       --jsonschema   output JSON Schema for this command and exit
+#       --jsonschema string[="true"]   output JSON Schema and exit (bare: this command, =tree: full subtree)
 #       --mcp          serve MCP over stdio
 ```
 
@@ -130,7 +130,7 @@ Instead of scraping `--help` and guessing, an agent can discover the contract, c
 
 ```go
 structcli.SetupJSONSchema(rootCmd, jsonschema.Options{})
-structcli.SetupHelpTopics(rootCmd)  // "mycli help env-vars" and "mycli help config-keys"
+structcli.SetupHelpTopics(rootCmd, helptopics.Options{ReferenceSection: true})  // "mycli env-vars" and "mycli config-keys"
 structcli.SetupFlagErrors(rootCmd)  // Optional, but recommended for typed flag-parse errors
 structcli.SetupMCP(rootCmd, mcp.Options{}) // Optional, exposes the CLI as an MCP server over stdio
 structcli.ExecuteOrExit(rootCmd)
@@ -138,8 +138,8 @@ structcli.ExecuteOrExit(rootCmd)
 
 With that wiring:
 
-- `--jsonschema` exposes flags, defaults, required inputs, enums, and env bindings across the command tree
-- `help env-vars` and `help config-keys` list every environment variable binding and config file key across the command tree
+- `--jsonschema` exposes flags, defaults, required inputs, enums, and env bindings for the current command; `--jsonschema=tree` dumps the entire subtree in one call
+- `mycli env-vars` and `mycli config-keys` list every environment variable binding and config file key across the command tree
 - `HandleError` / `ExecuteOrExit` emit structured JSON errors instead of forcing callers to parse human-oriented output
 - `--mcp` exposes the same command tree as MCP tools over stdio, with typed inputs and structured tool-call failures
 - semantic exit codes tell the caller whether it should fix input, fix config, retry, or escalate to a human
@@ -154,14 +154,27 @@ $ mycli srv --jsonschema
       "type": "integer",
       "default": 3000,
       "x-structcli-env-vars": ["MYCLI_SRV_PORT"]
+    },
+    "secret-key": {
+      "type": "string",
+      "x-structcli-env-vars": ["MYCLI_SRV_SECRET_KEY"],
+      "x-structcli-env-only": true
     }
-  }
+  },
+  "x-structcli-config-flag": "config"
 }
+```
+
+Use `--jsonschema=tree` to dump the entire command subtree in a single call — no need to invoke each subcommand separately:
+
+```console
+$ mycli --jsonschema=tree   # JSON array of schemas for all commands
+$ mycli srv --jsonschema=tree  # schemas for srv + its subcommands
 ```
 
 No `--help` parsing. No guessing what failed. Just a CLI that can explain itself and fail in machine-actionable ways.
 
-Use `exitcode.Category(code)` and `exitcode.IsRetryable(code)` to decide what to do next. See `jsonschema.WithFullTree()` and `jsonschema.WithEnumInDescription()` for schema customization, and pass the same schema options through `SetupJSONSchema` with `jsonschema.Options{SchemaOpts: ...}`.
+Use `exitcode.Category(code)` and `exitcode.IsRetryable(code)` to decide what to do next. See `jsonschema.WithEnumInDescription()` for schema customization, and pass schema options through `SetupJSONSchema` with `jsonschema.Options{SchemaOpts: ...}`.
 
 For CLIs that capture output streams during command construction, configure `mcp.Options.CommandFactory` so each MCP tool call builds a fresh command with the tool-call stdout and stderr writers. This keeps MCP protocol output separate from command output while preserving the existing command tree schema. If the command constructor requires stdin, the factory can wire a non-interactive reader such as `strings.NewReader("")`.
 
@@ -462,12 +475,14 @@ The flag can also be activated via environment variable: `FULL_DEBUG_OPTIONS=jso
 `SetupHelpTopics` adds two help topic commands that list every environment variable binding and every valid configuration file key across the command tree.
 
 ```go
-structcli.SetupHelpTopics(rootCmd)
+structcli.SetupHelpTopics(rootCmd, helptopics.Options{})
 ```
 
 Call this after all subcommands and flags are defined (typically right before `ExecuteOrExit`).
 
-**Environment variable listing** — `mycli help env-vars`:
+By default the commands appear as regular subcommands under "Available Commands:". Set `ReferenceSection: true` to move them into a dedicated "Reference:" section instead.
+
+**Environment variable listing** — `mycli env-vars`:
 
 ```
 Environment Variables
@@ -480,7 +495,7 @@ Environment Variables
     MYCLI_SERVE_PORT  --port  int            8080
 ```
 
-**Configuration key listing** — `mycli help config-keys`:
+**Configuration key listing** — `mycli config-keys`:
 
 ```
 Configuration Keys
@@ -500,7 +515,9 @@ Configuration Keys
   Keys can be nested under the command name in the config file.
 ```
 
-Both topics appear under "Additional help topics:" in `--help` output. Flags marked `flagenv:"only"` show an `(env-only)` suffix in the env-vars listing and are excluded from config-keys (since they are hidden). Config keys derived from embedded struct field paths appear as aliases (e.g., `database.maxconns` → `alias for --database.maxconns`).
+With `ReferenceSection: true`, both topics appear under "Reference:" in `--help` output instead of "Available Commands:". Flags marked `flagenv:"only"` show an `(env-only)` suffix in the env-vars listing and are excluded from config-keys (since they are hidden). Config keys derived from embedded struct field paths appear as aliases (e.g., `database.maxconns` → `alias for --database.maxconns`).
+
+For machine-readable cross-tree data, use `--jsonschema=tree` instead — it provides the same information in structured JSON.
 
 ### ↪️ Sharing Options Between Commands
 
@@ -810,7 +827,11 @@ Organize your `--help` output into logical groups for better readability.
 # Global Flags:
 #       --config string                   config file (fallbacks to: {/etc/full,{executable_dir}/.full,$HOME/.full,...}/config.{yaml,json,toml})
 #       --debug-options string[="text"]   debug output format (text, json)
-#       --jsonschema                      output JSON Schema for this command and exit
+#       --jsonschema string[="true"]      output JSON Schema and exit (bare: this command, =tree: full subtree)
+#
+# Reference:
+#   config-keys List all configuration file keys
+#   env-vars    List all environment variable bindings
 ```
 
 ```bash
@@ -855,7 +876,7 @@ Organize your `--help` output into logical groups for better readability.
 # Global Flags:
 #       --config string                   config file (fallbacks to: {/etc/full,{executable_dir}/.full,$HOME/.full,...}/config.{yaml,json,toml})
 #       --debug-options string[="text"]   debug output format (text, json)
-#       --jsonschema                      output JSON Schema for this command and exit
+#       --jsonschema string[="true"]      output JSON Schema and exit (bare: this command, =tree: full subtree)
 #
 # Use "full srv [command] --help" for more information about a command.
 ```

--- a/docs/ai-native.md
+++ b/docs/ai-native.md
@@ -10,7 +10,7 @@ Agents do not need to scrape `--help` and guess. They can ask the CLI for its co
 rootCmd := &cobra.Command{Use: "mycli"}
 
 structcli.SetupJSONSchema(rootCmd, jsonschema.Options{})
-structcli.SetupHelpTopics(rootCmd)  // "mycli help env-vars" and "mycli help config-keys"
+structcli.SetupHelpTopics(rootCmd, helptopics.Options{ReferenceSection: true})  // "mycli env-vars" and "mycli config-keys"
 structcli.SetupFlagErrors(rootCmd)  // Optional, but recommended
 structcli.SetupMCP(rootCmd, mcp.Options{}) // Optional, exposes the CLI as an MCP server over stdio
 structcli.ExecuteOrExit(rootCmd)
@@ -20,16 +20,26 @@ Use `ExecuteOrExit` when you want the simplest production `main()`. Use `HandleE
 
 ## Machine-readable self-description
 
-`SetupJSONSchema` adds a `--jsonschema` flag to the root command. When requested, structcli prints a JSON Schema (draft 2020-12) for the command being invoked.
+`SetupJSONSchema` adds a `--jsonschema` persistent flag to the root command. When requested, structcli prints a JSON Schema (draft 2020-12) for the command being invoked.
 
-That schema can describe:
+That schema includes:
 
 - flag names and types
 - defaults
 - required inputs
 - enum constraints
-- env var bindings
-- command-aware tree structure
+- env var bindings (`x-structcli-env-vars`)
+- env-only markers (`x-structcli-env-only`)
+- config flag name (`x-structcli-config-flag`)
+- struct field paths (`x-structcli-field-path`)
+
+Use `--jsonschema=tree` to dump the entire command subtree in a single call:
+
+```console
+$ mycli --jsonschema=tree     # all commands
+$ mycli srv --jsonschema=tree # srv + its subcommands
+$ mycli srv --jsonschema      # srv only (default)
+```
 
 Example excerpt:
 
@@ -40,8 +50,14 @@ Example excerpt:
       "type": "integer",
       "default": 3000,
       "x-structcli-env-vars": ["MYCLI_SRV_PORT"]
+    },
+    "secret-key": {
+      "type": "string",
+      "x-structcli-env-vars": ["MYCLI_SRV_SECRET_KEY"],
+      "x-structcli-env-only": true
     }
   },
+  "x-structcli-config-flag": "config",
   "required": ["port"]
 }
 ```
@@ -54,13 +70,13 @@ Programmatic APIs:
 
 ## Human-readable help topics
 
-`SetupHelpTopics` adds two help topic commands to the root: `help env-vars` and `help config-keys`. These list every environment variable binding and every valid configuration file key across the command tree.
+`SetupHelpTopics` adds two reference commands to the root: `env-vars` and `config-keys`. These list every environment variable binding and every valid configuration file key across the command tree.
 
 Unlike `--jsonschema` (machine-readable), help topics produce plain text grouped by command with aligned columns — useful for humans and for agents that prefer scanning text over parsing JSON.
 
-- Flags with `flagenv:"only"` show an `(env-only)` suffix in `help env-vars` and are excluded from `help config-keys`.
+- Flags with `flagenv:"only"` show an `(env-only)` suffix in `env-vars` and are excluded from `config-keys`.
 - Config keys derived from embedded struct paths appear as aliases.
-- Both topics appear under "Additional help topics:" in `--help` output.
+- By default, help topics appear as regular subcommands. Set `ReferenceSection: true` to move them into a dedicated "Reference:" section in `--help` output.
 
 Call `SetupHelpTopics` after all subcommands and flags are defined.
 
@@ -216,8 +232,9 @@ See the [structured error example](../examples/structerr/README.md) for a runnab
 
 | Need | Tool |
 |------|------|
-| Runtime self-description | `SetupJSONSchema` |
-| Env var / config key reference | `SetupHelpTopics` |
+| Runtime self-description (single command) | `--jsonschema` |
+| Cross-tree structured data (all commands) | `--jsonschema=tree` |
+| Env var / config key reference (human-readable) | `SetupHelpTopics` |
 | Live agent tool access | `SetupMCP` |
 | Better flag-parse errors | `SetupFlagErrors` |
 | Manual error formatting | `HandleError` |

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/flagkit"
+	"github.com/leodido/structcli/helptopics"
 	"github.com/leodido/structcli/jsonschema"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
@@ -438,8 +439,8 @@ func NewRootC(exitOnDebug bool) (*cobra.Command, error) {
 		return nil, err
 	}
 
-	// Add "help env-vars" and "help config-keys" help topics
-	if err := structcli.SetupHelpTopics(rootC); err != nil {
+	// Add "env-vars" and "config-keys" reference commands
+	if err := structcli.SetupHelpTopics(rootC, helptopics.Options{ReferenceSection: true}); err != nil {
 		return nil, err
 	}
 

--- a/helptopics.go
+++ b/helptopics.go
@@ -5,35 +5,73 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/leodido/structcli/helptopics"
 	internalenv "github.com/leodido/structcli/internal/env"
+	internalusage "github.com/leodido/structcli/internal/usage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-// SetupHelpTopics adds "env-vars" and "config-keys" help topic commands to the
-// root command. These appear under "Additional help topics:" in --help output
-// and are accessible via "mycli help env-vars" and "mycli help config-keys".
+// SetupHelpTopics adds "env-vars" and "config-keys" reference commands to the
+// root command. By default they appear as regular subcommands under "Available
+// Commands:". Set ReferenceSection to move them into a dedicated "Reference:"
+// section.
 //
-// Call this after all subcommands and flags are defined (typically right before
-// ExecuteOrExit).
-func SetupHelpTopics(rootC *cobra.Command) error {
+// Text is generated lazily at invocation time, so commands added after this
+// call are included.
+func SetupHelpTopics(rootC *cobra.Command, opts helptopics.Options) error {
 	if rootC.Parent() != nil {
 		return fmt.Errorf("SetupHelpTopics must be called on the root command")
 	}
 
-	rootC.AddCommand(&cobra.Command{
+	if opts.ReferenceSection {
+		if rootC.Annotations == nil {
+			rootC.Annotations = map[string]string{}
+		}
+		rootC.Annotations[internalusage.HelpTopicReferenceSection] = "true"
+	}
+
+	envVarsCmd := &cobra.Command{
 		Use:   "env-vars",
 		Short: "List all environment variable bindings",
-		Long:  buildEnvVarsTopic(rootC),
-	})
+		Long:  "Show every flag-to-environment-variable mapping across all commands.",
+		Annotations: map[string]string{
+			internalusage.HelpTopicAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Fprint(cmd.OutOrStdout(), buildEnvVarsTopic(rootC))
 
-	rootC.AddCommand(&cobra.Command{
+			return nil
+		},
+	}
+	rootC.AddCommand(envVarsCmd)
+
+	configKeysCmd := &cobra.Command{
 		Use:   "config-keys",
 		Short: "List all configuration file keys",
-		Long:  buildConfigKeysTopic(rootC),
-	})
+		Long:  "Show every valid configuration file key across all commands.",
+		Annotations: map[string]string{
+			internalusage.HelpTopicAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Fprint(cmd.OutOrStdout(), buildConfigKeysTopic(rootC))
+
+			return nil
+		},
+	}
+	rootC.AddCommand(configKeysCmd)
 
 	return nil
+}
+
+// IsHelpTopicCommand returns true if the command was registered by SetupHelpTopics.
+func IsHelpTopicCommand(c *cobra.Command) bool {
+	if c.Annotations == nil {
+		return false
+	}
+	_, ok := c.Annotations[internalusage.HelpTopicAnnotation]
+
+	return ok
 }
 
 // commandEnvBinding represents a single flag's env var binding.
@@ -175,7 +213,7 @@ func walkCommands(c *cobra.Command, fn func(c *cobra.Command, path string)) {
 
 func walkSubcommands(parent *cobra.Command, fn func(c *cobra.Command, path string)) {
 	for _, child := range parent.Commands() {
-		if child.IsAdditionalHelpTopicCommand() || !child.IsAvailableCommand() {
+		if IsHelpTopicCommand(child) || child.IsAdditionalHelpTopicCommand() || !child.IsAvailableCommand() {
 			continue
 		}
 		fn(child, child.CommandPath())

--- a/helptopics/types.go
+++ b/helptopics/types.go
@@ -1,0 +1,10 @@
+package helptopics
+
+// Options configures the help topic commands registered by SetupHelpTopics.
+type Options struct {
+	// ReferenceSection moves help topic commands from "Available Commands:"
+	// into a dedicated "Reference:" section in --help output. When false
+	// (default), help topic commands appear as regular subcommands, matching
+	// cobra's default behavior.
+	ReferenceSection bool
+}

--- a/helptopics_test.go
+++ b/helptopics_test.go
@@ -1,11 +1,13 @@
 package structcli_test
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/config"
+	"github.com/leodido/structcli/helptopics"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,62 +77,72 @@ func setupHelpTopicCmd(t *testing.T) *cobra.Command {
 	return root
 }
 
+// runHelpTopicCmd executes a help topic subcommand and returns its stdout.
+func runHelpTopicCmd(t *testing.T, root *cobra.Command, args ...string) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(args)
+	require.NoError(t, root.Execute())
+
+	return buf.String()
+}
+
 // --- SetupHelpTopics tests ---
 
 func TestSetupHelpTopics_AddsCommands(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	// Verify both help topic commands exist.
+	// Verify both commands exist and are annotated as help topics.
 	envCmd, _, err := root.Find([]string{"env-vars"})
 	require.NoError(t, err)
 	assert.Equal(t, "env-vars", envCmd.Use)
-	assert.True(t, envCmd.IsAdditionalHelpTopicCommand(), "env-vars should be a help topic (no Run)")
+	assert.True(t, structcli.IsHelpTopicCommand(envCmd), "env-vars should be annotated as help topic")
 
 	cfgCmd, _, err := root.Find([]string{"config-keys"})
 	require.NoError(t, err)
 	assert.Equal(t, "config-keys", cfgCmd.Use)
-	assert.True(t, cfgCmd.IsAdditionalHelpTopicCommand(), "config-keys should be a help topic (no Run)")
+	assert.True(t, structcli.IsHelpTopicCommand(cfgCmd), "config-keys should be annotated as help topic")
 }
 
 func TestSetupHelpTopics_EnvVars_ContainsGlobalFlags(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
-	assert.Contains(t, long, "Environment Variables")
-	assert.Contains(t, long, "myapp (global)")
-	assert.Contains(t, long, "--verbose")
-	assert.Contains(t, long, "MYAPP_VERBOSE")
+	assert.Contains(t, out, "Environment Variables")
+	assert.Contains(t, out, "myapp (global)")
+	assert.Contains(t, out, "--verbose")
+	assert.Contains(t, out, "MYAPP_VERBOSE")
 }
 
 func TestSetupHelpTopics_EnvVars_ContainsSubcommandFlags(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
-	assert.Contains(t, long, "myapp serve")
-	assert.Contains(t, long, "--port")
-	assert.Contains(t, long, "--host")
-	assert.Contains(t, long, "MYAPP_SERVE_PORT")
-	assert.Contains(t, long, "MYAPP_SERVE_HOST")
+	assert.Contains(t, out, "myapp serve")
+	assert.Contains(t, out, "--port")
+	assert.Contains(t, out, "--host")
+	assert.Contains(t, out, "MYAPP_SERVE_PORT")
+	assert.Contains(t, out, "MYAPP_SERVE_HOST")
 }
 
 func TestSetupHelpTopics_EnvVars_OmitsFlagsWithoutEnv(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
 	// --output has no flagenv, should not appear.
-	assert.NotContains(t, long, "--output")
+	assert.NotContains(t, out, "--output")
 	// --tls-cert has no flagenv, should not appear.
-	assert.NotContains(t, long, "--tls-cert")
+	assert.NotContains(t, out, "--tls-cert")
 }
 
 func TestSetupHelpTopics_EnvVars_EnvOnlyMarker(t *testing.T) {
@@ -140,51 +152,47 @@ func TestSetupHelpTopics_EnvVars_EnvOnlyMarker(t *testing.T) {
 	opts := &helpTopicEnvOnlyOptions{}
 	require.NoError(t, opts.Attach(root))
 
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
-	assert.Contains(t, long, "(env-only)")
-	assert.Contains(t, long, "MYAPP_SECRET")
+	assert.Contains(t, out, "(env-only)")
+	assert.Contains(t, out, "MYAPP_SECRET")
 }
 
 func TestSetupHelpTopics_EnvVars_ShowsTypeAndDefault(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
 	// Port should show int type and default 8080.
-	assert.Contains(t, long, "int")
-	assert.Contains(t, long, "8080")
+	assert.Contains(t, out, "int")
+	assert.Contains(t, out, "8080")
 }
 
 func TestSetupHelpTopics_ConfigKeys_ContainsGlobalFlags(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	cfgCmd, _, _ := root.Find([]string{"config-keys"})
-	long := cfgCmd.Long
+	out := runHelpTopicCmd(t, root, "config-keys")
 
-	assert.Contains(t, long, "Configuration Keys")
-	assert.Contains(t, long, "myapp (global)")
-	assert.Contains(t, long, "verbose")
-	assert.Contains(t, long, "output")
+	assert.Contains(t, out, "Configuration Keys")
+	assert.Contains(t, out, "myapp (global)")
+	assert.Contains(t, out, "verbose")
+	assert.Contains(t, out, "output")
 }
 
 func TestSetupHelpTopics_ConfigKeys_ContainsSubcommandFlags(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	cfgCmd, _, _ := root.Find([]string{"config-keys"})
-	long := cfgCmd.Long
+	out := runHelpTopicCmd(t, root, "config-keys")
 
-	assert.Contains(t, long, "myapp serve")
-	assert.Contains(t, long, "port")
-	assert.Contains(t, long, "host")
-	assert.Contains(t, long, "tls-cert")
+	assert.Contains(t, out, "myapp serve")
+	assert.Contains(t, out, "port")
+	assert.Contains(t, out, "host")
+	assert.Contains(t, out, "tls-cert")
 }
 
 func TestSetupHelpTopics_ConfigKeys_ExcludesHiddenFlags(t *testing.T) {
@@ -194,13 +202,12 @@ func TestSetupHelpTopics_ConfigKeys_ExcludesHiddenFlags(t *testing.T) {
 	opts := &helpTopicEnvOnlyOptions{}
 	require.NoError(t, opts.Attach(root))
 
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	cfgCmd, _, _ := root.Find([]string{"config-keys"})
-	long := cfgCmd.Long
+	out := runHelpTopicCmd(t, root, "config-keys")
 
 	// env-only flags are hidden, so they should not appear in config-keys.
-	assert.NotContains(t, long, "secret")
+	assert.NotContains(t, out, "secret")
 }
 
 func TestSetupHelpTopics_ConfigKeys_ShowsConfigFlag(t *testing.T) {
@@ -215,12 +222,11 @@ func TestSetupHelpTopics_ConfigKeys_ShowsConfigFlag(t *testing.T) {
 		FlagName: "config",
 	})
 
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	cfgCmd, _, _ := root.Find([]string{"config-keys"})
-	long := cfgCmd.Long
+	out := runHelpTopicCmd(t, root, "config-keys")
 
-	assert.Contains(t, long, "Config flag: --config")
+	assert.Contains(t, out, "Config flag: --config")
 }
 
 func TestSetupHelpTopics_ConfigKeys_AliasFromStructPath(t *testing.T) {
@@ -230,26 +236,24 @@ func TestSetupHelpTopics_ConfigKeys_AliasFromStructPath(t *testing.T) {
 	opts := &helpTopicEmbeddedOptions{}
 	require.NoError(t, opts.Attach(root))
 
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	cfgCmd, _, _ := root.Find([]string{"config-keys"})
-	long := cfgCmd.Long
+	out := runHelpTopicCmd(t, root, "config-keys")
 
 	// The struct path "auth.user" differs from flag name "user",
 	// so it should appear as an alias.
-	assert.Contains(t, long, "alias for")
+	assert.Contains(t, out, "alias for")
 }
 
 func TestSetupHelpTopics_SkipsHelpTopicCommands(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
 	// The help topic commands themselves should not appear as subcommands.
-	assert.NotContains(t, long, "env-vars:")
-	assert.NotContains(t, long, "config-keys:")
+	assert.NotContains(t, out, "env-vars:")
+	assert.NotContains(t, out, "config-keys:")
 }
 
 func TestSetupHelpTopics_SkipsHiddenCommands(t *testing.T) {
@@ -264,47 +268,34 @@ func TestSetupHelpTopics_SkipsHiddenCommands(t *testing.T) {
 	require.NoError(t, hiddenOpts.Attach(hidden))
 	root.AddCommand(hidden)
 
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
-	assert.NotContains(t, long, "myapp internal")
+	assert.NotContains(t, out, "myapp internal")
 }
 
 func TestSetupHelpTopics_NoEnvBindings_NoSection(t *testing.T) {
 	root := &cobra.Command{Use: "myapp"}
 	// No flags defined at all.
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
 	// Should have the header but no command sections.
-	assert.Contains(t, long, "Environment Variables")
-	assert.NotContains(t, long, "myapp (global)")
+	assert.Contains(t, out, "Environment Variables")
+	assert.NotContains(t, out, "myapp (global)")
 }
 
 func TestSetupHelpTopics_AccessibleViaHelp(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	// Simulate "myapp help env-vars" by executing the root with those args.
-	var out []byte
-	root.SetOut(writerFunc(func(p []byte) (int, error) {
-		out = append(out, p...)
-		return len(p), nil
-	}))
-	root.SetArgs([]string{"help", "env-vars"})
-	require.NoError(t, root.Execute())
+	// "myapp help env-vars" shows the Long description (static summary).
+	out := runHelpTopicCmd(t, root, "help", "env-vars")
 
-	assert.Contains(t, string(out), "Environment Variables")
+	assert.Contains(t, out, "environment-variable mapping")
 }
-
-// writerFunc adapts a function to io.Writer.
-type writerFunc func([]byte) (int, error)
-
-func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
 
 func TestSetupHelpTopics_NestedSubcommands(t *testing.T) {
 	structcli.SetEnvPrefix("MYAPP")
@@ -321,24 +312,22 @@ func TestSetupHelpTopics_NestedSubcommands(t *testing.T) {
 	require.NoError(t, childOpts.Attach(child))
 	parent.AddCommand(child)
 
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
-	assert.Contains(t, long, "myapp cluster create")
+	assert.Contains(t, out, "myapp cluster create")
 	// Env var names use the leaf command name, not the full path.
-	assert.Contains(t, long, "MYAPP_CREATE_PORT")
+	assert.Contains(t, out, "MYAPP_CREATE_PORT")
 }
 
 func TestSetupHelpTopics_ConfigKeys_NestingHint(t *testing.T) {
 	root := setupHelpTopicCmd(t)
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	cfgCmd, _, _ := root.Find([]string{"config-keys"})
-	long := cfgCmd.Long
+	out := runHelpTopicCmd(t, root, "config-keys")
 
-	assert.Contains(t, long, "Keys can be nested under the command name in the config file.")
+	assert.Contains(t, out, "Keys can be nested under the command name in the config file.")
 }
 
 func TestSetupHelpTopics_RejectsNonRoot(t *testing.T) {
@@ -346,7 +335,7 @@ func TestSetupHelpTopics_RejectsNonRoot(t *testing.T) {
 	child := &cobra.Command{Use: "sub", RunE: noop}
 	root.AddCommand(child)
 
-	err := structcli.SetupHelpTopics(child)
+	err := structcli.SetupHelpTopics(child, helptopics.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "root command")
 }
@@ -358,34 +347,106 @@ func TestSetupHelpTopics_EnvVars_AliasEnvVarShowsMapping(t *testing.T) {
 	globalOpts := &helpTopicGlobalOptions{}
 	require.NoError(t, globalOpts.Attach(root))
 
-	require.NoError(t, structcli.SetupHelpTopics(root))
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
 
-	envCmd, _, _ := root.Find([]string{"env-vars"})
-	long := envCmd.Long
+	out := runHelpTopicCmd(t, root, "env-vars")
 
-	// If a flag has multiple env var names, aliases should reference the primary.
-	// The global --verbose flag with MYAPP prefix should have at most one env var,
-	// so test with a command that has multi-env flags if available.
-	// At minimum, verify no orphan lines (lines with just an env var and no context).
-	for _, line := range splitNonEmpty(long) {
+	// Every env var line should have either "--" (primary) or "(alias for" (secondary).
+	for _, line := range strings.Split(out, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "Environment") ||
 			strings.HasSuffix(trimmed, ":") {
 			continue
 		}
-		// Every env var line should have either "--" (primary) or "(alias for" (secondary).
 		assert.True(t, strings.Contains(trimmed, "--") || strings.Contains(trimmed, "(alias for"),
 			"orphan env var line with no context: %q", trimmed)
 	}
 }
 
-// splitNonEmpty splits s by newlines and returns non-empty lines.
-func splitNonEmpty(s string) []string {
-	var out []string
-	for _, line := range strings.Split(s, "\n") {
-		if strings.TrimSpace(line) != "" {
-			out = append(out, line)
+func TestSetupHelpTopics_LazyGeneration(t *testing.T) {
+	structcli.SetEnvPrefix("MYAPP")
+
+	root := &cobra.Command{Use: "myapp"}
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
+
+	// Add a subcommand AFTER SetupHelpTopics.
+	late := &cobra.Command{Use: "late", Short: "Added late", RunE: noop}
+	lateOpts := &helpTopicServeOptions{}
+	require.NoError(t, lateOpts.Attach(late))
+	root.AddCommand(late)
+
+	out := runHelpTopicCmd(t, root, "env-vars")
+
+	// The late command should appear because generation is lazy.
+	assert.Contains(t, out, "myapp late")
+	assert.Contains(t, out, "MYAPP_LATE_PORT")
+}
+
+func TestSetupHelpTopics_ReferenceSection(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{ReferenceSection: true}))
+
+	// Check that --help shows Reference: section.
+	out := runHelpTopicCmd(t, root, "--help")
+
+	assert.Contains(t, out, "Reference:")
+	assert.Contains(t, out, "env-vars")
+	assert.Contains(t, out, "config-keys")
+	// They should NOT appear under Available Commands.
+	lines := strings.Split(out, "\n")
+	inAvailable := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Available Commands:") {
+			inAvailable = true
+
+			continue
+		}
+		if strings.HasPrefix(line, "Reference:") || strings.HasPrefix(line, "Flags:") ||
+			strings.HasPrefix(line, "Global Flags:") || line == "" {
+			inAvailable = false
+
+			continue
+		}
+		if inAvailable {
+			assert.NotContains(t, line, "env-vars", "env-vars should not be under Available Commands")
+			assert.NotContains(t, line, "config-keys", "config-keys should not be under Available Commands")
 		}
 	}
-	return out
+}
+
+func TestSetupHelpTopics_DefaultShowsInAvailableCommands(t *testing.T) {
+	root := setupHelpTopicCmd(t)
+	require.NoError(t, structcli.SetupHelpTopics(root, helptopics.Options{}))
+
+	out := runHelpTopicCmd(t, root, "--help")
+
+	// Default: no Reference section, help topics appear as regular commands.
+	assert.NotContains(t, out, "Reference:")
+	// They should appear under Available Commands.
+	lines := strings.Split(out, "\n")
+	inAvailable := false
+	foundEnvVars, foundConfigKeys := false, false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Available Commands:") {
+			inAvailable = true
+
+			continue
+		}
+		if inAvailable && (strings.HasPrefix(line, "Flags:") ||
+			strings.HasPrefix(line, "Global Flags:") || line == "") {
+			inAvailable = false
+
+			continue
+		}
+		if inAvailable {
+			if strings.Contains(line, "env-vars") {
+				foundEnvVars = true
+			}
+			if strings.Contains(line, "config-keys") {
+				foundConfigKeys = true
+			}
+		}
+	}
+	assert.True(t, foundEnvVars, "env-vars should appear under Available Commands by default")
+	assert.True(t, foundConfigKeys, "config-keys should appear under Available Commands by default")
 }

--- a/internal/usage/groups.go
+++ b/internal/usage/groups.go
@@ -11,7 +11,9 @@ var (
 )
 
 const (
-	FlagGroupAnnotation = "___leodido_structcli_flaggroups"
+	FlagGroupAnnotation       = "___leodido_structcli_flaggroups"
+	HelpTopicAnnotation       = "___leodido_structcli_helptopic"
+	HelpTopicReferenceSection       = "___leodido_structcli_helptopic_refsection"
 )
 
 // Groups returns a map of flag groups for the given command.

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -29,6 +29,16 @@ func tmpl(w io.Writer, text string) error {
 	return err
 }
 
+// isHelpTopicCommand returns true if the command was registered by SetupHelpTopics.
+func isHelpTopicCommand(c *cobra.Command) bool {
+	if c.Annotations == nil {
+		return false
+	}
+	_, ok := c.Annotations[HelpTopicAnnotation]
+
+	return ok
+}
+
 // Setup generates and sets a dynamic usage function for the command.
 //
 // It also groups flags based on the `flaggroup` annotation.
@@ -64,9 +74,18 @@ func Setup(c *cobra.Command) {
 		}
 
 		// Available Commands
+		// When ReferenceSection is set, help topic commands are collected into a
+		// separate "Reference:" section instead of appearing here.
+		showRef := c.Annotations != nil && c.Annotations[HelpTopicReferenceSection] == "true"
+		var refCmds []*cobra.Command
 		if c.HasAvailableSubCommands() {
 			b.WriteString("\nAvailable Commands:\n")
 			for _, cmd := range c.Commands() {
+				if showRef && isHelpTopicCommand(cmd) {
+					refCmds = append(refCmds, cmd)
+
+					continue
+				}
 				if !cmd.IsAvailableCommand() && cmd.Name() != "help" {
 					continue
 				}
@@ -108,7 +127,15 @@ func Setup(c *cobra.Command) {
 			b.WriteString(flagUsages(gFlags))
 		}
 
-		// Help Topics and "use" command
+		// Reference commands (help topics with RunE)
+		if len(refCmds) > 0 {
+			b.WriteString("\nReference:\n")
+			for _, cmd := range refCmds {
+				b.WriteString(fmt.Sprintf("  %s %s\n", rpad(cmd.Name(), c.NamePadding()), cmd.Short))
+			}
+		}
+
+		// Help Topics (Long-only commands without RunE)
 		if c.HasHelpSubCommands() {
 			b.WriteString("\nAdditional help topics:\n")
 			for _, cmd := range c.Commands() {

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -51,6 +51,7 @@ type CommandSchema struct {
 	Groups      map[string][]string    `json:"groups,omitempty"`
 	Subcommands []string               `json:"subcommands,omitempty"`
 	EnvPrefix   string                 `json:"env_prefix,omitempty"`
+	ConfigFlag  string                 `json:"config_flag,omitempty"`
 	Example     string                 `json:"example,omitempty"`    // Usage examples from cobra.Command.Example
 	Aliases     []string               `json:"aliases,omitempty"`    // Command aliases from cobra.Command.Aliases
 	ValidArgs   []string               `json:"valid_args,omitempty"` // Valid positional arguments from cobra.Command.ValidArgs
@@ -109,6 +110,10 @@ func jsonSchemaOne(c *cobra.Command, cfg *jsonschema.Config) (*CommandSchema, er
 	jsonSchemaFlagName := ""
 	if rootAnnotations := c.Root().Annotations; rootAnnotations != nil {
 		jsonSchemaFlagName = rootAnnotations[jsonSchemaFlagAnnotation]
+
+		if cfgFlag, ok := rootAnnotations[configFlagAnnotation]; ok && cfgFlag != "" {
+			schema.ConfigFlag = cfgFlag
+		}
 	}
 
 	// Walk all flags (local + inherited)
@@ -218,8 +223,11 @@ func jsonSchemaOne(c *cobra.Command, cfg *jsonschema.Config) (*CommandSchema, er
 		schema.Groups = groups
 	}
 
-	// Collect subcommand names
+	// Collect subcommand names (excluding help topic reference commands).
 	for _, sub := range c.Commands() {
+		if IsHelpTopicCommand(sub) {
+			continue
+		}
 		if !sub.IsAvailableCommand() && sub.Name() != "help" {
 			continue
 		}
@@ -242,6 +250,9 @@ func jsonSchemaTree(rootC *cobra.Command, cfg *jsonschema.Config) ([]*CommandSch
 		schemas = append(schemas, schema)
 
 		for _, sub := range c.Commands() {
+			if IsHelpTopicCommand(sub) {
+				continue
+			}
 			if !sub.IsAvailableCommand() && sub.Name() != "help" {
 				continue
 			}
@@ -270,6 +281,7 @@ type jsonSchemaProperty struct {
 
 	// x-structcli extensions
 	EnvVars   []string     `json:"x-structcli-env-vars,omitempty"`
+	EnvOnly   bool         `json:"x-structcli-env-only,omitempty"`
 	Shorthand string       `json:"x-structcli-shorthand,omitempty"`
 	Group     string       `json:"x-structcli-group,omitempty"`
 	FieldPath string       `json:"x-structcli-field-path,omitempty"`
@@ -288,6 +300,7 @@ type jsonSchema struct {
 	// x-structcli extensions at root level
 	Subcommands []string            `json:"x-structcli-subcommands,omitempty"`
 	EnvPrefix   string              `json:"x-structcli-env-prefix,omitempty"`
+	ConfigFlag  string              `json:"x-structcli-config-flag,omitempty"`
 	Groups      map[string][]string `json:"x-structcli-groups,omitempty"`
 }
 
@@ -400,6 +413,9 @@ func (cs *CommandSchema) ToJSONSchema() ([]byte, error) {
 	if cs.EnvPrefix != "" {
 		schema.EnvPrefix = cs.EnvPrefix
 	}
+	if cs.ConfigFlag != "" {
+		schema.ConfigFlag = cs.ConfigFlag
+	}
 	if len(cs.Subcommands) > 0 {
 		schema.Subcommands = cs.Subcommands
 	}
@@ -428,6 +444,9 @@ func (cs *CommandSchema) ToJSONSchema() ([]byte, error) {
 		}
 		if len(fs.EnvVars) > 0 {
 			prop.EnvVars = fs.EnvVars
+		}
+		if fs.EnvOnly {
+			prop.EnvOnly = true
 		}
 		if fs.Group != "" {
 			prop.Group = fs.Group
@@ -470,7 +489,8 @@ func SetupJSONSchema(rootC *cobra.Command, opts jsonschema.Options) error {
 	schemaOpts := opts.SchemaOpts
 	cfg := jsonschema.Apply(schemaOpts...)
 
-	rootC.PersistentFlags().Bool(flagName, false, "output JSON Schema for this command and exit")
+	rootC.PersistentFlags().String(flagName, "", "output JSON Schema and exit (bare: this command, =tree: full subtree)")
+	rootC.PersistentFlags().Lookup(flagName).NoOptDefVal = "true"
 
 	// Store the flag name in root annotations for lookup
 	if rootC.Annotations == nil {
@@ -501,13 +521,16 @@ func renderJSONSchemaIfRequested(c *cobra.Command, flagName string, cfg *jsonsch
 		c.Root().PersistentFlags(),
 	}
 
+	var flagValue string
 	flagChanged := false
 	for _, fs := range flagSets {
 		if fs == nil {
 			continue
 		}
-		if flag := fs.Lookup(flagName); flag != nil && flag.Changed {
+		if f := fs.Lookup(flagName); f != nil && f.Changed {
 			flagChanged = true
+			flagValue = f.Value.String()
+
 			break
 		}
 	}
@@ -516,7 +539,14 @@ func renderJSONSchemaIfRequested(c *cobra.Command, flagName string, cfg *jsonsch
 		return false, nil, nil
 	}
 
-	schemas, err := JSONSchema(c, schemaOptsFromConfig(cfg)...)
+	opts := schemaOptsFromConfig(cfg)
+
+	// "tree" walks from the current command downward.
+	if strings.EqualFold(flagValue, "tree") {
+		opts = append(opts, jsonschema.WithFullTree())
+	}
+
+	schemas, err := JSONSchema(c, opts...)
 	if err != nil {
 		return true, nil, fmt.Errorf("couldn't generate JSON Schema: %w", err)
 	}

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/leodido/structcli/config"
+	"github.com/leodido/structcli/helptopics"
 	"github.com/leodido/structcli/jsonschema"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -992,7 +993,7 @@ func TestSetupJSONSchema_TreeExcludesHelpTopics(t *testing.T) {
 	}
 	require.NoError(t, Define(root, &jsonSchemaPortEnvOptions{}))
 	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{}))
-	require.NoError(t, SetupHelpTopics(root))
+	require.NoError(t, SetupHelpTopics(root, helptopics.Options{}))
 
 	var out bytes.Buffer
 	root.SetOut(&out)

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/jsonschema"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -775,3 +776,236 @@ func TestJSONSchema_FullTreeOption(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, schemas, 2, "full tree should include root and subcommand")
 }
+
+type jsonSchemaEnvOnlyOptions struct {
+	Secret string `flagenv:"only" flag:"secret" flagdescr:"a secret"`
+	Port   int    `flag:"port" flagdescr:"port" flagenv:"true"`
+}
+
+func (o *jsonSchemaEnvOnlyOptions) Attach(c *cobra.Command) error { return nil }
+
+type jsonSchemaSimpleOptions struct {
+	Port int `flag:"port" flagdescr:"port"`
+}
+
+func (o *jsonSchemaSimpleOptions) Attach(c *cobra.Command) error { return nil }
+
+type jsonSchemaVerboseOptions struct {
+	Verbose bool `flag:"verbose" flagdescr:"verbose"`
+}
+
+func (o *jsonSchemaVerboseOptions) Attach(c *cobra.Command) error { return nil }
+
+type jsonSchemaPortOptions struct {
+	Port int `flag:"port" flagdescr:"port" default:"8080"`
+}
+
+func (o *jsonSchemaPortOptions) Attach(c *cobra.Command) error { return nil }
+
+type jsonSchemaNameOptions struct {
+	Name string `flag:"name" flagdescr:"cluster name"`
+}
+
+func (o *jsonSchemaNameOptions) Attach(c *cobra.Command) error { return nil }
+
+type jsonSchemaPortEnvOptions struct {
+	Port int `flag:"port" flagdescr:"port" flagenv:"true"`
+}
+
+func (o *jsonSchemaPortEnvOptions) Attach(c *cobra.Command) error { return nil }
+
+func TestJSONSchema_EnvOnlyExtension(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{Use: "app", SilenceErrors: true, SilenceUsage: true}
+	require.NoError(t, Define(root, &jsonSchemaEnvOnlyOptions{}))
+
+	schemas, err := JSONSchema(root)
+	require.NoError(t, err)
+	require.Len(t, schemas, 1)
+
+	secretFlag := schemas[0].Flags["secret"]
+	require.NotNil(t, secretFlag)
+	assert.True(t, secretFlag.EnvOnly, "secret should be marked env-only")
+
+	portFlag := schemas[0].Flags["port"]
+	require.NotNil(t, portFlag)
+	assert.False(t, portFlag.EnvOnly, "port should not be marked env-only")
+
+	// Verify it appears in JSON Schema output.
+	output, err := schemas[0].ToJSONSchema()
+	require.NoError(t, err)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(output, &schema))
+
+	props := schema["properties"].(map[string]any)
+	secretProp := props["secret"].(map[string]any)
+	assert.Equal(t, true, secretProp["x-structcli-env-only"])
+
+	portProp := props["port"].(map[string]any)
+	_, hasEnvOnly := portProp["x-structcli-env-only"]
+	assert.False(t, hasEnvOnly, "non-env-only flag should omit x-structcli-env-only")
+}
+
+func TestJSONSchema_ConfigFlagExtension(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{Use: "app", SilenceErrors: true, SilenceUsage: true}
+	require.NoError(t, Define(root, &jsonSchemaSimpleOptions{}))
+
+	// Without SetupConfig, no config flag annotation.
+	schemas, err := JSONSchema(root)
+	require.NoError(t, err)
+	assert.Empty(t, schemas[0].ConfigFlag)
+
+	output, err := schemas[0].ToJSONSchema()
+	require.NoError(t, err)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(output, &schema))
+	_, hasConfigFlag := schema["x-structcli-config-flag"]
+	assert.False(t, hasConfigFlag, "should not have config flag without SetupConfig")
+
+	// With SetupConfig, config flag annotation should appear.
+	viper.Reset()
+	root2 := &cobra.Command{Use: "app", SilenceErrors: true, SilenceUsage: true}
+	require.NoError(t, Define(root2, &jsonSchemaSimpleOptions{}))
+	require.NoError(t, SetupConfig(root2, config.Options{AppName: "app", FlagName: "config"}))
+
+	schemas2, err := JSONSchema(root2)
+	require.NoError(t, err)
+	assert.Equal(t, "config", schemas2[0].ConfigFlag)
+
+	output2, err := schemas2[0].ToJSONSchema()
+	require.NoError(t, err)
+
+	var schema2 map[string]any
+	require.NoError(t, json.Unmarshal(output2, &schema2))
+	assert.Equal(t, "config", schema2["x-structcli-config-flag"])
+}
+
+func TestSetupJSONSchema_TreeMode(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{
+		Use: "app", SilenceErrors: true, SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(root, &jsonSchemaVerboseOptions{}))
+
+	sub := &cobra.Command{
+		Use: "serve", Short: "start server",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(sub, &jsonSchemaPortOptions{}))
+	root.AddCommand(sub)
+
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{}))
+
+	// Bare --jsonschema: single command.
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"--jsonschema"})
+	require.NoError(t, root.Execute())
+
+	var single map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &single))
+	assert.Equal(t, "app", single["title"])
+
+	// --jsonschema=tree: array of all commands.
+	out.Reset()
+	root.SetArgs([]string{"--jsonschema=tree"})
+	require.NoError(t, root.Execute())
+
+	var tree []map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &tree))
+	require.GreaterOrEqual(t, len(tree), 2)
+
+	titles := make([]string, len(tree))
+	for i, s := range tree {
+		titles[i] = s["title"].(string)
+	}
+	assert.Contains(t, titles, "app")
+	assert.Contains(t, titles, "app serve")
+}
+
+func TestSetupJSONSchema_TreeOnSubcommand(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{Use: "app", SilenceErrors: true, SilenceUsage: true}
+
+	parent := &cobra.Command{
+		Use: "cluster", Short: "cluster mgmt",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(parent)
+
+	child := &cobra.Command{
+		Use: "create", Short: "create cluster",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(child, &jsonSchemaNameOptions{}))
+	parent.AddCommand(child)
+
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{}))
+
+	// --jsonschema=tree on a subcommand walks from that command down.
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"cluster", "--jsonschema=tree"})
+	require.NoError(t, root.Execute())
+
+	var tree []map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &tree))
+
+	titles := make([]string, len(tree))
+	for i, s := range tree {
+		titles[i] = s["title"].(string)
+	}
+	assert.Contains(t, titles, "app cluster")
+	assert.Contains(t, titles, "app cluster create")
+	assert.NotContains(t, titles, "app", "should not include root when tree starts from subcommand")
+}
+
+func TestSetupJSONSchema_TreeExcludesHelpTopics(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{
+		Use: "app", SilenceErrors: true, SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(root, &jsonSchemaPortEnvOptions{}))
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{}))
+	require.NoError(t, SetupHelpTopics(root))
+
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"--jsonschema=tree"})
+	require.NoError(t, root.Execute())
+
+	var tree []map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &tree))
+
+	for _, s := range tree {
+		title := s["title"].(string)
+		assert.NotContains(t, title, "env-vars", "help topic commands should not appear in tree")
+		assert.NotContains(t, title, "config-keys", "help topic commands should not appear in tree")
+	}
+}
+


### PR DESCRIPTION
## Description

Close three gaps in `--jsonschema` that made the help topics JSON proposal redundant, and improve help topics with lazy generation.

### --jsonschema changes

| Gap | Fix |
|-----|-----|
| No cross-tree from CLI | `--jsonschema=tree` (NoOptDefVal pattern, backward compatible) |
| Env-only flags unmarked | `x-structcli-env-only: true` on jsonSchemaProperty |
| No config flag info | `x-structcli-config-flag: "config"` at schema root |

`--jsonschema` changes from `bool` to `string` with `NoOptDefVal = "true"`. Bare `--jsonschema` produces identical output to before. `--jsonschema=tree` walks from the invoked command downward, producing a JSON array of schemas for the entire subtree.

### Help topics changes

- Converted from eager `Long`-only to `RunE` with lazy text generation — commands added after `SetupHelpTopics` are now included
- Help topic commands annotated with `___leodido_structcli_helptopic` so `internal/usage` renders them under a **"Reference:"** section instead of "Available Commands:"
- `walkSubcommands` and `jsonSchemaTree` skip annotated help topics
- Exported `IsHelpTopicCommand()` for external use

### Files changed

| File | What |
|------|------|
| `jsonschema.go` | String flag, tree mode, env-only + config-flag extensions |
| `jsonschema_test.go` | 7 new tests: tree mode, env-only, config-flag, tree-excludes-help-topics |
| `helptopics.go` | RunE, lazy generation, annotation, `IsHelpTopicCommand` |
| `helptopics_test.go` | 21 tests (rewritten for RunE + 2 new: lazy generation, Reference section) |
| `internal/usage/groups.go` | `HelpTopicAnnotation` constant |
| `internal/usage/usage.go` | "Reference:" section, exclude annotated commands from "Available Commands:" |
| `README.md` | Updated jsonschema examples, help output snippets, help topics section |
| `docs/ai-native.md` | Updated jsonschema section, "When to use what" table |

## How to test

```bash
# Full test suite
go test -count=1 ./...

# New jsonschema tests
go test -run "TestJSONSchema_EnvOnly|TestJSONSchema_ConfigFlag|TestSetupJSONSchema_Tree" -v .

# New help topics tests
go test -run TestSetupHelpTopics -v .

# Live verification
go run examples/full/main.go --jsonschema=tree | python3 -m json.tool
go run examples/full/main.go srv --jsonschema=tree | python3 -m json.tool
go run examples/full/main.go srv --jsonschema | python3 -c \"import json,sys; print(json.load(sys.stdin)['properties']['secret-key'])\"
go run examples/full/main.go --help  # check Reference: section
go run examples/full/main.go env-vars
```