### PR TITLE
feat: add `WithAppName` and `WithConfig` to `Setup`

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -1,6 +1,9 @@
 package structcli
 
 import (
+	"fmt"
+	"sync"
+
 	internalcmd "github.com/leodido/structcli/internal/cmd"
 	internalscope "github.com/leodido/structcli/internal/scope"
 	"github.com/spf13/cobra"
@@ -29,6 +32,8 @@ var originalHooks = struct {
 //   - Runs SetupUsage on every command in the tree.
 //   - Recursively wraps PersistentPreRunE on every command to run the bind pipeline
 //     (auto-unmarshal for all Bind-registered options, root-to-leaf, FIFO per command).
+//   - When WithConfig was used in Setup, auto-loads config (UseConfigSimple) once
+//     before the first auto-unmarshal.
 //   - Skips the bind pipeline when execution is intercepted (--jsonschema, --mcp).
 //   - Preserves any user-set PersistentPreRunE or PersistentPreRun.
 //
@@ -39,23 +44,26 @@ func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
 	root.SilenceErrors = true
 	root.SilenceUsage = true
 
-	prepareTree(root)
+	// Fresh once-guard per ExecuteC call for config auto-load.
+	configOnce := &sync.Once{}
+
+	prepareTree(root, configOnce)
 
 	return cmd.ExecuteC()
 }
 
 // prepareTree walks the command tree and installs the bind pipeline wrapper
 // and SetupUsage on every command. Idempotent via annotation guard.
-func prepareTree(c *cobra.Command) {
+func prepareTree(c *cobra.Command, configOnce *sync.Once) {
 	if c == nil {
 		return
 	}
 
 	SetupUsage(c)
-	wrapBindPipeline(c)
+	wrapBindPipeline(c, configOnce)
 
 	for _, sub := range c.Commands() {
-		prepareTree(sub)
+		prepareTree(sub, configOnce)
 	}
 }
 
@@ -69,7 +77,7 @@ func prepareTree(c *cobra.Command) {
 // persistent hooks in root-first order. This ensures user hooks on
 // ancestor commands fire even when a descendant's wrapper is the one
 // Cobra picks.
-func wrapBindPipeline(c *cobra.Command) {
+func wrapBindPipeline(c *cobra.Command, configOnce *sync.Once) {
 	if c.Annotations == nil {
 		c.Annotations = make(map[string]string)
 	}
@@ -91,6 +99,11 @@ func wrapBindPipeline(c *cobra.Command) {
 			return nil
 		}
 
+		// Auto-load config once per execution if WithConfig was used.
+		if err := autoLoadConfig(cmd, configOnce); err != nil {
+			return err
+		}
+
 		// Run bind pipeline: walk root → executed command, unmarshal bound options.
 		if err := runBindPipeline(cmd); err != nil {
 			return err
@@ -110,6 +123,26 @@ func wrapBindPipeline(c *cobra.Command) {
 	c.PersistentPreRun = nil
 
 	c.Annotations[bindPipelineAnnotation] = "true"
+}
+
+// autoLoadConfig calls UseConfigSimple once per execution when WithConfig
+// was used in Setup. The sync.Once ensures config is loaded exactly once
+// even though every command in the tree has the wrapper.
+func autoLoadConfig(cmd *cobra.Command, configOnce *sync.Once) error {
+	root := cmd.Root()
+	if root.Annotations == nil || root.Annotations[configAutoLoadAnnotation] != "true" {
+		return nil
+	}
+
+	var configErr error
+	configOnce.Do(func() {
+		_, _, configErr = UseConfigSimple(cmd)
+	})
+	if configErr != nil {
+		return fmt.Errorf("structcli: auto-load config: %w", configErr)
+	}
+
+	return nil
 }
 
 // replayOriginalHooks walks from root to the executed command and calls

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -115,6 +115,31 @@ func GetEnv(f reflect.StructField, inherit bool, path, alias, envPrefix string) 
 	return ret, EnvOff
 }
 
+// PatchEnvPrefix updates env annotations on all flags of c to use newPrefix.
+// It strips any existing oldPrefix from annotation values and prepends newPrefix.
+// For each patched flag, it clears the bound-env marker in the command's scope
+// so that a subsequent BindEnv call will re-bind with the corrected env var names.
+func PatchEnvPrefix(c *cobra.Command, oldPrefix, newPrefix string) {
+	s := internalscope.Get(c)
+
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		envs, ok := f.Annotations[FlagAnnotation]
+		if !ok || len(envs) == 0 {
+			return
+		}
+
+		patched := make([]string, len(envs))
+		for i, env := range envs {
+			bare := strings.TrimPrefix(env, oldPrefix)
+			patched[i] = newPrefix + bare
+		}
+		f.Annotations[FlagAnnotation] = patched
+
+		// Clear bound state so BindEnv will re-bind with the new names.
+		s.ClearBoundEnv(f.Name)
+	})
+}
+
 func BindEnv(c *cobra.Command) error {
 	s := internalscope.Get(c)
 	var bindErr error

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -117,10 +117,20 @@ func GetEnv(f reflect.StructField, inherit bool, path, alias, envPrefix string) 
 
 // PatchEnvPrefix updates env annotations on all flags of c to use newPrefix.
 // It strips any existing oldPrefix from annotation values and prepends newPrefix.
+// When oldPrefix is empty and c is the root command, the root command's name was
+// used as a pseudo-prefix by GetEnv and must be stripped before applying newPrefix.
 // For each patched flag, it clears the bound-env marker in the command's scope
 // so that a subsequent BindEnv call will re-bind with the corrected env var names.
 func PatchEnvPrefix(c *cobra.Command, oldPrefix, newPrefix string) {
 	s := internalscope.Get(c)
+
+	// When no global prefix existed, GetEnv baked the command name into env
+	// vars as a pseudo-prefix. For the root command, that pseudo-prefix
+	// should be replaced by the real app prefix.
+	stripPrefix := oldPrefix
+	if oldPrefix == "" && c.Parent() == nil {
+		stripPrefix = NormEnv(c.Name()) + EnvSep
+	}
 
 	c.Flags().VisitAll(func(f *pflag.Flag) {
 		envs, ok := f.Annotations[FlagAnnotation]
@@ -130,7 +140,7 @@ func PatchEnvPrefix(c *cobra.Command, oldPrefix, newPrefix string) {
 
 		patched := make([]string, len(envs))
 		for i, env := range envs {
-			bare := strings.TrimPrefix(env, oldPrefix)
+			bare := strings.TrimPrefix(env, stripPrefix)
 			patched[i] = newPrefix + bare
 		}
 		f.Annotations[FlagAnnotation] = patched

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -92,6 +92,15 @@ func (s *Scope) SetBound(flagName string) {
 	s.boundEnvs[flagName] = true
 }
 
+// ClearBoundEnv removes the bound marker for a single flag so that
+// BindEnv will re-bind it on the next call. Used by env annotation
+// patching when WithAppName retroactively updates env var names.
+func (s *Scope) ClearBoundEnv(flagName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.boundEnvs, flagName)
+}
+
 // GetBoundEnvs is for testing purposes only
 func (s *Scope) GetBoundEnvs() map[string]bool {
 	s.mu.RLock()

--- a/setup.go
+++ b/setup.go
@@ -3,15 +3,21 @@ package structcli
 import (
 	"fmt"
 
+	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/helptopics"
+	internalenv "github.com/leodido/structcli/internal/env"
 	"github.com/leodido/structcli/jsonschema"
 	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/spf13/cobra"
 )
 
+const configAutoLoadAnnotation = "structcli/config-auto-load"
+
 // setupConfig holds the resolved configuration from SetupOption functions.
 type setupConfig struct {
+	appName    string
+	config     *config.Options
 	debug      *debug.Options
 	jsonSchema *jsonschema.Options
 	mcp        *structclimcp.Options
@@ -21,6 +27,32 @@ type setupConfig struct {
 
 // SetupOption configures a feature in Setup.
 type SetupOption func(*setupConfig)
+
+// WithAppName sets the application name used for environment variable prefixes
+// and config file discovery. When flags already exist on the command tree (from
+// earlier Bind calls), their env annotations are retroactively patched to include
+// the new prefix.
+//
+// If a sub-option (e.g., debug.Options.AppName or config.Options.AppName) specifies
+// a different name, Setup returns an error.
+func WithAppName(name string) SetupOption {
+	return func(c *setupConfig) {
+		c.appName = name
+	}
+}
+
+// WithConfig enables config file discovery and the --config flag on the root command.
+// The actual config loading (UseConfigSimple) is deferred to ExecuteC's bind pipeline,
+// before the first auto-unmarshal.
+func WithConfig(opts ...config.Options) SetupOption {
+	return func(c *setupConfig) {
+		o := config.Options{}
+		if len(opts) > 0 {
+			o = opts[0]
+		}
+		c.config = &o
+	}
+}
 
 // WithDebug enables the debug flag (--debug-options) on the root command.
 func WithDebug(opts debug.Options) SetupOption {
@@ -78,17 +110,52 @@ func WithFlagErrors() SetupOption {
 // Individual Setup* functions remain available for power users.
 //
 // Ordering is handled internally:
-//  1. Debug (registers --debug-options flag)
-//  2. JSON Schema (registers --jsonschema flag, wraps execution)
-//  3. Help Topics (adds help topic subcommands)
-//  4. Flag Errors (intercepts flag parsing errors)
-//  5. MCP (registers --mcp flag, wraps execution)
-//
-// WithConfig and WithAppName are not yet supported (PR 5).
+//  1. AppName + env annotation patching (if flags already exist from earlier Bind calls)
+//  2. Config (registers --config flag, defers auto-load to ExecuteC)
+//  3. Debug (registers --debug-options flag)
+//  4. JSON Schema (registers --jsonschema flag, wraps execution)
+//  5. Help Topics (adds help topic subcommands)
+//  6. Flag Errors (intercepts flag parsing errors)
+//  7. MCP (registers --mcp flag, wraps execution)
 func Setup(cmd *cobra.Command, opts ...SetupOption) error {
 	cfg := &setupConfig{}
 	for _, opt := range opts {
 		opt(cfg)
+	}
+
+	// Validate AppName conflicts with sub-options.
+	if cfg.appName != "" {
+		if err := validateAppNameConflicts(cfg); err != nil {
+			return err
+		}
+	}
+
+	// Apply AppName: set the global prefix and patch existing flags.
+	if cfg.appName != "" {
+		if err := applyAppName(cmd, cfg.appName); err != nil {
+			return fmt.Errorf("structcli.Setup: appname: %w", err)
+		}
+	}
+
+	// Propagate AppName into sub-options that accept it.
+	if cfg.appName != "" {
+		if cfg.config != nil && cfg.config.AppName == "" {
+			cfg.config.AppName = cfg.appName
+		}
+		if cfg.debug != nil && cfg.debug.AppName == "" {
+			cfg.debug.AppName = cfg.appName
+		}
+	}
+
+	if cfg.config != nil {
+		if err := SetupConfig(cmd, *cfg.config); err != nil {
+			return fmt.Errorf("structcli.Setup: config: %w", err)
+		}
+		// Mark root for deferred auto-load in ExecuteC.
+		if cmd.Annotations == nil {
+			cmd.Annotations = make(map[string]string)
+		}
+		cmd.Annotations[configAutoLoadAnnotation] = "true"
 	}
 
 	if cfg.debug != nil {
@@ -120,4 +187,48 @@ func Setup(cmd *cobra.Command, opts ...SetupOption) error {
 	}
 
 	return nil
+}
+
+// validateAppNameConflicts checks that sub-option AppName fields don't conflict
+// with the top-level WithAppName value.
+func validateAppNameConflicts(cfg *setupConfig) error {
+	if cfg.debug != nil && cfg.debug.AppName != "" && cfg.debug.AppName != cfg.appName {
+		return fmt.Errorf("structcli.Setup: WithAppName(%q) conflicts with debug.Options.AppName(%q)", cfg.appName, cfg.debug.AppName)
+	}
+	if cfg.config != nil && cfg.config.AppName != "" && cfg.config.AppName != cfg.appName {
+		return fmt.Errorf("structcli.Setup: WithAppName(%q) conflicts with config.Options.AppName(%q)", cfg.appName, cfg.config.AppName)
+	}
+
+	return nil
+}
+
+// applyAppName sets the global env prefix and retroactively patches env
+// annotations on any flags already defined on the command tree (from earlier
+// Bind calls). For each patched command, it clears bound-env state and re-runs
+// BindEnv so viper picks up the corrected env var names.
+func applyAppName(cmd *cobra.Command, appName string) error {
+	oldPrefix := internalenv.GetPrefix() // e.g. "" or "OLD_"
+	SetEnvPrefix(appName)
+	newPrefix := internalenv.GetPrefix() // e.g. "MYAPP_"
+
+	if oldPrefix == newPrefix {
+		return nil // no change needed
+	}
+
+	// Walk the entire command tree and patch env annotations.
+	patchTreeEnvPrefix(cmd, oldPrefix, newPrefix)
+
+	return nil
+}
+
+// patchTreeEnvPrefix recursively patches env annotations on cmd and all descendants.
+func patchTreeEnvPrefix(c *cobra.Command, oldPrefix, newPrefix string) {
+	internalenv.PatchEnvPrefix(c, oldPrefix, newPrefix)
+	// Re-bind env vars with the updated annotations.
+	// Errors here are non-fatal — flags without env annotations are simply skipped.
+	_ = internalenv.BindEnv(c)
+
+	for _, sub := range c.Commands() {
+		patchTreeEnvPrefix(sub, oldPrefix, newPrefix)
+	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,13 +1,18 @@
 package structcli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/helptopics"
+	internalenv "github.com/leodido/structcli/internal/env"
 	"github.com/leodido/structcli/jsonschema"
 	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -170,4 +175,334 @@ func TestSetup_CombinesWithBind(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 8080, opts.Port)
+}
+
+// --- WithAppName tests ---
+
+func TestSetup_WithAppName_SetsPrefix(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithAppName("myapp"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "MYAPP", EnvPrefix())
+}
+
+func TestSetup_WithAppName_PatchesExistingFlags(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	opts := &struct {
+		Port int `flag:"port" default:"3000" flagenv:"true"`
+	}{}
+
+	// Bind first — no global prefix, but command name "test" is baked in
+	// by GetEnv as a pseudo-prefix, so annotation is "TEST_PORT".
+	require.NoError(t, Bind(cmd, opts))
+
+	f := cmd.Flags().Lookup("port")
+	require.NotNil(t, f)
+	envsBefore := f.Annotations[internalenv.FlagAnnotation]
+	require.NotEmpty(t, envsBefore)
+	assert.Equal(t, "TEST_PORT", envsBefore[0], "before Setup, env uses command name as prefix")
+
+	// Setup with AppName — on root command, the command name pseudo-prefix
+	// is replaced by the real app prefix: TEST_PORT → MYAPP_PORT.
+	require.NoError(t, Setup(cmd, WithAppName("myapp")))
+
+	envsAfter := f.Annotations[internalenv.FlagAnnotation]
+	require.NotEmpty(t, envsAfter)
+	assert.Equal(t, "MYAPP_PORT", envsAfter[0], "after Setup, env should use app prefix")
+}
+
+func TestSetup_WithAppName_BindBeforeSetup_EnvWorks(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{
+		Use: "myapp",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	opts := &struct {
+		Port int `flag:"port" default:"3000" flagenv:"true"`
+	}{}
+
+	// Bind before Setup (ordering independence — AC3).
+	require.NoError(t, Bind(cmd, opts))
+	require.NoError(t, Setup(cmd, WithAppName("myapp")))
+
+	t.Setenv("MYAPP_PORT", "9090")
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 9090, opts.Port, "env var with app prefix should populate the field")
+}
+
+func TestSetup_WithAppName_SetupBeforeBind_EnvWorks(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{
+		Use: "myapp",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	opts := &struct {
+		Port int `flag:"port" default:"3000" flagenv:"true"`
+	}{}
+
+	// Setup before Bind (AC4) — prefix is set before Define runs.
+	require.NoError(t, Setup(cmd, WithAppName("myapp")))
+	require.NoError(t, Bind(cmd, opts))
+
+	t.Setenv("MYAPP_PORT", "7070")
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 7070, opts.Port, "env var with app prefix should populate the field")
+}
+
+func TestSetup_WithAppName_PatchesSubcommandFlags(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	root := &cobra.Command{Use: "myapp"}
+	child := &cobra.Command{
+		Use: "serve",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	opts := &struct {
+		Port int `flag:"port" default:"3000" flagenv:"true"`
+	}{}
+
+	// Bind on child, then Setup on root.
+	require.NoError(t, Bind(child, opts))
+	require.NoError(t, Setup(root, WithAppName("myapp")))
+
+	// Child command flags include the command name in the env var.
+	f := child.Flags().Lookup("port")
+	require.NotNil(t, f)
+	envs := f.Annotations[internalenv.FlagAnnotation]
+	require.NotEmpty(t, envs)
+	assert.Equal(t, "MYAPP_SERVE_PORT", envs[0], "child command env should include command name")
+}
+
+func TestSetup_WithAppName_ConflictWithDebug(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd,
+		WithAppName("myapp"),
+		WithDebug(debug.Options{AppName: "other"}),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts")
+}
+
+func TestSetup_WithAppName_ConflictWithConfig(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd,
+		WithAppName("myapp"),
+		WithConfig(config.Options{AppName: "other"}),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts")
+}
+
+func TestSetup_WithAppName_SameNameNoConflict(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd,
+		WithAppName("myapp"),
+		WithDebug(debug.Options{AppName: "myapp"}),
+	)
+	require.NoError(t, err)
+}
+
+func TestSetup_WithAppName_PropagatesIntoSubOptions(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd,
+		WithAppName("myapp"),
+		WithDebug(debug.Options{}),
+		WithConfig(config.Options{}),
+	)
+	require.NoError(t, err)
+
+	// Debug flag should exist (AppName propagated).
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("debug-options"))
+	// Config flag should exist (AppName propagated).
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("config"))
+}
+
+// --- WithConfig tests ---
+
+func TestSetup_WithConfig_Defaults(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithConfig())
+	require.NoError(t, err)
+
+	f := cmd.PersistentFlags().Lookup("config")
+	assert.NotNil(t, f, "config flag should exist")
+}
+
+func TestSetup_WithConfig_CustomOptions(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	cmd := &cobra.Command{Use: "test"}
+	err := Setup(cmd, WithConfig(config.Options{FlagName: "settings"}))
+	require.NoError(t, err)
+
+	f := cmd.PersistentFlags().Lookup("settings")
+	assert.NotNil(t, f, "custom config flag name should exist")
+}
+
+func TestSetup_WithConfig_SetsAutoLoadAnnotation(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	cmd := &cobra.Command{Use: "test"}
+	require.NoError(t, Setup(cmd, WithConfig()))
+
+	assert.Equal(t, "true", cmd.Annotations[configAutoLoadAnnotation],
+		"config auto-load annotation should be set on root")
+}
+
+func TestSetup_WithConfig_AutoLoadsBeforeUnmarshal(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	// Create a temp config file.
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("port: 4242\n"), 0o644))
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	opts := &struct {
+		Port int `flag:"port" default:"3000"`
+	}{}
+
+	require.NoError(t, Setup(cmd,
+		WithAppName("test"),
+		WithConfig(config.Options{}),
+	))
+	require.NoError(t, Bind(cmd, opts))
+
+	// Point --config at our temp file.
+	cmd.SetArgs([]string{"--config", cfgFile})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4242, opts.Port, "config file value should be loaded before unmarshal")
+}
+
+func TestSetup_WithConfig_NoAnnotationWithoutWithConfig(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+
+	cmd := &cobra.Command{Use: "test"}
+	require.NoError(t, Setup(cmd, WithAppName("myapp")))
+
+	if cmd.Annotations != nil {
+		assert.Empty(t, cmd.Annotations[configAutoLoadAnnotation],
+			"config auto-load annotation should not be set without WithConfig")
+	}
+}
+
+// --- Combined WithAppName + WithConfig tests ---
+
+func TestSetup_WithAppNameAndConfig_FullIntegration(t *testing.T) {
+	SetEnvPrefix("")
+	t.Cleanup(func() { SetEnvPrefix("") })
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("host: example.com\n"), 0o644))
+
+	root := &cobra.Command{Use: "myapp"}
+	child := &cobra.Command{
+		Use: "serve",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	opts := &struct {
+		Host string `flag:"host" default:"localhost" flagenv:"true"`
+	}{}
+
+	require.NoError(t, Bind(child, opts))
+	require.NoError(t, Setup(root,
+		WithAppName("myapp"),
+		WithConfig(config.Options{}),
+	))
+
+	root.SetArgs([]string{"serve", "--config", cfgFile})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, "example.com", opts.Host, "config value should be loaded")
+	assert.Equal(t, "MYAPP", EnvPrefix(), "prefix should be set")
+
+	// Verify env annotation was patched — child commands include command name.
+	f := child.Flags().Lookup("host")
+	require.NotNil(t, f)
+	envs := f.Annotations[internalenv.FlagAnnotation]
+	require.NotEmpty(t, envs)
+	assert.Equal(t, "MYAPP_SERVE_HOST", envs[0])
 }


### PR DESCRIPTION
## Description

Add `WithAppName` and `WithConfig` functional options to `Setup`, completing the Setup API. This enables ordering independence between `Setup` and `Bind` — env vars work correctly regardless of call order.

PR 5 of 7 in the ergonomics spec.

### Commits

**1. `feat: add WithAppName and env annotation patching`**
- `WithAppName(name)` sets the global env prefix and retroactively patches env annotations on flags already defined by earlier `Bind` calls.
- `Scope.ClearBoundEnv(flagName)` added for selective bound-state reset.
- `PatchEnvPrefix(c, oldPrefix, newPrefix)` in `internal/env` rewrites flag annotations and clears bound state. Handles the root command case where `GetEnv` bakes the command name as a pseudo-prefix when no global prefix exists.
- Validates that sub-option `AppName` fields (debug, config) don't conflict with the top-level `WithAppName` value. Propagates `AppName` into sub-options that accept it.

**2. `feat: add WithConfig and deferred config auto-load in ExecuteC`**
- `WithConfig(…config.Options)` calls `SetupConfig` and marks the root with a `configAutoLoadAnnotation`.
- `ExecuteC` creates a fresh `sync.Once` per call and threads it into the bind pipeline wrapper. Before auto-unmarshal, the wrapper calls `UseConfigSimple(cmd)` exactly once when the annotation is present.
- Config loading is skipped on intercepted execution paths (`--jsonschema`, `--mcp`).

**3. `test: add tests for WithAppName, WithConfig, and env patching`**
15 new tests covering:
- Prefix setting and env annotation patching (root + subcommand)
- Bind-before-Setup and Setup-before-Bind ordering independence (AC3, AC4)
- AppName conflict detection and propagation into sub-options
- WithConfig flag registration, auto-load annotation, deferred loading
- Combined WithAppName + WithConfig full integration with config file

Also fixes `PatchEnvPrefix` to strip the root command name pseudo-prefix when no global prefix existed.

## How to test

```
go test -v -run "TestSetup_WithAppName|TestSetup_WithConfig|TestSetup_WithAppNameAndConfig" .
go test ./... -count=1
```