### PR TITLE
chore: add Makefile release target and fix CI proxy race

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -47,6 +47,8 @@ jobs:
           queries: security-and-quality
 
       - name: Build
+        env:
+          GONOSUMCHECK: github.com/leodido/structcli
         run: |
             go mod download
             go build -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,11 @@ jobs:
           env
 
       - name: Run tests
+        env:
+          # The mcp-command-factory example requires the parent module at the
+          # latest tag which may not be on sum.golang.org yet after a release.
+          # The go.work workspace resolves it locally; skip checksum verification.
+          GONOSUMCHECK: github.com/leodido/structcli
         run: |
           PKGS=$(go list ./... | tr '\n' ',')
           echo "mode: atomic" > coverage.out
@@ -76,6 +81,8 @@ jobs:
           check-latest: true
 
       - name: Verify generated files are up to date
+        env:
+          GONOSUMCHECK: github.com/leodido/structcli
         run: |
           (cd examples/full && go generate ./...)
           if ! git diff --quiet examples/full/; then

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: release test generate
+
+# Release a new version.
+#
+# Usage:
+#   make release VERSION=0.17.0
+#
+# Before running:
+#   1. Fill in the CHANGELOG.md [Unreleased] section
+#   2. Commit the changelog: git commit -m "docs(changelog): add vX.Y.Z release notes"
+#
+# This target then:
+#   1. Bumps the Version constant in version.go
+#   2. Bumps the mcp-command-factory example go.mod require
+#   3. Regenerates files that depend on the version (SKILL.md, etc.)
+#   4. Commits, tags, and pushes
+#
+release:
+ifndef VERSION
+	$(error VERSION is required. Usage: make release VERSION=0.17.0)
+endif
+	@# Guard: clean working tree
+	@git diff --quiet && git diff --cached --quiet || (echo "error: working tree is dirty" && exit 1)
+	@# Guard: on main
+	@test "$$(git branch --show-current)" = "main" || (echo "error: not on main branch" && exit 1)
+	@echo "==> Releasing v$(VERSION)"
+	@# 1. Bump version.go
+	@sed -i 's/const Version = ".*"/const Version = "$(VERSION)"/' version.go
+	@# 2. Bump mcp-command-factory example
+	@sed -i 's|github.com/leodido/structcli v[0-9.]*|github.com/leodido/structcli v$(VERSION)|' examples/mcp-command-factory/go.mod
+	@# 3. Regenerate
+	@(cd examples/full && go generate ./...)
+	@# 4. Commit, tag, push
+	@git add version.go examples/mcp-command-factory/go.mod examples/full/
+	@git commit -m "chore: bump Version constant to $(VERSION)" \
+		-m "Also bump the mcp-command-factory example go.mod require to v$(VERSION)." \
+		--trailer "Co-authored-by: Ona <no-reply@ona.com>"
+	@git tag v$(VERSION)
+	@git push origin main
+	@git push origin v$(VERSION)
+	@echo "==> v$(VERSION) released. Watch CI at https://github.com/leodido/structcli/actions"
+
+test:
+	go test -count=1 ./...
+
+generate:
+	(cd examples/full && go generate ./...)


### PR DESCRIPTION
Prevents the two issues hit during the v0.16.0 release:

1. **Stale generated files.** `make release VERSION=X.Y.Z` bumps `version.go`, `mcp-command-factory/go.mod`, runs `go generate` (regenerates `SKILL.md`), commits, tags, and pushes. The CHANGELOG is a manual step before running the target.

2. **Go module proxy race.** `GONOSUMCHECK=github.com/leodido/structcli` added to test, generate, and SAST workflow steps. The `mcp-command-factory` example's `go.mod` references the parent module at the latest tag, which may not be on `sum.golang.org` for up to 10 minutes after a release. The workspace resolves it locally; the checksum skip prevents the verification failure.