### PR TITLE
feat: add standalone capability interfaces (`Validatable`, `Transformable`, `ContextInjector`)

### DIFF
--- a/contract.go
+++ b/contract.go
@@ -13,9 +13,37 @@ type Options interface {
 	Attach(*cobra.Command) error
 }
 
+// Validatable is a struct that supports validation after unmarshalling.
+//
+// Validate is called automatically during Unmarshal(), after Transform.
+// Does not require Options (Attach) — works with plain struct pointers via Bind.
+type Validatable interface {
+	Validate(context.Context) []error
+}
+
+// Transformable is a struct that supports transformation after unmarshalling.
+//
+// Transform is called automatically during Unmarshal(), before Validate.
+// Does not require Options (Attach) — works with plain struct pointers via Bind.
+type Transformable interface {
+	Transform(context.Context) error
+}
+
+// ContextInjector is a struct that propagates values into the command context after unmarshalling.
+//
+// Context is called automatically during Unmarshal() to derive a new context.
+// Does not require Options (Attach) — works with plain struct pointers via Bind.
+//
+// FromContext (reading values back from context) is a user-side pattern, not part of this interface.
+type ContextInjector interface {
+	Context(context.Context) context.Context
+}
+
 // ValidatableOptions extends Options with validation capabilities.
 //
-// The Validate method is called automatically during Unmarshal().
+// Deprecated: Use Validatable instead. ValidatableOptions requires implementing Attach,
+// which is unnecessary for validation. Validatable works with both Options implementors
+// and plain struct pointers.
 type ValidatableOptions interface {
 	Options
 	Validate(context.Context) []error
@@ -23,7 +51,9 @@ type ValidatableOptions interface {
 
 // TransformableOptions extends Options with transformation capabilities.
 //
-// The Transform method is called automatically during Unmarshal() before validation.
+// Deprecated: Use Transformable instead. TransformableOptions requires implementing Attach,
+// which is unnecessary for transformation. Transformable works with both Options implementors
+// and plain struct pointers.
 type TransformableOptions interface {
 	Options
 	Transform(context.Context) error
@@ -49,7 +79,9 @@ type EnumValuer interface {
 
 // ContextOptions extends Options with context manipulation capabilities.
 //
-// The Context method is called automatically during Unmarshal() to modify the command context.
+// Deprecated: Use ContextInjector instead. ContextInjector only requires the Context method
+// (propagation). FromContext is a user-side pattern — structcli never calls it internally.
+// ContextInjector works with both Options implementors and plain struct pointers.
 type ContextOptions interface {
 	Options
 	Context(context.Context) context.Context

--- a/contract_test.go
+++ b/contract_test.go
@@ -9,9 +9,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// --- Standalone interface test types ---
+
 type validateOnlyOptions struct{}
 
 func (o *validateOnlyOptions) Validate(context.Context) []error { return nil }
+
+type transformOnlyOptions struct{}
+
+func (o *transformOnlyOptions) Transform(context.Context) error { return nil }
+
+type contextInjectorOnly struct{}
+
+func (o *contextInjectorOnly) Context(ctx context.Context) context.Context { return ctx }
+
+// --- Deprecated interface test types (with Attach) ---
 
 type validateWithAttachOptions struct{}
 
@@ -20,14 +32,25 @@ func (o *validateWithAttachOptions) Validate(context.Context) []error {
 	return nil
 }
 
-type transformOnlyOptions struct{}
-
-func (o *transformOnlyOptions) Transform(context.Context) error { return nil }
-
 type transformWithAttachOptions struct{}
 
 func (o *transformWithAttachOptions) Attach(*cobra.Command) error { return nil }
 func (o *transformWithAttachOptions) Transform(context.Context) error {
+	return nil
+}
+
+type contextOptionsWithAttach struct{}
+
+func (o *contextOptionsWithAttach) Attach(*cobra.Command) error              { return nil }
+func (o *contextOptionsWithAttach) Context(ctx context.Context) context.Context { return ctx }
+func (o *contextOptionsWithAttach) FromContext(context.Context) error         { return nil }
+
+// --- Types implementing both standalone and deprecated ---
+
+type validateBothInterfaces struct{}
+
+func (o *validateBothInterfaces) Attach(*cobra.Command) error { return nil }
+func (o *validateBothInterfaces) Validate(context.Context) []error {
 	return nil
 }
 
@@ -52,5 +75,62 @@ func TestOptionContracts(t *testing.T) {
 
 		assert.False(t, transformOnlyImplements)
 		assert.True(t, transformWithAttachImplements)
+	})
+}
+
+func TestStandaloneCapabilityInterfaces(t *testing.T) {
+	t.Run("Validatable does not require Attach", func(t *testing.T) {
+		var v any = &validateOnlyOptions{}
+		_, ok := v.(structcli.Validatable)
+		assert.True(t, ok, "validateOnlyOptions should implement Validatable")
+
+		_, hasAttach := v.(structcli.Options)
+		assert.False(t, hasAttach, "validateOnlyOptions should not implement Options")
+	})
+
+	t.Run("Transformable does not require Attach", func(t *testing.T) {
+		var v any = &transformOnlyOptions{}
+		_, ok := v.(structcli.Transformable)
+		assert.True(t, ok, "transformOnlyOptions should implement Transformable")
+
+		_, hasAttach := v.(structcli.Options)
+		assert.False(t, hasAttach, "transformOnlyOptions should not implement Options")
+	})
+
+	t.Run("ContextInjector does not require Attach", func(t *testing.T) {
+		var v any = &contextInjectorOnly{}
+		_, ok := v.(structcli.ContextInjector)
+		assert.True(t, ok, "contextInjectorOnly should implement ContextInjector")
+
+		_, hasAttach := v.(structcli.Options)
+		assert.False(t, hasAttach, "contextInjectorOnly should not implement Options")
+
+		_, hasFromContext := v.(structcli.ContextOptions)
+		assert.False(t, hasFromContext, "contextInjectorOnly should not implement ContextOptions")
+	})
+
+	t.Run("ContextInjector does not require FromContext", func(t *testing.T) {
+		var v any = &contextInjectorOnly{}
+		_, ok := v.(structcli.ContextInjector)
+		assert.True(t, ok)
+		// ContextInjector only has Context(), not FromContext()
+	})
+
+	t.Run("deprecated interfaces still satisfied by types with Attach", func(t *testing.T) {
+		var v any = &validateBothInterfaces{}
+
+		_, isValidatable := v.(structcli.Validatable)
+		_, isValidatableOptions := v.(structcli.ValidatableOptions)
+		assert.True(t, isValidatable, "should implement Validatable")
+		assert.True(t, isValidatableOptions, "should still implement ValidatableOptions")
+	})
+
+	t.Run("ContextOptions type also satisfies ContextInjector", func(t *testing.T) {
+		var v any = &contextOptionsWithAttach{}
+
+		_, isInjector := v.(structcli.ContextInjector)
+		_, isContextOptions := v.(structcli.ContextOptions)
+		assert.True(t, isInjector, "ContextOptions implementor should also satisfy ContextInjector")
+		assert.True(t, isContextOptions, "should still implement ContextOptions")
 	})
 }

--- a/define.go
+++ b/define.go
@@ -208,10 +208,13 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			presets = filtered
 		}
 
-		// Determine whether to represent hierarchy with the command name
-		// We assume that options that are not context options are subcommand-specific options
+		// Determine whether to represent hierarchy with the command name.
+		// Context-injecting options are treated as shared/common (no command name prefix in env vars).
+		// Prefer ContextInjector (standalone); fall back to deprecated ContextOptions.
 		cName := ""
-		if _, isContextOptions := o.(ContextOptions); !isContextOptions {
+		_, isContextInjector := o.(ContextInjector)
+		_, isContextOptions := o.(ContextOptions)
+		if !isContextInjector && !isContextOptions {
 			cName = c.Name()
 		}
 

--- a/viper.go
+++ b/viper.go
@@ -151,20 +151,36 @@ func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookF
 		return fmt.Errorf("couldn't unmarshal config to options: %w", err)
 	}
 
-	// Automatically set common options into the context of the cobra command
-	if o, ok := opts.(ContextOptions); ok {
+	// Automatically set common options into the context of the cobra command.
+	// Prefer ContextInjector (standalone); fall back to deprecated ContextOptions.
+	if o, ok := opts.(ContextInjector); ok {
+		c.SetContext(o.Context(c.Context()))
+	} else if o, ok := opts.(ContextOptions); ok {
 		c.SetContext(o.Context(c.Context()))
 	}
 
-	// Automatically transform options if feasible
-	if o, ok := opts.(TransformableOptions); ok {
+	// Automatically transform options if feasible.
+	// Prefer Transformable (standalone); fall back to deprecated TransformableOptions.
+	if o, ok := opts.(Transformable); ok {
+		if transformErr := o.Transform(c.Context()); transformErr != nil {
+			return fmt.Errorf("couldn't transform options: %w", transformErr)
+		}
+	} else if o, ok := opts.(TransformableOptions); ok {
 		if transformErr := o.Transform(c.Context()); transformErr != nil {
 			return fmt.Errorf("couldn't transform options: %w", transformErr)
 		}
 	}
 
-	// Automatically run options validation if feasible
-	if o, ok := opts.(ValidatableOptions); ok {
+	// Automatically run options validation if feasible.
+	// Prefer Validatable (standalone); fall back to deprecated ValidatableOptions.
+	if o, ok := opts.(Validatable); ok {
+		if validationErrors := o.Validate(c.Context()); validationErrors != nil {
+			return &structclierrors.ValidationError{
+				ContextName: c.Name(),
+				Errors:      validationErrors,
+			}
+		}
+	} else if o, ok := opts.(ValidatableOptions); ok {
 		if validationErrors := o.Validate(c.Context()); validationErrors != nil {
 			return &structclierrors.ValidationError{
 				ContextName: c.Name(),


### PR DESCRIPTION
## Description

Add `Validatable`, `Transformable`, and `ContextInjector` as standalone interfaces that do not embed `Options`. This decouples validation, transformation, and context propagation from the `Attach` method, enabling plain struct pointers to use these capabilities (needed for the upcoming `Bind` API).

**Changes:**

- **`contract.go`**: Add three new interfaces. Mark `ValidatableOptions`, `TransformableOptions`, `ContextOptions` as `// Deprecated:`.
- **`viper.go`**: `Unmarshal` now checks new interfaces first, falls back to deprecated ones.
- **`define.go`**: `ContextInjector` check added alongside `ContextOptions` for env var naming (shared vs subcommand-specific).
- **`contract_test.go`**: 6 new tests verifying standalone interfaces don't require `Attach`, deprecated interfaces still work, and `ContextOptions` implementors satisfy `ContextInjector`.

`ContextInjector` only requires `Context()` (propagation). `FromContext` is a user-side pattern — structcli never calls it internally.

No behavior change for existing code. PR 1 of 7 in the ergonomics spec (`spec-ergonomics.md`).

## How to test

```
go test ./... -count=1
go test -v -run "TestStandaloneCapabilityInterfaces|TestOptionContracts" .
```