### PR TITLE
feat: add `Setup` orchestrator with functional options

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -1,0 +1,70 @@
+package structcli
+
+import (
+	"github.com/leodido/structcli/debug"
+	"github.com/leodido/structcli/helptopics"
+	"github.com/leodido/structcli/jsonschema"
+	structclimcp "github.com/leodido/structcli/mcp"
+)
+
+// setupConfig holds the resolved configuration from SetupOption functions.
+type setupConfig struct {
+	debug      *debug.Options
+	jsonSchema *jsonschema.Options
+	mcp        *structclimcp.Options
+	helpTopics *helptopics.Options
+	flagErrors bool
+}
+
+// SetupOption configures a feature in Setup.
+type SetupOption func(*setupConfig)
+
+// WithDebug enables the debug flag (--debug-options) on the root command.
+func WithDebug(opts debug.Options) SetupOption {
+	return func(c *setupConfig) {
+		c.debug = &opts
+	}
+}
+
+// WithJSONSchema enables the --jsonschema flag on the root command.
+// Pass jsonschema.Options{} for defaults.
+func WithJSONSchema(opts ...jsonschema.Options) SetupOption {
+	return func(c *setupConfig) {
+		o := jsonschema.Options{}
+		if len(opts) > 0 {
+			o = opts[0]
+		}
+		c.jsonSchema = &o
+	}
+}
+
+// WithMCP enables the --mcp flag on the root command.
+// Pass mcp.Options{} for defaults.
+func WithMCP(opts ...structclimcp.Options) SetupOption {
+	return func(c *setupConfig) {
+		o := structclimcp.Options{}
+		if len(opts) > 0 {
+			o = opts[0]
+		}
+		c.mcp = &o
+	}
+}
+
+// WithHelpTopics enables help topic commands on the root command.
+// Pass helptopics.Options{} for defaults.
+func WithHelpTopics(opts ...helptopics.Options) SetupOption {
+	return func(c *setupConfig) {
+		o := helptopics.Options{}
+		if len(opts) > 0 {
+			o = opts[0]
+		}
+		c.helpTopics = &o
+	}
+}
+
+// WithFlagErrors enables structured flag error interception on the root command.
+func WithFlagErrors() SetupOption {
+	return func(c *setupConfig) {
+		c.flagErrors = true
+	}
+}

--- a/setup.go
+++ b/setup.go
@@ -1,10 +1,13 @@
 package structcli
 
 import (
+	"fmt"
+
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/helptopics"
 	"github.com/leodido/structcli/jsonschema"
 	structclimcp "github.com/leodido/structcli/mcp"
+	"github.com/spf13/cobra"
 )
 
 // setupConfig holds the resolved configuration from SetupOption functions.
@@ -67,4 +70,54 @@ func WithFlagErrors() SetupOption {
 	return func(c *setupConfig) {
 		c.flagErrors = true
 	}
+}
+
+// Setup configures the root command with the selected features.
+//
+// It calls the underlying Setup* functions in the correct internal order.
+// Individual Setup* functions remain available for power users.
+//
+// Ordering is handled internally:
+//  1. Debug (registers --debug-options flag)
+//  2. JSON Schema (registers --jsonschema flag, wraps execution)
+//  3. Help Topics (adds help topic subcommands)
+//  4. Flag Errors (intercepts flag parsing errors)
+//  5. MCP (registers --mcp flag, wraps execution)
+//
+// WithConfig and WithAppName are not yet supported (PR 5).
+func Setup(cmd *cobra.Command, opts ...SetupOption) error {
+	cfg := &setupConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	if cfg.debug != nil {
+		if err := SetupDebug(cmd, *cfg.debug); err != nil {
+			return fmt.Errorf("structcli.Setup: debug: %w", err)
+		}
+	}
+
+	if cfg.jsonSchema != nil {
+		if err := SetupJSONSchema(cmd, *cfg.jsonSchema); err != nil {
+			return fmt.Errorf("structcli.Setup: jsonschema: %w", err)
+		}
+	}
+
+	if cfg.helpTopics != nil {
+		if err := SetupHelpTopics(cmd, *cfg.helpTopics); err != nil {
+			return fmt.Errorf("structcli.Setup: helptopics: %w", err)
+		}
+	}
+
+	if cfg.flagErrors {
+		SetupFlagErrors(cmd)
+	}
+
+	if cfg.mcp != nil {
+		if err := SetupMCP(cmd, *cfg.mcp); err != nil {
+			return fmt.Errorf("structcli.Setup: mcp: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,173 @@
+package structcli
+
+import (
+	"testing"
+
+	"github.com/leodido/structcli/debug"
+	"github.com/leodido/structcli/helptopics"
+	"github.com/leodido/structcli/jsonschema"
+	structclimcp "github.com/leodido/structcli/mcp"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetup_NoOptions(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd)
+	require.NoError(t, err)
+}
+
+func TestSetup_WithDebug(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithDebug(debug.Options{}))
+	require.NoError(t, err)
+
+	// Debug flag is registered as a persistent flag
+	f := cmd.PersistentFlags().Lookup("debug-options")
+	assert.NotNil(t, f, "debug-options flag should exist")
+}
+
+func TestSetup_WithDebug_CustomFlagName(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithDebug(debug.Options{FlagName: "dbg"}))
+	require.NoError(t, err)
+
+	f := cmd.PersistentFlags().Lookup("dbg")
+	assert.NotNil(t, f, "custom debug flag name should exist")
+}
+
+func TestSetup_WithJSONSchema_Defaults(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithJSONSchema())
+	require.NoError(t, err)
+
+	f := cmd.PersistentFlags().Lookup("jsonschema")
+	assert.NotNil(t, f, "jsonschema flag should exist")
+}
+
+func TestSetup_WithJSONSchema_CustomOptions(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithJSONSchema(jsonschema.Options{FlagName: "schema"}))
+	require.NoError(t, err)
+
+	f := cmd.PersistentFlags().Lookup("schema")
+	assert.NotNil(t, f, "custom jsonschema flag name should exist")
+}
+
+func TestSetup_WithMCP_Defaults(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithMCP())
+	require.NoError(t, err)
+
+	f := cmd.PersistentFlags().Lookup("mcp")
+	assert.NotNil(t, f, "mcp flag should exist")
+}
+
+func TestSetup_WithMCP_CustomOptions(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithMCP(structclimcp.Options{FlagName: "mcp-mode"}))
+	require.NoError(t, err)
+
+	f := cmd.PersistentFlags().Lookup("mcp-mode")
+	assert.NotNil(t, f, "custom mcp flag name should exist")
+}
+
+func TestSetup_WithHelpTopics_Defaults(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithHelpTopics())
+	require.NoError(t, err)
+
+	// SetupHelpTopics adds "env-vars" and "config-keys" subcommands
+	var names []string
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.Contains(t, names, "env-vars", "env-vars subcommand should exist")
+	assert.Contains(t, names, "config-keys", "config-keys subcommand should exist")
+}
+
+func TestSetup_WithFlagErrors(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithFlagErrors())
+	require.NoError(t, err)
+	// SetupFlagErrors doesn't register flags — it intercepts errors.
+}
+
+func TestSetup_AllOptions(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd,
+		WithDebug(debug.Options{}),
+		WithJSONSchema(),
+		WithMCP(),
+		WithHelpTopics(helptopics.Options{ReferenceSection: true}),
+		WithFlagErrors(),
+	)
+	require.NoError(t, err)
+
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("debug-options"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("jsonschema"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("mcp"))
+
+	var names []string
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.Contains(t, names, "env-vars")
+	assert.Contains(t, names, "config-keys")
+}
+
+func TestSetup_CombinesWithBind(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	opts := &struct {
+		Port int `flag:"port" default:"3000"`
+	}{}
+
+	require.NoError(t, Setup(cmd, WithJSONSchema(), WithFlagErrors()))
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{"--port", "8080"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 8080, opts.Port)
+}


### PR DESCRIPTION
## Description

Add `Setup(cmd, ...SetupOption)` as the single entry point for configuring root command features. Uses functional options (`WithDebug`, `WithJSONSchema`, `WithMCP`, `WithHelpTopics`, `WithFlagErrors`) so callers don't need to remember the correct call order — `Setup` handles internal ordering.

PR 4 of 7 in the ergonomics spec.

### Commits

**1. `feat: add SetupOption type and With* functional options`**
- `SetupOption` function type and `setupConfig` aggregate struct.
- `WithDebug(debug.Options)`, `WithJSONSchema(…)`, `WithMCP(…)`, `WithHelpTopics(…)`, `WithFlagErrors()`.
- Variadic signatures for JSONSchema/MCP/HelpTopics so callers can omit options for defaults.

**2. `feat: add Setup orchestrator for root command configuration`**
- `Setup(cmd *cobra.Command, opts ...SetupOption) error` — collects options, calls underlying `Setup*` functions in the correct order: Debug → JSONSchema → HelpTopics → FlagErrors → MCP.
- Wraps errors with feature context (`structcli.Setup: debug: …`).
- Individual `Setup*` functions remain available for power users.

**3. `test: add tests for Setup orchestrator API`**
12 tests covering:
- No-op (no options)
- Each `With*` option individually with default and custom settings
- All options combined
- Integration with `Bind` + `ExecuteC`
- Global env prefix isolation via `SetEnvPrefix("")` + `t.Cleanup`

## How to test

```
go test -v -run TestSetup .
go test ./... -count=1
```