### PR TITLE
feat: add `ExecuteC` + bind pipeline for auto-unmarshal

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -1,0 +1,72 @@
+package structcli
+
+import (
+	"fmt"
+	"reflect"
+
+	internalenv "github.com/leodido/structcli/internal/env"
+	internalscope "github.com/leodido/structcli/internal/scope"
+	internalvalidation "github.com/leodido/structcli/internal/validation"
+	"github.com/spf13/cobra"
+)
+
+// Bind defines flags from opts on cmd and registers opts for auto-unmarshal
+// during ExecuteC/ExecuteOrExit.
+//
+// opts must be a non-nil struct pointer. If opts implements Options (has Attach),
+// Attach is called. Otherwise flags are defined directly from struct tags.
+//
+// Multiple Bind calls per command are supported; unmarshal order matches call order (FIFO).
+// Define runs immediately — flags exist on the command after Bind returns.
+//
+// The current manual Unmarshal model still works. Auto-unmarshal via the execution
+// pipeline is wired in ExecuteC (PR 3).
+func Bind(c *cobra.Command, opts any) error {
+	if c == nil {
+		return fmt.Errorf("structcli.Bind: command must not be nil")
+	}
+	if opts == nil {
+		return fmt.Errorf("structcli.Bind: opts must not be nil")
+	}
+
+	rv := reflect.ValueOf(opts)
+	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("structcli.Bind: opts must be a non-nil struct pointer, got %T", opts)
+	}
+
+	// Fast path: if opts implements Options, delegate to Attach.
+	// Attach typically calls Define internally, which handles validation,
+	// flag definition, viper binding, env binding, and usage setup.
+	if o, ok := opts.(Options); ok {
+		if err := o.Attach(c); err != nil {
+			return fmt.Errorf("structcli.Bind: Attach failed: %w", err)
+		}
+
+		internalscope.Get(c).AddBoundOptions(opts)
+
+		return nil
+	}
+
+	// Internal define path for plain struct pointers (no Attach method).
+	// Replicates the Define sequence: validate → define → BindPFlags → BindEnv → SetupUsage.
+	if err := internalvalidation.Struct(c, opts); err != nil {
+		return fmt.Errorf("structcli.Bind: %w", err)
+	}
+
+	if err := define(c, opts, "", "", nil, false, false, "validate", "mod"); err != nil {
+		return fmt.Errorf("structcli.Bind: %w", err)
+	}
+
+	v := GetViper(c)
+	v.BindPFlags(c.Flags())
+
+	if err := internalenv.BindEnv(c); err != nil {
+		return fmt.Errorf("structcli.Bind: couldn't bind environment variables: %w", err)
+	}
+
+	SetupUsage(c)
+
+	internalscope.Get(c).AddBoundOptions(opts)
+
+	return nil
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,0 +1,218 @@
+package structcli
+
+import (
+	"context"
+	"testing"
+
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Plain struct (no Attach) ---
+
+type bindPlainOpts struct {
+	Port int    `flag:"port" flagshort:"p" flagdescr:"server port" default:"3000"`
+	Host string `flag:"host" flagdescr:"server host" default:"localhost"`
+}
+
+// --- Options implementor (has Attach) ---
+
+type bindAttachOpts struct {
+	Verbose bool `flag:"verbose" flagshort:"v" flagdescr:"enable verbose output"`
+}
+
+func (o *bindAttachOpts) Attach(c *cobra.Command) error {
+	return Define(c, o)
+}
+
+// --- Standalone capability interfaces (no Attach) ---
+
+type bindValidatableOpts struct {
+	Name string `flag:"name" flagdescr:"user name" default:"world"`
+}
+
+func (o *bindValidatableOpts) Validate(context.Context) []error {
+	if o.Name == "" {
+		return []error{assert.AnError}
+	}
+
+	return nil
+}
+
+func (o *bindValidatableOpts) Transform(context.Context) error {
+	return nil
+}
+
+// --- Tests ---
+
+func TestBind_NilCommand(t *testing.T) {
+	err := Bind(nil, &bindPlainOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command must not be nil")
+}
+
+func TestBind_NilOpts(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	err := Bind(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opts must not be nil")
+}
+
+func TestBind_NonStructPointer(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+
+	err := Bind(cmd, "not a struct")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "struct pointer")
+
+	num := 42
+	err = Bind(cmd, &num)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "struct pointer")
+}
+
+func TestBind_PlainStruct_DefinesFlags(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindPlainOpts{}
+
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	// Flags should be registered
+	portFlag := cmd.Flags().Lookup("port")
+	require.NotNil(t, portFlag, "port flag should be defined")
+	assert.Equal(t, "p", portFlag.Shorthand)
+	assert.Equal(t, "3000", portFlag.DefValue)
+
+	hostFlag := cmd.Flags().Lookup("host")
+	require.NotNil(t, hostFlag, "host flag should be defined")
+	assert.Equal(t, "localhost", hostFlag.DefValue)
+}
+
+func TestBind_OptionsImplementor_CallsAttach(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindAttachOpts{}
+
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	// Flags should be registered via Attach → Define
+	verboseFlag := cmd.Flags().Lookup("verbose")
+	require.NotNil(t, verboseFlag, "verbose flag should be defined")
+	assert.Equal(t, "v", verboseFlag.Shorthand)
+}
+
+func TestBind_RegistersInScope(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindPlainOpts{}
+
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	scope := internalscope.Get(cmd)
+	bound := scope.BoundOptions()
+	require.Len(t, bound, 1)
+	assert.Same(t, opts, bound[0].(*bindPlainOpts))
+}
+
+func TestBind_MultipleCalls_PreservesOrder(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	plain := &bindPlainOpts{}
+	attach := &bindAttachOpts{}
+
+	require.NoError(t, Bind(cmd, plain))
+	require.NoError(t, Bind(cmd, attach))
+
+	scope := internalscope.Get(cmd)
+	bound := scope.BoundOptions()
+	require.Len(t, bound, 2)
+	assert.Same(t, plain, bound[0].(*bindPlainOpts), "first Bind should be first in list")
+	assert.Same(t, attach, bound[1].(*bindAttachOpts), "second Bind should be second in list")
+}
+
+func TestBind_PlainStruct_WithCapabilityInterfaces(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindValidatableOpts{}
+
+	// Should succeed — Validatable and Transformable don't require Attach
+	err := Bind(cmd, opts)
+	require.NoError(t, err)
+
+	nameFlag := cmd.Flags().Lookup("name")
+	require.NotNil(t, nameFlag, "name flag should be defined")
+
+	// Verify it's registered in scope
+	scope := internalscope.Get(cmd)
+	bound := scope.BoundOptions()
+	require.Len(t, bound, 1)
+
+	// Verify it satisfies standalone interfaces but not Options
+	_, isValidatable := bound[0].(Validatable)
+	_, isTransformable := bound[0].(Transformable)
+	_, isOptions := bound[0].(Options)
+	assert.True(t, isValidatable)
+	assert.True(t, isTransformable)
+	assert.False(t, isOptions)
+}
+
+func TestBind_PlainStruct_FlagsWorkWithParsing(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{Use: "test"}
+	opts := &bindPlainOpts{}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	// Simulate flag parsing
+	cmd.SetArgs([]string{"--port", "8080", "--host", "0.0.0.0"})
+	require.NoError(t, cmd.ParseFlags([]string{"--port", "8080", "--host", "0.0.0.0"}))
+
+	// Flags should have the parsed values
+	portFlag := cmd.Flags().Lookup("port")
+	assert.Equal(t, "8080", portFlag.Value.String())
+
+	hostFlag := cmd.Flags().Lookup("host")
+	assert.Equal(t, "0.0.0.0", hostFlag.Value.String())
+}
+
+func TestBind_ScopeIsolation_DifferentCommands(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+
+	rootOpts := &bindPlainOpts{}
+	childOpts := &bindAttachOpts{}
+
+	require.NoError(t, Bind(root, rootOpts))
+	require.NoError(t, Bind(child, childOpts))
+
+	rootBound := internalscope.Get(root).BoundOptions()
+	childBound := internalscope.Get(child).BoundOptions()
+
+	require.Len(t, rootBound, 1)
+	require.Len(t, childBound, 1)
+	assert.Same(t, rootOpts, rootBound[0].(*bindPlainOpts))
+	assert.Same(t, childOpts, childBound[0].(*bindAttachOpts))
+}

--- a/contract.go
+++ b/contract.go
@@ -13,9 +13,37 @@ type Options interface {
 	Attach(*cobra.Command) error
 }
 
+// Validatable is a struct that supports validation after unmarshalling.
+//
+// Validate is called automatically during Unmarshal(), after Transform.
+// Does not require Options (Attach) — works with plain struct pointers via Bind.
+type Validatable interface {
+	Validate(context.Context) []error
+}
+
+// Transformable is a struct that supports transformation after unmarshalling.
+//
+// Transform is called automatically during Unmarshal(), before Validate.
+// Does not require Options (Attach) — works with plain struct pointers via Bind.
+type Transformable interface {
+	Transform(context.Context) error
+}
+
+// ContextInjector is a struct that propagates values into the command context after unmarshalling.
+//
+// Context is called automatically during Unmarshal() to derive a new context.
+// Does not require Options (Attach) — works with plain struct pointers via Bind.
+//
+// FromContext (reading values back from context) is a user-side pattern, not part of this interface.
+type ContextInjector interface {
+	Context(context.Context) context.Context
+}
+
 // ValidatableOptions extends Options with validation capabilities.
 //
-// The Validate method is called automatically during Unmarshal().
+// Deprecated: Use Validatable instead. ValidatableOptions requires implementing Attach,
+// which is unnecessary for validation. Validatable works with both Options implementors
+// and plain struct pointers.
 type ValidatableOptions interface {
 	Options
 	Validate(context.Context) []error
@@ -23,7 +51,9 @@ type ValidatableOptions interface {
 
 // TransformableOptions extends Options with transformation capabilities.
 //
-// The Transform method is called automatically during Unmarshal() before validation.
+// Deprecated: Use Transformable instead. TransformableOptions requires implementing Attach,
+// which is unnecessary for transformation. Transformable works with both Options implementors
+// and plain struct pointers.
 type TransformableOptions interface {
 	Options
 	Transform(context.Context) error
@@ -49,7 +79,9 @@ type EnumValuer interface {
 
 // ContextOptions extends Options with context manipulation capabilities.
 //
-// The Context method is called automatically during Unmarshal() to modify the command context.
+// Deprecated: Use ContextInjector instead. ContextInjector only requires the Context method
+// (propagation). FromContext is a user-side pattern — structcli never calls it internally.
+// ContextInjector works with both Options implementors and plain struct pointers.
 type ContextOptions interface {
 	Options
 	Context(context.Context) context.Context

--- a/contract_test.go
+++ b/contract_test.go
@@ -9,9 +9,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// --- Standalone interface test types ---
+
 type validateOnlyOptions struct{}
 
 func (o *validateOnlyOptions) Validate(context.Context) []error { return nil }
+
+type transformOnlyOptions struct{}
+
+func (o *transformOnlyOptions) Transform(context.Context) error { return nil }
+
+type contextInjectorOnly struct{}
+
+func (o *contextInjectorOnly) Context(ctx context.Context) context.Context { return ctx }
+
+// --- Deprecated interface test types (with Attach) ---
 
 type validateWithAttachOptions struct{}
 
@@ -20,14 +32,25 @@ func (o *validateWithAttachOptions) Validate(context.Context) []error {
 	return nil
 }
 
-type transformOnlyOptions struct{}
-
-func (o *transformOnlyOptions) Transform(context.Context) error { return nil }
-
 type transformWithAttachOptions struct{}
 
 func (o *transformWithAttachOptions) Attach(*cobra.Command) error { return nil }
 func (o *transformWithAttachOptions) Transform(context.Context) error {
+	return nil
+}
+
+type contextOptionsWithAttach struct{}
+
+func (o *contextOptionsWithAttach) Attach(*cobra.Command) error              { return nil }
+func (o *contextOptionsWithAttach) Context(ctx context.Context) context.Context { return ctx }
+func (o *contextOptionsWithAttach) FromContext(context.Context) error         { return nil }
+
+// --- Types implementing both standalone and deprecated ---
+
+type validateBothInterfaces struct{}
+
+func (o *validateBothInterfaces) Attach(*cobra.Command) error { return nil }
+func (o *validateBothInterfaces) Validate(context.Context) []error {
 	return nil
 }
 
@@ -52,5 +75,62 @@ func TestOptionContracts(t *testing.T) {
 
 		assert.False(t, transformOnlyImplements)
 		assert.True(t, transformWithAttachImplements)
+	})
+}
+
+func TestStandaloneCapabilityInterfaces(t *testing.T) {
+	t.Run("Validatable does not require Attach", func(t *testing.T) {
+		var v any = &validateOnlyOptions{}
+		_, ok := v.(structcli.Validatable)
+		assert.True(t, ok, "validateOnlyOptions should implement Validatable")
+
+		_, hasAttach := v.(structcli.Options)
+		assert.False(t, hasAttach, "validateOnlyOptions should not implement Options")
+	})
+
+	t.Run("Transformable does not require Attach", func(t *testing.T) {
+		var v any = &transformOnlyOptions{}
+		_, ok := v.(structcli.Transformable)
+		assert.True(t, ok, "transformOnlyOptions should implement Transformable")
+
+		_, hasAttach := v.(structcli.Options)
+		assert.False(t, hasAttach, "transformOnlyOptions should not implement Options")
+	})
+
+	t.Run("ContextInjector does not require Attach", func(t *testing.T) {
+		var v any = &contextInjectorOnly{}
+		_, ok := v.(structcli.ContextInjector)
+		assert.True(t, ok, "contextInjectorOnly should implement ContextInjector")
+
+		_, hasAttach := v.(structcli.Options)
+		assert.False(t, hasAttach, "contextInjectorOnly should not implement Options")
+
+		_, hasFromContext := v.(structcli.ContextOptions)
+		assert.False(t, hasFromContext, "contextInjectorOnly should not implement ContextOptions")
+	})
+
+	t.Run("ContextInjector does not require FromContext", func(t *testing.T) {
+		var v any = &contextInjectorOnly{}
+		_, ok := v.(structcli.ContextInjector)
+		assert.True(t, ok)
+		// ContextInjector only has Context(), not FromContext()
+	})
+
+	t.Run("deprecated interfaces still satisfied by types with Attach", func(t *testing.T) {
+		var v any = &validateBothInterfaces{}
+
+		_, isValidatable := v.(structcli.Validatable)
+		_, isValidatableOptions := v.(structcli.ValidatableOptions)
+		assert.True(t, isValidatable, "should implement Validatable")
+		assert.True(t, isValidatableOptions, "should still implement ValidatableOptions")
+	})
+
+	t.Run("ContextOptions type also satisfies ContextInjector", func(t *testing.T) {
+		var v any = &contextOptionsWithAttach{}
+
+		_, isInjector := v.(structcli.ContextInjector)
+		_, isContextOptions := v.(structcli.ContextOptions)
+		assert.True(t, isInjector, "ContextOptions implementor should also satisfy ContextInjector")
+		assert.True(t, isContextOptions, "should still implement ContextOptions")
 	})
 }

--- a/define.go
+++ b/define.go
@@ -208,10 +208,13 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			presets = filtered
 		}
 
-		// Determine whether to represent hierarchy with the command name
-		// We assume that options that are not context options are subcommand-specific options
+		// Determine whether to represent hierarchy with the command name.
+		// Context-injecting options are treated as shared/common (no command name prefix in env vars).
+		// Prefer ContextInjector (standalone); fall back to deprecated ContextOptions.
 		cName := ""
-		if _, isContextOptions := o.(ContextOptions); !isContextOptions {
+		_, isContextInjector := o.(ContextInjector)
+		_, isContextOptions := o.(ContextOptions)
+		if !isContextInjector && !isContextOptions {
 			cName = c.Name()
 		}
 

--- a/execute.go
+++ b/execute.go
@@ -1,0 +1,167 @@
+package structcli
+
+import (
+	internalcmd "github.com/leodido/structcli/internal/cmd"
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+const bindPipelineAnnotation = "structcli/bind-pipeline-wrapped"
+
+// originalHookKey is used to store original persistent hooks before wrapping.
+const originalPreRunEKey = "structcli/original-persistent-prerun-e"
+const originalPreRunKey = "structcli/original-persistent-prerun"
+
+// originalHooks stores the original PersistentPreRunE/PersistentPreRun per command,
+// keyed by command pointer. We use a separate map because annotations are string-only.
+var originalHooks = struct {
+	preRunE map[*cobra.Command]func(*cobra.Command, []string) error
+	preRun  map[*cobra.Command]func(*cobra.Command, []string)
+}{
+	preRunE: make(map[*cobra.Command]func(*cobra.Command, []string) error),
+	preRun:  make(map[*cobra.Command]func(*cobra.Command, []string)),
+}
+
+// ExecuteC prepares the command tree for execution and delegates to cmd.ExecuteC().
+//
+// Preparation (idempotent — safe to call multiple times on the same tree):
+//   - Sets SilenceErrors and SilenceUsage on the root command.
+//   - Runs SetupUsage on every command in the tree.
+//   - Recursively wraps PersistentPreRunE on every command to run the bind pipeline
+//     (auto-unmarshal for all Bind-registered options, root-to-leaf, FIFO per command).
+//   - Skips the bind pipeline when execution is intercepted (--jsonschema, --mcp).
+//   - Preserves any user-set PersistentPreRunE or PersistentPreRun.
+//
+// Returns the executed subcommand and any error.
+func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
+	root := cmd.Root()
+
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+
+	prepareTree(root)
+
+	return cmd.ExecuteC()
+}
+
+// prepareTree walks the command tree and installs the bind pipeline wrapper
+// and SetupUsage on every command. Idempotent via annotation guard.
+func prepareTree(c *cobra.Command) {
+	if c == nil {
+		return
+	}
+
+	SetupUsage(c)
+	wrapBindPipeline(c)
+
+	for _, sub := range c.Commands() {
+		prepareTree(sub)
+	}
+}
+
+// wrapBindPipeline installs a PersistentPreRunE on c that runs the bind
+// pipeline before chaining to original hooks. Idempotent.
+//
+// Because Cobra (without EnableTraverseRunHooks) only executes the first
+// PersistentPreRunE it finds walking from the executed command upward,
+// every command in the tree gets a wrapper. The wrapper itself runs the
+// full root-to-leaf pipeline and then replays all original ancestor
+// persistent hooks in root-first order. This ensures user hooks on
+// ancestor commands fire even when a descendant's wrapper is the one
+// Cobra picks.
+func wrapBindPipeline(c *cobra.Command) {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string)
+	}
+	if c.Annotations[bindPipelineAnnotation] == "true" {
+		return
+	}
+
+	// Save original hooks before overwriting.
+	if c.PersistentPreRunE != nil {
+		originalHooks.preRunE[c] = c.PersistentPreRunE
+	}
+	if c.PersistentPreRun != nil {
+		originalHooks.preRun[c] = c.PersistentPreRun
+	}
+
+	c.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// Skip pipeline on intercepted execution (--jsonschema, --mcp, etc.)
+		if internalcmd.IsExecutionIntercepted(cmd) {
+			return nil
+		}
+
+		// Run bind pipeline: walk root → executed command, unmarshal bound options.
+		if err := runBindPipeline(cmd); err != nil {
+			return err
+		}
+
+		// Replay original persistent hooks from root to the command whose
+		// wrapper Cobra selected (which is cmd's closest ancestor with a
+		// PersistentPreRunE — i.e., this command c, since we wrapped it).
+		// We replay all ancestors' original hooks in root-first order so
+		// user hooks on parent commands still fire.
+		if err := replayOriginalHooks(cmd, args); err != nil {
+			return err
+		}
+
+		return nil
+	}
+	c.PersistentPreRun = nil
+
+	c.Annotations[bindPipelineAnnotation] = "true"
+}
+
+// replayOriginalHooks walks from root to the executed command and calls
+// any original PersistentPreRunE or PersistentPreRun that was saved
+// before wrapping, in root-first order.
+func replayOriginalHooks(executedCmd *cobra.Command, args []string) error {
+	path := pathToRoot(executedCmd)
+
+	for _, c := range path {
+		if hook, ok := originalHooks.preRunE[c]; ok {
+			if err := hook(executedCmd, args); err != nil {
+				return err
+			}
+		} else if hook, ok := originalHooks.preRun[c]; ok {
+			hook(executedCmd, args)
+		}
+	}
+
+	return nil
+}
+
+// runBindPipeline walks from root to the executed command, collecting bound
+// options from each command's scope, and calls unmarshal for each in FIFO order.
+//
+// Every Unmarshal call receives the executed command (not the owning command),
+// because Unmarshal rebuilds flag metadata by walking from the passed command
+// upward through its ancestors.
+func runBindPipeline(executedCmd *cobra.Command) error {
+	path := pathToRoot(executedCmd)
+
+	for _, c := range path {
+		scope := internalscope.Get(c)
+		for _, opts := range scope.BoundOptions() {
+			if err := unmarshal(executedCmd, opts); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// pathToRoot returns the path from root to cmd (root-first order).
+func pathToRoot(cmd *cobra.Command) []*cobra.Command {
+	var path []*cobra.Command
+	for c := cmd; c != nil; c = c.Parent() {
+		path = append(path, c)
+	}
+	// Reverse to get root-first order.
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+
+	return path
+}

--- a/execute_test.go
+++ b/execute_test.go
@@ -1,0 +1,461 @@
+package structcli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test option types ---
+
+type execPlainOpts struct {
+	Port int    `flag:"port" flagshort:"p" flagdescr:"server port" default:"3000"`
+	Host string `flag:"host" flagdescr:"server host" default:"localhost"`
+}
+
+type execAttachOpts struct {
+	Verbose bool `flag:"verbose" flagshort:"v" flagdescr:"verbose output"`
+}
+
+func (o *execAttachOpts) Attach(c *cobra.Command) error {
+	return Define(c, o)
+}
+
+type execContextOpts struct {
+	AppName string `flag:"app-name" flagdescr:"application name" default:"myapp"`
+}
+
+func (o *execContextOpts) Context(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKey("app-name"), o.AppName)
+}
+
+type ctxKey string
+
+type execChildOpts struct {
+	Debug bool `flag:"debug" flagshort:"d" flagdescr:"enable debug"`
+}
+
+// --- Tests ---
+
+func TestExecuteC_BasicExecution(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var ran bool
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			ran = true
+			return nil
+		},
+	}
+
+	c, err := ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.True(t, ran)
+	assert.Equal(t, "test", c.Name())
+}
+
+func TestExecuteC_AutoUnmarshal_PlainStruct(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{"--port", "8080", "--host", "0.0.0.0"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 8080, opts.Port)
+	assert.Equal(t, "0.0.0.0", opts.Host)
+}
+
+func TestExecuteC_AutoUnmarshal_OptionsImplementor(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execAttachOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{"--verbose"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, opts.Verbose)
+}
+
+func TestExecuteC_AutoUnmarshal_Defaults(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3000, opts.Port)
+	assert.Equal(t, "localhost", opts.Host)
+}
+
+func TestExecuteC_PopulatedBeforePreRunE(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var portInPreRun int
+
+	cmd := &cobra.Command{
+		Use: "test",
+		PreRunE: func(c *cobra.Command, args []string) error {
+			portInPreRun = opts.Port
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{"--port", "9090"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 9090, portInPreRun, "opts should be populated before PreRunE")
+}
+
+func TestExecuteC_MultipleBind_FIFOOrder(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	plain := &execPlainOpts{}
+	attach := &execAttachOpts{}
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, plain))
+	require.NoError(t, Bind(cmd, attach))
+
+	cmd.SetArgs([]string{"--port", "4000", "--verbose"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4000, plain.Port)
+	assert.True(t, attach.Verbose)
+}
+
+func TestExecuteC_AncestorBeforeDescendant(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	rootOpts := &execContextOpts{}
+	childOpts := &execChildOpts{}
+
+	var ctxValueInRun string
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			// rootOpts.Context() should have been called before childOpts unmarshal
+			if v := c.Context().Value(ctxKey("app-name")); v != nil {
+				ctxValueInRun = v.(string)
+			}
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	// Bind rootOpts on child too — flags are local per command.
+	// The ancestor-before-descendant contract is about unmarshal order
+	// when both root and child have bound options.
+	require.NoError(t, Bind(root, rootOpts))
+	require.NoError(t, Bind(child, childOpts))
+
+	// rootOpts flags are on root (local), childOpts flags are on child (local).
+	// Execute child with child-local flags only; root opts get defaults.
+	root.SetArgs([]string{"child", "--debug"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, "myapp", rootOpts.AppName, "root opts should get default value")
+	assert.True(t, childOpts.Debug)
+	assert.Equal(t, "myapp", ctxValueInRun, "root context injection should be visible in child RunE")
+}
+
+func TestExecuteC_PreservesUserPersistentPreRunE(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var userHookRan bool
+	var portInUserHook int
+
+	cmd := &cobra.Command{
+		Use: "root",
+	}
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		userHookRan = true
+		portInUserHook = opts.Port
+		return nil
+	}
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.AddCommand(child)
+
+	// Bind on child so flags are local to child
+	require.NoError(t, Bind(child, opts))
+
+	cmd.SetArgs([]string{"child", "--port", "5555"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, userHookRan, "user PersistentPreRunE should still run")
+	assert.Equal(t, 5555, portInUserHook, "opts should be populated before user hook")
+}
+
+func TestExecuteC_PreservesUserPersistentPreRun(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var userHookRan bool
+
+	cmd := &cobra.Command{
+		Use: "root",
+	}
+	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+		userHookRan = true
+	}
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.AddCommand(child)
+
+	// Bind on child so flags are local to child
+	require.NoError(t, Bind(child, opts))
+
+	cmd.SetArgs([]string{"child", "--port", "5555"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, userHookRan, "user PersistentPreRun should still run")
+}
+
+func TestExecuteC_SilencesErrorsAndUsage(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, cmd.SilenceErrors)
+	assert.True(t, cmd.SilenceUsage)
+}
+
+func TestExecuteC_Idempotent(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var runCount int
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			runCount++
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	// First execution
+	cmd.SetArgs([]string{"--port", "1111"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, 1111, opts.Port)
+	assert.Equal(t, 1, runCount)
+
+	// Second execution on same tree — wrappers should not stack
+	cmd.SetArgs([]string{"--port", "2222"})
+	_, err = ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, 2222, opts.Port)
+	assert.Equal(t, 2, runCount)
+}
+
+func TestExecuteC_NoBoundOptions_StillWorks(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var ran bool
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			ran = true
+			return nil
+		},
+	}
+
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.True(t, ran)
+}
+
+func TestExecuteC_AutoSetupUsage(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	// No manual SetupUsage call needed
+	root.SetArgs([]string{"child"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	// Verify annotation was set (proves prepareTree ran)
+	assert.Equal(t, "true", root.Annotations[bindPipelineAnnotation])
+	assert.Equal(t, "true", child.Annotations[bindPipelineAnnotation])
+}
+
+func TestExecuteC_ChildPersistentPreRunE_DoesNotShadowPipeline(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	rootOpts := &execPlainOpts{}
+	childOpts := &execChildOpts{}
+	var childHookRan bool
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	child.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		childHookRan = true
+		return nil
+	}
+	root.AddCommand(child)
+
+	// Bind rootOpts on root (gets defaults), childOpts on child (gets flags)
+	require.NoError(t, Bind(root, rootOpts))
+	require.NoError(t, Bind(child, childOpts))
+
+	root.SetArgs([]string{"child", "--debug"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	// Root opts should be unmarshalled with defaults even though child has its own PersistentPreRunE
+	assert.Equal(t, 3000, rootOpts.Port, "root bound opts should be unmarshalled with defaults")
+	assert.True(t, childOpts.Debug, "child bound opts should be unmarshalled")
+	assert.True(t, childHookRan, "child's original PersistentPreRunE should still run")
+}
+
+func TestExecuteC_ErrorInUnmarshal_Propagates(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	// Bind an opts struct, then corrupt the scope to force an unmarshal error.
+	opts := &execPlainOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	// Manually add a non-struct to bound options to trigger unmarshal error
+	internalscope.Get(cmd).AddBoundOptions("not-a-struct-pointer")
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.Error(t, err, "unmarshal of invalid bound option should propagate error")
+}
+
+func TestExecuteC_ErrorInUserHook_Propagates(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	hookErr := fmt.Errorf("user hook failed")
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		return hookErr
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, hookErr)
+}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -22,6 +22,7 @@ type Scope struct {
 	boundEnvs         map[string]bool
 	customDecodeHooks map[string]mapstructure.DecodeHookFunc
 	definedFlags      map[string]string
+	boundOptions      []any // ordered list of options registered via Bind, unmarshalled in FIFO order
 	mu                sync.RWMutex
 }
 
@@ -128,4 +129,27 @@ func (s *Scope) AddDefinedFlag(name, fieldPath string) error {
 	s.definedFlags[name] = fieldPath
 
 	return nil
+}
+
+// AddBoundOptions appends an options struct to the ordered list of bound options for this command.
+// Unmarshal order matches call order (FIFO).
+func (s *Scope) AddBoundOptions(opts any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.boundOptions = append(s.boundOptions, opts)
+}
+
+// BoundOptions returns a copy of the ordered list of bound options for this command.
+func (s *Scope) BoundOptions() []any {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.boundOptions) == 0 {
+		return nil
+	}
+
+	result := make([]any, len(s.boundOptions))
+	copy(result, s.boundOptions)
+
+	return result
 }

--- a/structerr.go
+++ b/structerr.go
@@ -159,25 +159,15 @@ func HandleError(cmd *cobra.Command, err error, w io.Writer) int {
 	return se.ExitCode
 }
 
-// ExecuteOrExit runs cmd.Execute(). On error it writes structured JSON to stderr
-// and exits with a semantic exit code. On success it exits 0.
-//
-// It automatically sets SilenceErrors and SilenceUsage on the root command
-// so cobra doesn't print its own error messages or usage text — structcli
-// handles all error output as structured JSON.
-//
-// This is a convenience wrapper for the common main() pattern:
+// ExecuteOrExit is a convenience wrapper around ExecuteC for the common main() pattern.
+// On error it writes structured JSON to stderr and exits with a semantic exit code.
+// On success it exits 0.
 //
 //	func main() {
 //	    structcli.ExecuteOrExit(buildMyCLI())
 //	}
 func ExecuteOrExit(cmd *cobra.Command) {
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-
-	// ExecuteC returns the actual subcommand that ran (or failed),
-	// giving HandleError the correct flag set for metadata lookups.
-	c, err := cmd.ExecuteC()
+	c, err := ExecuteC(cmd)
 	if err != nil {
 		os.Exit(HandleError(c, err, os.Stderr))
 	}

--- a/viper.go
+++ b/viper.go
@@ -151,20 +151,36 @@ func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookF
 		return fmt.Errorf("couldn't unmarshal config to options: %w", err)
 	}
 
-	// Automatically set common options into the context of the cobra command
-	if o, ok := opts.(ContextOptions); ok {
+	// Automatically set common options into the context of the cobra command.
+	// Prefer ContextInjector (standalone); fall back to deprecated ContextOptions.
+	if o, ok := opts.(ContextInjector); ok {
+		c.SetContext(o.Context(c.Context()))
+	} else if o, ok := opts.(ContextOptions); ok {
 		c.SetContext(o.Context(c.Context()))
 	}
 
-	// Automatically transform options if feasible
-	if o, ok := opts.(TransformableOptions); ok {
+	// Automatically transform options if feasible.
+	// Prefer Transformable (standalone); fall back to deprecated TransformableOptions.
+	if o, ok := opts.(Transformable); ok {
+		if transformErr := o.Transform(c.Context()); transformErr != nil {
+			return fmt.Errorf("couldn't transform options: %w", transformErr)
+		}
+	} else if o, ok := opts.(TransformableOptions); ok {
 		if transformErr := o.Transform(c.Context()); transformErr != nil {
 			return fmt.Errorf("couldn't transform options: %w", transformErr)
 		}
 	}
 
-	// Automatically run options validation if feasible
-	if o, ok := opts.(ValidatableOptions); ok {
+	// Automatically run options validation if feasible.
+	// Prefer Validatable (standalone); fall back to deprecated ValidatableOptions.
+	if o, ok := opts.(Validatable); ok {
+		if validationErrors := o.Validate(c.Context()); validationErrors != nil {
+			return &structclierrors.ValidationError{
+				ContextName: c.Name(),
+				Errors:      validationErrors,
+			}
+		}
+	} else if o, ok := opts.(ValidatableOptions); ok {
 		if validationErrors := o.Validate(c.Context()); validationErrors != nil {
 			return &structclierrors.ValidationError{
 				ContextName: c.Name(),

--- a/viper.go
+++ b/viper.go
@@ -88,6 +88,13 @@ func GetConfigViper(c *cobra.Command) *viper.Viper {
 // Before decoding, Unmarshal merges command-relevant config from the root-scoped
 // config-source viper (GetConfigViper(c)).
 func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookFunc) error {
+	return unmarshal(c, opts, hooks...)
+}
+
+// unmarshal is the internal implementation that accepts any (struct pointer).
+// The public Unmarshal constrains to Options for API compatibility;
+// the bind pipeline uses this directly for plain struct pointers.
+func unmarshal(c *cobra.Command, opts any, hooks ...mapstructure.DecodeHookFunc) error {
 	// Reject CLI usage of env-only flags before any resolution.
 	if err := rejectEnvOnlyCLIUsage(c); err != nil {
 		return err


### PR DESCRIPTION
## Description

Add `ExecuteC` as the non-exiting execution entry point and wire the bind pipeline that makes `Bind` actually ergonomic. PR 3 of 7 in the ergonomics spec.

### Commits

**1. `refactor: extract internal unmarshal accepting any`**
Split `Unmarshal` into a public wrapper (`Options` constraint) and an internal `unmarshal` function (`any`). The bind pipeline needs to call unmarshal for plain struct pointers that don't implement `Options`.

**2. `feat: add ExecuteC and refactor ExecuteOrExit`**
- `ExecuteC(cmd) (*cobra.Command, error)` — prepares the tree and delegates to `cmd.ExecuteC()`.
- Sets `SilenceErrors`/`SilenceUsage` on root.
- Auto-`SetupUsage` on every command (idempotent).
- Recursively wraps `PersistentPreRunE` on every command in the tree (idempotent via `structcli/bind-pipeline-wrapped` annotation).
- Each wrapper: skips on intercepted execution → runs bind pipeline (root-to-leaf, FIFO per command) → replays original ancestor persistent hooks (root-first).
- `Unmarshal(executedCmd, opts)` — executed command passed, not owner, so flag metadata walking works across ancestor boundaries.
- `ExecuteOrExit` refactored to thin wrapper: `ExecuteC` → `HandleError` + `os.Exit`.

The recursive wrapping solves Cobra's hook-shadowing problem: without `EnableTraverseRunHooks`, Cobra only runs the first `PersistentPreRunE` it finds walking upward. By wrapping every command, whichever one Cobra picks runs the full pipeline and replays all ancestor hooks.

**3. `test: ExecuteC bind pipeline, hook preservation, idempotency`**
16 tests covering auto-unmarshal, defaults, populated-before-PreRunE, FIFO ordering, ancestor-before-descendant, user hook preservation (both `PersistentPreRunE` and `PersistentPreRun`), SilenceErrors, idempotency, auto-SetupUsage, child hook shadowing, and error propagation.

## How to test

```
go test -v -run TestExecuteC .
go test ./... -count=1
```