### PR TITLE
fix: allow `--jsonschema` and `--debug-options` on commands without `RunE`

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -70,6 +70,10 @@ func SetupDebug(rootC *cobra.Command, debugOpts debug.Options) error {
 
 	// Wrap all commands run hooks
 	if debugOpts.Exit {
+		// Ensure the root command is runnable so cobra calls PreRunE
+		// instead of short-circuiting to Help().
+		internalcmd.EnsureRunnable(rootC)
+
 		// Wrap already-registered commands now.
 		internalcmd.RecursivelyWrapRun(rootC)
 

--- a/debug_test.go
+++ b/debug_test.go
@@ -182,6 +182,32 @@ func TestIsDebugActive_False(t *testing.T) {
 	assert.False(t, structcli.IsDebugActive(cmd))
 }
 
+func TestSetupDebug_WorksWithoutRunE(t *testing.T) {
+	// Verify that --debug-options on a root command without RunE/Run doesn't
+	// short-circuit to Help(). EnsureRunnable sets a synthetic RunE so cobra
+	// calls PreRunE, and RecursivelyWrapRun intercepts execution when debug
+	// is active (returning nil instead of running the original).
+	root := &cobra.Command{
+		Use:           "app",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	require.NoError(t, structcli.SetupDebug(root, debug.Options{
+		AppName: "app",
+		Exit:    true,
+	}))
+
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"--debug-options"})
+	require.NoError(t, root.Execute())
+
+	output := out.String()
+	// The wrapped RunE returns nil when debug is active, so the synthetic
+	// Help() body never runs — output should be empty (no help text).
+	assert.NotContains(t, output, "Usage:", "debug interception should prevent help output")
+}
+
 func TestUseDebug_HiddenFlagsExcluded(t *testing.T) {
 	var buf bytes.Buffer
 	opts := &debugTestOptions{}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	internaldebug "github.com/leodido/structcli/internal/debug"
+	internalusage "github.com/leodido/structcli/internal/usage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -96,6 +97,30 @@ func resetFlags(root *cobra.Command) {
 		}
 	}
 	walk(root)
+}
+
+// EnsureRunnable sets a synthetic RunE on the command if it has no Run/RunE.
+// This prevents cobra from short-circuiting to Help() before PreRunE fires,
+// which is where execution interception (--jsonschema, --debug-options, etc.)
+// happens. The synthetic RunE falls through to cmd.Help() so the user-visible
+// behavior is unchanged.
+//
+// The command is annotated with SyntheticRunAnnotation so the usage template
+// can suppress the bare usage line (avoiding a misleading "app" line that
+// implies the root is directly invocable).
+//
+// Safe to call multiple times — idempotent. Subsequent Setup* calls and
+// RecursivelyWrapExecution will wrap the synthetic RunE like any other.
+func EnsureRunnable(c *cobra.Command) {
+	if c.RunE == nil && c.Run == nil {
+		if c.Annotations == nil {
+			c.Annotations = map[string]string{}
+		}
+		c.Annotations[internalusage.SyntheticRunAnnotation] = "true"
+		c.RunE = func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		}
+	}
 }
 
 func RecursivelyWrapExecution(c *cobra.Command, interceptor ExecutionInterceptor) {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,6 +1,7 @@
 package internalcmd
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"testing"
@@ -260,4 +261,70 @@ func TestRecursivelyWrapExecution_InterceptsWithoutRunningCommand(t *testing.T) 
 		require.Error(t, err)
 		assert.EqualError(t, err, "boom")
 	})
+}
+
+func TestEnsureRunnable_InterceptsCommandWithoutRunE(t *testing.T) {
+	RestoreInterceptedExecutions()
+	t.Cleanup(RestoreInterceptedExecutions)
+
+	intercepted := false
+	// Root has no RunE/Run — cobra would normally short-circuit to Help().
+	root := &cobra.Command{
+		Use:           "app",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	EnsureRunnable(root)
+	RecursivelyWrapExecution(root, ExecutionInterceptor{
+		Annotation:      "structcli/test-wrapped",
+		ShouldIntercept: func(_ *cobra.Command) bool { return true },
+		Intercept: func(_ *cobra.Command, _ []string) (bool, error) {
+			intercepted = true
+			return true, nil
+		},
+	})
+
+	require.NoError(t, root.Execute())
+	assert.True(t, intercepted, "interception should fire on commands without RunE")
+}
+
+func TestEnsureRunnable_ShowsHelpWhenNotIntercepted(t *testing.T) {
+	RestoreInterceptedExecutions()
+	t.Cleanup(RestoreInterceptedExecutions)
+
+	// Command without RunE/Run should show help when not intercepted.
+	root := &cobra.Command{
+		Use:   "app",
+		Short: "test app",
+	}
+
+	EnsureRunnable(root)
+	RecursivelyWrapExecution(root, ExecutionInterceptor{
+		Annotation:      "structcli/test-wrapped",
+		ShouldIntercept: func(_ *cobra.Command) bool { return false },
+		Intercept: func(_ *cobra.Command, _ []string) (bool, error) {
+			return false, nil
+		},
+	})
+
+	var out bytes.Buffer
+	root.SetOut(&out)
+	require.NoError(t, root.Execute())
+	assert.Contains(t, out.String(), "test app", "should show help output")
+}
+
+func TestEnsureRunnable_NoopWhenRunEExists(t *testing.T) {
+	called := false
+	root := &cobra.Command{
+		Use: "app",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			called = true
+			return nil
+		},
+	}
+
+	EnsureRunnable(root)
+	require.NoError(t, root.Execute())
+	assert.True(t, called, "original RunE should still be called")
 }

--- a/internal/usage/groups.go
+++ b/internal/usage/groups.go
@@ -13,7 +13,8 @@ var (
 const (
 	FlagGroupAnnotation       = "___leodido_structcli_flaggroups"
 	HelpTopicAnnotation       = "___leodido_structcli_helptopic"
-	HelpTopicReferenceSection       = "___leodido_structcli_helptopic_refsection"
+	HelpTopicReferenceSection = "___leodido_structcli_helptopic_refsection"
+	SyntheticRunAnnotation    = "___leodido_structcli_synthetic_run"
 )
 
 // Groups returns a map of flag groups for the given command.

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -47,8 +47,9 @@ func Setup(c *cobra.Command) {
 		var b strings.Builder
 
 		// Usage Line
+		syntheticRun := c.Annotations != nil && c.Annotations[SyntheticRunAnnotation] == "true"
 		b.WriteString("Usage:")
-		if c.Runnable() {
+		if c.Runnable() && !syntheticRun {
 			b.WriteString("\n  ")
 			b.WriteString(c.UseLine())
 		}

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -498,6 +498,10 @@ func SetupJSONSchema(rootC *cobra.Command, opts jsonschema.Options) error {
 	}
 	rootC.Annotations[jsonSchemaFlagAnnotation] = flagName
 
+	// Ensure the root command is runnable so cobra calls PreRunE (where
+	// interception happens) instead of short-circuiting to Help().
+	internalcmd.EnsureRunnable(rootC)
+
 	// Wrap right before execution so commands and hooks added after setup are
 	// still intercepted before Cobra validates args and required flags.
 	cobra.OnInitialize(func() {

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -1004,7 +1004,8 @@ func TestSetupJSONSchema_TreeExcludesHelpTopics(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out.Bytes(), &tree))
 
 	for _, s := range tree {
-		title := s["title"].(string)
+		title, ok := s["title"].(string)
+		require.True(t, ok, "schema entry should have a string title")
 		assert.NotContains(t, title, "env-vars", "help topic commands should not appear in tree")
 		assert.NotContains(t, title, "config-keys", "help topic commands should not appear in tree")
 	}
@@ -1086,4 +1087,59 @@ func TestSetupJSONSchema_TreeFlagWithConfigFullTree(t *testing.T) {
 	var tree []json.RawMessage
 	require.NoError(t, json.Unmarshal(output, &tree))
 	assert.Len(t, tree, 2, "tree should contain root + sub")
+}
+
+func TestSetupJSONSchema_WorksWithoutRunE(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+	SetEnvPrefix("APP")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	// Root command with no RunE/Run — the common case for CLI apps
+	// where the root just shows help.
+	root := &cobra.Command{
+		Use: "app", SilenceErrors: true, SilenceUsage: true,
+	}
+	sub := &cobra.Command{
+		Use:  "serve",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(sub)
+	require.NoError(t, Define(root, &jsonSchemaPortEnvOptions{}))
+	require.NoError(t, SetupJSONSchema(root, jsonschema.Options{}))
+
+	// Bare --jsonschema on root (no RunE) should produce a schema.
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"--jsonschema"})
+	require.NoError(t, root.Execute())
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &schema))
+	assert.Equal(t, "app", schema["title"])
+
+	// --jsonschema=tree on root (no RunE) should produce a tree.
+	out.Reset()
+	root.SetArgs([]string{"--jsonschema=tree"})
+	require.NoError(t, root.Execute())
+
+	var tree []map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &tree))
+	// Tree includes root, serve, plus cobra's auto-generated completion/help commands.
+	titles := make([]string, 0, len(tree))
+	for _, s := range tree {
+		title, ok := s["title"].(string)
+		require.True(t, ok, "schema entry should have a string title")
+		titles = append(titles, title)
+	}
+	assert.Contains(t, titles, "app")
+	assert.Contains(t, titles, "app serve")
+
+	// Verify the usage template suppresses the bare usage line for synthetic RunE.
+	out.Reset()
+	root.SetArgs([]string{"--help"})
+	require.NoError(t, root.Execute())
+	helpOut := out.String()
+	assert.Contains(t, helpOut, "app [command]")
+	assert.NotContains(t, helpOut, "\n  app\n", "synthetic RunE should not add a bare usage line")
 }

--- a/mcp.go
+++ b/mcp.go
@@ -69,6 +69,8 @@ func SetupMCP(rootC *cobra.Command, opts structclimcp.Options) error {
 	}
 	rootC.Annotations[mcpFlagAnnotation] = cfg.flagName
 
+	internalcmd.EnsureRunnable(rootC)
+
 	// Wrap right before execution so commands and hooks added after setup are
 	// still intercepted before Cobra validates args and required flags.
 	cobra.OnInitialize(func() {


### PR DESCRIPTION
Cobra skips `PreRunE` for commands without `Run`/`RunE`, short-circuiting to `Help()`. This prevented `--jsonschema` and `--debug-options` interception on root commands that don't define `RunE` — the common case for CLIs where root just shows help.

Users had to add a dummy `RunE` to their root command:
```go
RunE: func(cmd *cobra.Command, args []string) error {
    return cmd.Help()
},
```

Now handled internally. `EnsureRunnable()` sets a help-showing `RunE` on commands that lack one, making cobra treat them as runnable so `PreRunE` fires. Called from `SetupJSONSchema` and `SetupDebug` (with `Exit: true`).

**Tests:**
- `TestEnsureRunnable_InterceptsCommandWithoutRunE` — verifies interception fires
- `TestEnsureRunnable_ShowsHelpWhenNotIntercepted` — verifies help output when not intercepted
- `TestEnsureRunnable_NoopWhenRunEExists` — verifies existing RunE is preserved
- `TestSetupJSONSchema_WorksWithoutRunE` — end-to-end: bare `--jsonschema` and `--jsonschema=tree` on a root without RunE