### PR TITLE
feat: add `Bind(cmd, opts)` for flag definition and auto-unmarshal registration

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -1,0 +1,72 @@
+package structcli
+
+import (
+	"fmt"
+	"reflect"
+
+	internalenv "github.com/leodido/structcli/internal/env"
+	internalscope "github.com/leodido/structcli/internal/scope"
+	internalvalidation "github.com/leodido/structcli/internal/validation"
+	"github.com/spf13/cobra"
+)
+
+// Bind defines flags from opts on cmd and registers opts for auto-unmarshal
+// during ExecuteC/ExecuteOrExit.
+//
+// opts must be a non-nil struct pointer. If opts implements Options (has Attach),
+// Attach is called. Otherwise flags are defined directly from struct tags.
+//
+// Multiple Bind calls per command are supported; unmarshal order matches call order (FIFO).
+// Define runs immediately — flags exist on the command after Bind returns.
+//
+// The current manual Unmarshal model still works. Auto-unmarshal via the execution
+// pipeline is wired in ExecuteC (PR 3).
+func Bind(c *cobra.Command, opts any) error {
+	if c == nil {
+		return fmt.Errorf("structcli.Bind: command must not be nil")
+	}
+	if opts == nil {
+		return fmt.Errorf("structcli.Bind: opts must not be nil")
+	}
+
+	rv := reflect.ValueOf(opts)
+	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("structcli.Bind: opts must be a non-nil struct pointer, got %T", opts)
+	}
+
+	// Fast path: if opts implements Options, delegate to Attach.
+	// Attach typically calls Define internally, which handles validation,
+	// flag definition, viper binding, env binding, and usage setup.
+	if o, ok := opts.(Options); ok {
+		if err := o.Attach(c); err != nil {
+			return fmt.Errorf("structcli.Bind: Attach failed: %w", err)
+		}
+
+		internalscope.Get(c).AddBoundOptions(opts)
+
+		return nil
+	}
+
+	// Internal define path for plain struct pointers (no Attach method).
+	// Replicates the Define sequence: validate → define → BindPFlags → BindEnv → SetupUsage.
+	if err := internalvalidation.Struct(c, opts); err != nil {
+		return fmt.Errorf("structcli.Bind: %w", err)
+	}
+
+	if err := define(c, opts, "", "", nil, false, false, "validate", "mod"); err != nil {
+		return fmt.Errorf("structcli.Bind: %w", err)
+	}
+
+	v := GetViper(c)
+	v.BindPFlags(c.Flags())
+
+	if err := internalenv.BindEnv(c); err != nil {
+		return fmt.Errorf("structcli.Bind: couldn't bind environment variables: %w", err)
+	}
+
+	SetupUsage(c)
+
+	internalscope.Get(c).AddBoundOptions(opts)
+
+	return nil
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,0 +1,218 @@
+package structcli
+
+import (
+	"context"
+	"testing"
+
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Plain struct (no Attach) ---
+
+type bindPlainOpts struct {
+	Port int    `flag:"port" flagshort:"p" flagdescr:"server port" default:"3000"`
+	Host string `flag:"host" flagdescr:"server host" default:"localhost"`
+}
+
+// --- Options implementor (has Attach) ---
+
+type bindAttachOpts struct {
+	Verbose bool `flag:"verbose" flagshort:"v" flagdescr:"enable verbose output"`
+}
+
+func (o *bindAttachOpts) Attach(c *cobra.Command) error {
+	return Define(c, o)
+}
+
+// --- Standalone capability interfaces (no Attach) ---
+
+type bindValidatableOpts struct {
+	Name string `flag:"name" flagdescr:"user name" default:"world"`
+}
+
+func (o *bindValidatableOpts) Validate(context.Context) []error {
+	if o.Name == "" {
+		return []error{assert.AnError}
+	}
+
+	return nil
+}
+
+func (o *bindValidatableOpts) Transform(context.Context) error {
+	return nil
+}
+
+// --- Tests ---
+
+func TestBind_NilCommand(t *testing.T) {
+	err := Bind(nil, &bindPlainOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command must not be nil")
+}
+
+func TestBind_NilOpts(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	err := Bind(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opts must not be nil")
+}
+
+func TestBind_NonStructPointer(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+
+	err := Bind(cmd, "not a struct")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "struct pointer")
+
+	num := 42
+	err = Bind(cmd, &num)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "struct pointer")
+}
+
+func TestBind_PlainStruct_DefinesFlags(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindPlainOpts{}
+
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	// Flags should be registered
+	portFlag := cmd.Flags().Lookup("port")
+	require.NotNil(t, portFlag, "port flag should be defined")
+	assert.Equal(t, "p", portFlag.Shorthand)
+	assert.Equal(t, "3000", portFlag.DefValue)
+
+	hostFlag := cmd.Flags().Lookup("host")
+	require.NotNil(t, hostFlag, "host flag should be defined")
+	assert.Equal(t, "localhost", hostFlag.DefValue)
+}
+
+func TestBind_OptionsImplementor_CallsAttach(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindAttachOpts{}
+
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	// Flags should be registered via Attach → Define
+	verboseFlag := cmd.Flags().Lookup("verbose")
+	require.NotNil(t, verboseFlag, "verbose flag should be defined")
+	assert.Equal(t, "v", verboseFlag.Shorthand)
+}
+
+func TestBind_RegistersInScope(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindPlainOpts{}
+
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	scope := internalscope.Get(cmd)
+	bound := scope.BoundOptions()
+	require.Len(t, bound, 1)
+	assert.Same(t, opts, bound[0].(*bindPlainOpts))
+}
+
+func TestBind_MultipleCalls_PreservesOrder(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	plain := &bindPlainOpts{}
+	attach := &bindAttachOpts{}
+
+	require.NoError(t, Bind(cmd, plain))
+	require.NoError(t, Bind(cmd, attach))
+
+	scope := internalscope.Get(cmd)
+	bound := scope.BoundOptions()
+	require.Len(t, bound, 2)
+	assert.Same(t, plain, bound[0].(*bindPlainOpts), "first Bind should be first in list")
+	assert.Same(t, attach, bound[1].(*bindAttachOpts), "second Bind should be second in list")
+}
+
+func TestBind_PlainStruct_WithCapabilityInterfaces(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindValidatableOpts{}
+
+	// Should succeed — Validatable and Transformable don't require Attach
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	nameFlag := cmd.Flags().Lookup("name")
+	require.NotNil(t, nameFlag, "name flag should be defined")
+
+	// Verify it's registered in scope
+	scope := internalscope.Get(cmd)
+	bound := scope.BoundOptions()
+	require.Len(t, bound, 1)
+
+	// Verify it satisfies standalone interfaces but not Options
+	_, isValidatable := bound[0].(Validatable)
+	_, isTransformable := bound[0].(Transformable)
+	_, isOptions := bound[0].(Options)
+	assert.True(t, isValidatable)
+	assert.True(t, isTransformable)
+	assert.False(t, isOptions)
+}
+
+func TestBind_PlainStruct_FlagsWorkWithParsing(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindPlainOpts{}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	// Simulate flag parsing
+	cmd.SetArgs([]string{"--port", "8080", "--host", "0.0.0.0"})
+	require.NoError(t, cmd.ParseFlags([]string{"--port", "8080", "--host", "0.0.0.0"}))
+
+	// Flags should have the parsed values
+	portFlag := cmd.Flags().Lookup("port")
+	assert.Equal(t, "8080", portFlag.Value.String())
+
+	hostFlag := cmd.Flags().Lookup("host")
+	assert.Equal(t, "0.0.0.0", hostFlag.Value.String())
+}
+
+func TestBind_ScopeIsolation_DifferentCommands(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+
+	rootOpts := &bindPlainOpts{}
+	childOpts := &bindAttachOpts{}
+
+	require.NoError(t, Bind(root, rootOpts))
+	require.NoError(t, Bind(child, childOpts))
+
+	rootBound := internalscope.Get(root).BoundOptions()
+	childBound := internalscope.Get(child).BoundOptions()
+
+	require.Len(t, rootBound, 1)
+	require.Len(t, childBound, 1)
+	assert.Same(t, rootOpts, rootBound[0].(*bindPlainOpts))
+	assert.Same(t, childOpts, childBound[0].(*bindAttachOpts))
+}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -22,6 +22,7 @@ type Scope struct {
 	boundEnvs         map[string]bool
 	customDecodeHooks map[string]mapstructure.DecodeHookFunc
 	definedFlags      map[string]string
+	boundOptions      []any // ordered list of options registered via Bind, unmarshalled in FIFO order
 	mu                sync.RWMutex
 }
 
@@ -128,4 +129,27 @@ func (s *Scope) AddDefinedFlag(name, fieldPath string) error {
 	s.definedFlags[name] = fieldPath
 
 	return nil
+}
+
+// AddBoundOptions appends an options struct to the ordered list of bound options for this command.
+// Unmarshal order matches call order (FIFO).
+func (s *Scope) AddBoundOptions(opts any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.boundOptions = append(s.boundOptions, opts)
+}
+
+// BoundOptions returns a copy of the ordered list of bound options for this command.
+func (s *Scope) BoundOptions() []any {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.boundOptions) == 0 {
+		return nil
+	}
+
+	result := make([]any, len(s.boundOptions))
+	copy(result, s.boundOptions)
+
+	return result
 }


### PR DESCRIPTION
## Description

Add `structcli.Bind` as the new primary way to define flags from a struct and register it for auto-unmarshal during execution. PR 2 of 7 in the ergonomics spec.

**Changes:**

- **`bind.go`**: New `Bind(cmd *cobra.Command, opts any) error` function.
  - If `opts` implements `Options` (has `Attach`), delegates to `Attach`.
  - Otherwise uses the internal define path: `internalvalidation.Struct` → `define` → `BindPFlags` → `BindEnv` → `SetupUsage`.
  - Validates inputs: nil command, nil opts, non-struct-pointer all return errors.
  - Registers `opts` in the command's scope for later auto-unmarshal.

- **`internal/scope/scope.go`**: Add `boundOptions []any` field, `AddBoundOptions(opts any)`, and `BoundOptions() []any` methods. Unmarshal order matches call order (FIFO).

- **`bind_test.go`**: 10 tests covering:
  - Nil/invalid input rejection
  - Plain struct flag definition (no `Attach`)
  - `Options` implementor fast path via `Attach`
  - Scope registration and FIFO ordering
  - Multiple `Bind` calls per command
  - Standalone capability interfaces (`Validatable`, `Transformable`) without `Attach`
  - Flag parsing after `Bind`
  - Scope isolation across parent/child commands

Auto-unmarshal via the execution pipeline is not wired yet: that's PR #143.

## How to test

```
go test -v -run TestBind ./...
go test ./... -count=1
```