### PR TITLE
fix(ci): add `GONOSUMDB` alongside `GONOSUMCHECK` in workflows

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Build
         env:
+          GONOSUMDB: github.com/leodido/structcli
           GONOSUMCHECK: github.com/leodido/structcli
         run: |
             go mod download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,9 @@ jobs:
         env:
           # The mcp-command-factory example requires the parent module at the
           # latest tag which may not be on sum.golang.org yet after a release.
-          # The go.work workspace resolves it locally; skip checksum verification.
+          # The go.work workspace resolves it locally; skip sumdb lookup and
+          # checksum verification for the self-referencing module.
+          GONOSUMDB: github.com/leodido/structcli
           GONOSUMCHECK: github.com/leodido/structcli
         run: |
           PKGS=$(go list ./... | tr '\n' ',')
@@ -82,6 +84,7 @@ jobs:
 
       - name: Verify generated files are up to date
         env:
+          GONOSUMDB: github.com/leodido/structcli
           GONOSUMCHECK: github.com/leodido/structcli
         run: |
           (cd examples/full && go generate ./...)


### PR DESCRIPTION
`GONOSUMCHECK` alone skips checksum **verification** but the sumdb is still **consulted** — and returns 404 if the tag isn't indexed yet. `GONOSUMDB` skips the sumdb lookup entirely.

Adds `GONOSUMDB: github.com/leodido/structcli` alongside the existing `GONOSUMCHECK` in all three workflow steps (test, generate, sast).

Without this, CI can still fail after a release if `sum.golang.org` hasn't indexed the new tag.