### PR TITLE
fix: reject `--jsonschema` on help topic commands

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -539,6 +539,10 @@ func renderJSONSchemaIfRequested(c *cobra.Command, flagName string, cfg *jsonsch
 		return false, nil, nil
 	}
 
+	if IsHelpTopicCommand(c) {
+		return true, nil, fmt.Errorf("--jsonschema is not supported on help topic commands (try it on the parent command, or use --jsonschema=tree on root)")
+	}
+
 	opts := schemaOptsFromConfig(cfg)
 
 	// "tree" walks from the current command downward.

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -1010,3 +1010,26 @@ func TestSetupJSONSchema_TreeExcludesHelpTopics(t *testing.T) {
 	}
 }
 
+func TestSetupJSONSchema_ErrorOnHelpTopicCommand(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{
+		Use: "app", SilenceErrors: true, SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(root, &jsonSchemaPortEnvOptions{}))
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{}))
+	require.NoError(t, SetupHelpTopics(root, helptopics.Options{}))
+
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"env-vars", "--jsonschema"})
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported on help topic commands")
+}
+


### PR DESCRIPTION
`--jsonschema` on a help topic command (e.g. `env-vars`) produced an empty schema with no properties — `{"title": "app env-vars", "type": "object"}`. An agent consuming this output would get no useful information.

Now returns a clear error: `--jsonschema is not supported on help topic commands (try it on the parent command, or use --jsonschema=tree on root)`.

**Changes:**
- `jsonschema.go`: Early return with error in `renderJSONSchemaIfRequested` when `IsHelpTopicCommand(c)` is true
- `jsonschema_test.go`: New `TestSetupJSONSchema_ErrorOnHelpTopicCommand`

Stacked on #134.