### PR TITLE
fix: avoid double-adding `WithFullTree` in `--jsonschema=tree` path

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -542,7 +542,8 @@ func renderJSONSchemaIfRequested(c *cobra.Command, flagName string, cfg *jsonsch
 	opts := schemaOptsFromConfig(cfg)
 
 	// "tree" walks from the current command downward.
-	if strings.EqualFold(flagValue, "tree") {
+	// Skip if cfg already has FullTree to avoid adding the option twice.
+	if strings.EqualFold(flagValue, "tree") && (cfg == nil || !cfg.FullTree) {
 		opts = append(opts, jsonschema.WithFullTree())
 	}
 

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -1010,3 +1010,35 @@ func TestSetupJSONSchema_TreeExcludesHelpTopics(t *testing.T) {
 	}
 }
 
+func TestSetupJSONSchema_TreeFlagWithConfigFullTree(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{
+		Use: "app", SilenceErrors: true, SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	sub := &cobra.Command{
+		Use: "sub", RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	require.NoError(t, Define(root, &jsonSchemaPortEnvOptions{}))
+	root.AddCommand(sub)
+
+	// WithFullTree in SchemaOpts + --jsonschema=tree should not double-add the option.
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{
+		SchemaOpts: []jsonschema.Opt{jsonschema.WithFullTree()},
+	}))
+	cfg := jsonschema.Apply(jsonschema.WithFullTree())
+	require.NoError(t, root.PersistentFlags().Set("jsonschema", "tree"))
+
+	handled, output, err := renderJSONSchemaIfRequested(root, "jsonschema", cfg)
+	require.NoError(t, err)
+	assert.True(t, handled)
+
+	// Should produce a valid tree (array) without errors from double-add.
+	var tree []json.RawMessage
+	require.NoError(t, json.Unmarshal(output, &tree))
+	assert.Len(t, tree, 2, "tree should contain root + sub")
+}


### PR DESCRIPTION
When `SetupJSONSchema` is called with `WithFullTree()` in `SchemaOpts` and the user also passes `--jsonschema=tree`, the `WithFullTree` option was added twice — once from `schemaOptsFromConfig` and once from the flag value handler.

The option is idempotent so this was harmless, but the guard makes the intent clearer and avoids unnecessary work.

**Changes:**
- `jsonschema.go`: Skip appending `WithFullTree()` from flag value when `cfg.FullTree` is already true
- `jsonschema_test.go`: New `TestSetupJSONSchema_TreeFlagWithConfigFullTree`

Stacked on #134.