### PR TITLE
fix: validate `--jsonschema` flag values and deduplicate `WithFullTree`

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -545,9 +545,17 @@ func renderJSONSchemaIfRequested(c *cobra.Command, flagName string, cfg *jsonsch
 
 	opts := schemaOptsFromConfig(cfg)
 
-	// "tree" walks from the current command downward.
-	if strings.EqualFold(flagValue, "tree") {
-		opts = append(opts, jsonschema.WithFullTree())
+	switch strings.ToLower(flagValue) {
+	case "true", "":
+		// bare --jsonschema: single-command schema (default)
+	case "tree":
+		// Only append WithFullTree if the config doesn't already have it,
+		// avoiding a redundant duplicate when SchemaOpts includes WithFullTree().
+		if cfg == nil || !cfg.FullTree {
+			opts = append(opts, jsonschema.WithFullTree())
+		}
+	default:
+		return true, nil, fmt.Errorf("unknown --jsonschema value %q (valid: bare flag or =tree)", flagValue)
 	}
 
 	schemas, err := JSONSchema(c, opts...)

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -1033,3 +1033,57 @@ func TestSetupJSONSchema_ErrorOnHelpTopicCommand(t *testing.T) {
 	assert.Contains(t, err.Error(), "not supported on help topic commands")
 }
 
+func TestSetupJSONSchema_RejectsUnknownValue(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{
+		Use: "app", SilenceErrors: true, SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(root, &jsonSchemaPortEnvOptions{}))
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{}))
+
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--jsonschema=xml"})
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown --jsonschema value")
+}
+
+func TestSetupJSONSchema_TreeFlagWithConfigFullTree(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{
+		Use: "app", SilenceErrors: true, SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	sub := &cobra.Command{
+		Use: "sub", RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(root, &jsonSchemaPortEnvOptions{}))
+	root.AddCommand(sub)
+
+	// WithFullTree in SchemaOpts + --jsonschema=tree should not double-add the option.
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{
+		SchemaOpts: []jsonschema.Opt{jsonschema.WithFullTree()},
+	}))
+	cfg := jsonschema.Apply(jsonschema.WithFullTree())
+	require.NoError(t, root.PersistentFlags().Set("jsonschema", "tree"))
+
+	handled, output, err := renderJSONSchemaIfRequested(root, "jsonschema", cfg)
+	require.NoError(t, err)
+	assert.True(t, handled)
+
+	// Should produce a valid tree (array) without errors from double-add.
+	var tree []json.RawMessage
+	require.NoError(t, json.Unmarshal(output, &tree))
+	assert.Len(t, tree, 2, "tree should contain root + sub")
+}


### PR DESCRIPTION
Two fixes to `renderJSONSchemaIfRequested`:

1. **Unknown values rejected.** `--jsonschema=xml` (or any unrecognized value) silently fell through to single-command mode. Now returns: `unknown --jsonschema value "xml" (valid: bare flag or =tree)`.

2. **WithFullTree dedup.** When `SchemaOpts` already contains `WithFullTree()` and the user passes `--jsonschema=tree`, the option was added twice. Now skipped when `cfg.FullTree` is already true. The option is idempotent so this was harmless, but the guard makes the intent clearer.

**Changes:**
- `jsonschema.go`: Replace `if` with `switch` in `renderJSONSchemaIfRequested`; guard `WithFullTree` append
- `jsonschema_test.go`: New `TestSetupJSONSchema_RejectsUnknownValue`, `TestSetupJSONSchema_TreeFlagWithConfigFullTree`

Subsumes #137 (closed). Stacked on #134.