### PR TITLE
docs: update README, ai-native.md, and examples for Setup + Bind + ExecuteC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
@@ -33,35 +32,23 @@ type Options struct {
 	Port     int
 }
 
-func (o *Options) Attach(c *cobra.Command) error {
-	return structcli.Define(c, o)
-}
-
 func main() {
 	opts := &Options{}
-	cli := &cobra.Command{Use: "myapp"}
+	cli := &cobra.Command{
+		Use: "myapp",
+		RunE: func(c *cobra.Command, args []string) error {
+			fmt.Println(opts) // already populated
 
-	if err := opts.Attach(cli); err != nil {
-		log.Fatalln(err)
+			return nil
+		},
 	}
 
-	cli.PreRunE = func(c *cobra.Command, args []string) error {
-		return structcli.Unmarshal(c, opts)
-	}
-
-	cli.RunE = func(c *cobra.Command, args []string) error {
-		fmt.Println(opts)
-
-		return nil
-	}
-
-	if err := cli.Execute(); err != nil {
-		log.Fatalln(err)
-	}
+	structcli.Bind(cli, opts)
+	structcli.ExecuteOrExit(cli)
 }
 ```
 
-That single `Define` call creates the CLI surface from your struct, and `Unmarshal` hydrates it back from flags, env vars, config, and defaults.
+`Bind` creates flags and env vars from your struct and registers it for auto-unmarshal. `ExecuteOrExit` hydrates the struct from flags, env vars, config, and defaults before your `RunE` fires.
 
 ```bash
 ❯ go run examples/minimal/main.go --help
@@ -129,10 +116,12 @@ Add the AI-native wiring below and it also gains machine-readable JSON Schema, s
 Instead of scraping `--help` and guessing, an agent can discover the contract, call the command correctly, and recover from structured failures.
 
 ```go
-structcli.SetupJSONSchema(rootCmd, jsonschema.Options{})
-structcli.SetupHelpTopics(rootCmd, helptopics.Options{ReferenceSection: true})  // "mycli env-vars" and "mycli config-keys"
-structcli.SetupFlagErrors(rootCmd)  // Optional, but recommended for typed flag-parse errors
-structcli.SetupMCP(rootCmd, mcp.Options{}) // Optional, exposes the CLI as an MCP server over stdio
+structcli.Setup(rootCmd,
+    structcli.WithJSONSchema(),
+    structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),  // "mycli env-vars" and "mycli config-keys"
+    structcli.WithFlagErrors(),  // Optional, but recommended for typed flag-parse errors
+    structcli.WithMCP(),         // Optional, exposes the CLI as an MCP server over stdio
+)
 structcli.ExecuteOrExit(rootCmd)
 ```
 
@@ -174,7 +163,7 @@ $ mycli srv --jsonschema=tree  # schemas for srv + its subcommands
 
 No `--help` parsing. No guessing what failed. Just a CLI that can explain itself and fail in machine-actionable ways.
 
-Use `exitcode.Category(code)` and `exitcode.IsRetryable(code)` to decide what to do next. See `jsonschema.WithEnumInDescription()` for schema customization, and pass schema options through `SetupJSONSchema` with `jsonschema.Options{SchemaOpts: ...}`.
+Use `exitcode.Category(code)` and `exitcode.IsRetryable(code)` to decide what to do next. See `jsonschema.WithEnumInDescription()` for schema customization, and pass schema options through `WithJSONSchema` with `jsonschema.Options{SchemaOpts: ...}`.
 
 For CLIs that capture output streams during command construction, configure `mcp.Options.CommandFactory` so each MCP tool call builds a fresh command with the tool-call stdout and stderr writers. This keeps MCP protocol output separate from command output while preserving the existing command tree schema. If the command constructor requires stdin, the factory can wire a non-interactive reader such as `strings.NewReader("")`.
 
@@ -257,24 +246,29 @@ For example, if `Port` is attached to the `srv` command, `FULL_SRV_PORT` is used
 
 ### ⚙️ Configuration File Support
 
-Easily set up configuration file discovery (flag, environment variable, and fallback paths) with a single line of code.
+Set up configuration file discovery (flag, environment variable, and fallback paths) via `Setup`:
 
 ```go
-structcli.SetupConfig(rootCmd, config.Options{AppName: "full"})
+structcli.Setup(rootCmd,
+    structcli.WithAppName("full"),
+    structcli.WithConfig(config.Options{}),
+)
 ```
 
 Enable strict config-key validation with:
 
 ```go
-structcli.SetupConfig(rootCmd, config.Options{
-  AppName:      "full",
-  ValidateKeys: true, // opt-in
-})
+structcli.Setup(rootCmd,
+    structcli.WithAppName("full"),
+    structcli.WithConfig(config.Options{ValidateKeys: true}),
+)
 ```
 
 When enabled, `Unmarshal` fails if command-relevant config contains unknown keys.
 
-Call `SetupConfig` before attaching/defining options when you rely on app-prefixed environment variables, so the env prefix is initialized before env annotations are generated.
+`WithAppName` sets the env prefix. `WithConfig` registers the `--config` flag and defers config loading to `ExecuteC`'s bind pipeline (before auto-unmarshal). Ordering between `Setup` and `Bind` does not matter — `WithAppName` retroactively patches env annotations on already-defined flags.
+
+Individual `SetupConfig`, `SetupDebug`, etc. remain available for power users who need fine-grained control.
 
 The line above:
 
@@ -414,8 +408,10 @@ See a full working example [here](examples/full/cli/cli.go).
 Create a `--debug-options` flag (plus a matching env var) for troubleshooting config/env/flags resolution.
 
 ```go
-structcli.SetupDebug(rootCmd, debug.Options{})
+structcli.Setup(rootCmd, structcli.WithDebug(debug.Options{}))
 ```
+
+Or standalone: `structcli.SetupDebug(rootCmd, debug.Options{})`.
 
 The flag accepts `text` (default when used bare) or `json` for machine-readable output. Truthy values like `true`, `1`, `yes` are treated as `text` for backward compatibility.
 
@@ -472,10 +468,10 @@ The flag can also be activated via environment variable: `FULL_DEBUG_OPTIONS=jso
 
 ### 📋 Self-Documenting Help Topics
 
-`SetupHelpTopics` adds two help topic commands that list every environment variable binding and every valid configuration file key across the command tree.
+`WithHelpTopics` (or standalone `SetupHelpTopics`) adds two help topic commands that list every environment variable binding and every valid configuration file key across the command tree.
 
 ```go
-structcli.SetupHelpTopics(rootCmd, helptopics.Options{})
+structcli.Setup(rootCmd, structcli.WithHelpTopics(helptopics.Options{}))
 ```
 
 Call this after all subcommands and flags are defined (typically right before `ExecuteOrExit`).
@@ -531,7 +527,7 @@ The pattern allows you to:
 
 #### 🍩 In a Nutshell
 
-Create a shared struct that implements the `ContextOptions` interface. This struct will hold both the configuration flags and the computed state (e.g., the logger).
+Create a shared struct that implements the `ContextInjector` interface. This struct will hold both the configuration flags and the computed state (e.g., the logger).
 
 ```go
 // This struct holds our shared state.
@@ -540,37 +536,35 @@ type CommonOptions struct {
     Logger   *zap.Logger   `flagignore:"true"` // This field is computed, not a flag.
 }
 
-// The Context/FromContext methods enable the propagation pattern.
+// Context injects the struct into the command context during auto-unmarshal.
 func (o *CommonOptions) Context(ctx context.Context) context.Context { /* ... */ }
+
+// FromContext retrieves the struct from context (user-side, not interface-enforced).
 func (o *CommonOptions) FromContext(ctx context.Context) error { /* ... */ }
 
 // Initialize is a custom method to create the computed state.
 func (o *CommonOptions) Initialize() error { /* ... */ }
 ```
 
-Initialize the state in the root command. Use a `PersistentPreRunE` hook on your root command to populate your struct and initialize any resources.
-Invoking `structcli.Unmarshal` will automatically inject the prepared object into the context for all subcommands to use.
+Bind the shared struct to the root command. `Bind` registers it for auto-unmarshal — the bind pipeline populates it and calls `Context()` to inject it before any `PreRunE` or `RunE` fires.
+
+```go
+structcli.Bind(rootC, commonOpts)
+```
+
+If you need to initialize computed state (like a logger) after unmarshal, use a `PersistentPreRunE` hook — by the time it fires, `commonOpts` is already populated:
 
 ```go
 rootC.PersistentPreRunE = func(c *cobra.Command, args []string) error {
-	// Populate the master `commonOpts` from flags, env, and config file.
-	if err := structcli.Unmarshal(c, commonOpts); err != nil {
-		return err
-	}
-	// Use the populated values to initialize the computed state (the logger).
-	if err := commonOpts.Initialize(); err != nil {
-		return err
-	}
-
-	return nil
+	// commonOpts is already populated by the bind pipeline.
+	return commonOpts.Initialize()
 }
 ```
 
-Finally, retrieve the state in subcommands. In your subcommand's `RunE`, simply call `.FromContext()` to retrieve the shared, initialized object.
+Retrieve the state in subcommands. In your subcommand's `RunE`, call `.FromContext()` to retrieve the shared, initialized object.
 
 ```go
 func(c *cobra.Command, args []string) error {
-    // Create a receiver and retrieve the master state from the context.
     config := &CommonOptions{}
     if err := config.FromContext(c.Context()); err != nil {
         return err
@@ -582,6 +576,8 @@ func(c *cobra.Command, args []string) error {
 ```
 
 This pattern ensures that subcommands remain decoupled while having access to a consistent, centrally-managed state.
+
+> **Note:** The deprecated `ContextOptions` interface (which embeds `Options` and requires `Attach`) still works for backward compatibility. New code should use `ContextInjector` instead.
 
 For a complete, runnable implementation of this pattern, see the loginsvc example located in the [/examples/loginsvc](/examples/loginsvc/) directory.
 
@@ -676,14 +672,16 @@ func (o *ServerOptions) Attach(c *cobra.Command) error {
 }
 ```
 
+Types using `flagcustom:"true"` require the `Options` interface (`Attach` method) because the `Define<Field>`/`Decode<Field>` methods are discovered on the receiver. `Bind` works too — it detects `Options` implementors and delegates to `Attach`.
+
 For enum types, prefer `RegisterEnum`/`RegisterIntEnum` instead. They handle the same concerns with less boilerplate.
 
 `Complete<FieldName>` works for any field that becomes a flag (not only `flagcustom:"true"` fields).
 
 Completion precedence:
 
-- If a completion function is already registered on a flag before `structcli.Define()`, structcli preserves it.
-- If `structcli.Define()` auto-registers `Complete<FieldName>`, a later manual `RegisterFlagCompletionFunc` on the same flag returns Cobra's `already registered` error.
+- If a completion function is already registered on a flag before `Define`, structcli preserves it.
+- If `Define` auto-registers `Complete<FieldName>`, a later manual `RegisterFlagCompletionFunc` on the same flag returns Cobra's `already registered` error.
 
 In [values](/values/values.go) we provide `pflag.Value` implementations for standard types.
 
@@ -779,6 +777,8 @@ func (o *LogsOptions) Attach(c *cobra.Command) error {
 }
 ```
 
+`Attach` is needed here because of the custom `flagkit.AnnotateCommand` call. For structs without custom define-time logic, use `structcli.Bind(cmd, opts)` instead — it handles both plain structs and `Options` implementors.
+
 Available types:
 
 | Type | Flag | Default | Description |
@@ -828,6 +828,7 @@ Organize your `--help` output into logical groups for better readability.
 #       --config string                   config file (fallbacks to: {/etc/full,{executable_dir}/.full,$HOME/.full,...}/config.{yaml,json,toml})
 #       --debug-options string[="text"]   debug output format (text, json)
 #       --jsonschema string[="true"]      output JSON Schema and exit (bare: this command, =tree: full subtree)
+#       --mcp                             serve MCP over stdio
 #
 # Reference:
 #   config-keys List all configuration file keys
@@ -877,6 +878,7 @@ Organize your `--help` output into logical groups for better readability.
 #       --config string                   config file (fallbacks to: {/etc/full,{executable_dir}/.full,$HOME/.full,...}/config.{yaml,json,toml})
 #       --debug-options string[="text"]   debug output format (text, json)
 #       --jsonschema string[="true"]      output JSON Schema and exit (bare: this command, =tree: full subtree)
+#       --mcp                             serve MCP over stdio
 #
 # Use "full srv [command] --help" for more information about a command.
 ```

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ For machine-readable cross-tree data, use `--jsonschema=tree` instead — it pro
 
 ### ↪️ Sharing Options Between Commands
 
-In complex CLIs, multiple commands often need access to the same global configuration and shared resources (like a logger or a database connection). `structcli` provides a powerful pattern using the [ContextOptions](/contract.go) interface to achieve this without resorting to global variables, by propagating a single "source of truth" through the command context.
+In complex CLIs, multiple commands often need access to the same global configuration and shared resources (like a logger or a database connection). `structcli` provides a pattern using the [`ContextInjector`](/contract.go) interface to achieve this without resorting to global variables, by propagating a single "source of truth" through the command context.
 
 The pattern allows you to:
 
@@ -551,6 +551,8 @@ Bind the shared struct to the root command. `Bind` registers it for auto-unmarsh
 ```go
 structcli.Bind(rootC, commonOpts)
 ```
+
+> **Important:** `Bind` on root creates **local** flags on the root command. By default, Cobra rejects unknown flags before finding the subcommand, so `app --loglevel info sub` would fail. Set `rootC.TraverseChildren = true` so root parses its own flags first, then resolves the subcommand. Alternatively, bind the shared struct on each leaf command that needs the flags.
 
 If you need to initialize computed state (like a logger) after unmarshal, use a `PersistentPreRunE` hook — by the time it fires, `commonOpts` is already populated:
 

--- a/docs/ai-native.md
+++ b/docs/ai-native.md
@@ -9,18 +9,22 @@ Agents do not need to scrape `--help` and guess. They can ask the CLI for its co
 ```go
 rootCmd := &cobra.Command{Use: "mycli"}
 
-structcli.SetupJSONSchema(rootCmd, jsonschema.Options{})
-structcli.SetupHelpTopics(rootCmd, helptopics.Options{ReferenceSection: true})  // "mycli env-vars" and "mycli config-keys"
-structcli.SetupFlagErrors(rootCmd)  // Optional, but recommended
-structcli.SetupMCP(rootCmd, mcp.Options{}) // Optional, exposes the CLI as an MCP server over stdio
+structcli.Setup(rootCmd,
+    structcli.WithJSONSchema(),
+    structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),  // "mycli env-vars" and "mycli config-keys"
+    structcli.WithFlagErrors(),  // Optional, but recommended
+    structcli.WithMCP(),         // Optional, exposes the CLI as an MCP server over stdio
+)
 structcli.ExecuteOrExit(rootCmd)
 ```
 
 Use `ExecuteOrExit` when you want the simplest production `main()`. Use `HandleError` directly when you want full control over output streams and exit flow.
 
+Individual `SetupJSONSchema`, `SetupMCP`, etc. remain available for power users who need fine-grained control.
+
 ## Machine-readable self-description
 
-`SetupJSONSchema` adds a `--jsonschema` persistent flag to the root command. When requested, structcli prints a JSON Schema (draft 2020-12) for the command being invoked.
+`WithJSONSchema` (or standalone `SetupJSONSchema`) adds a `--jsonschema` persistent flag to the root command. When requested, structcli prints a JSON Schema (draft 2020-12) for the command being invoked.
 
 That schema includes:
 
@@ -66,11 +70,11 @@ Programmatic APIs:
 
 - `structcli.JSONSchema(cmd, jsonschema.WithFullTree())`
 - `jsonschema.WithEnumInDescription()`
-- `jsonschema.Options{SchemaOpts: ...}` passed through `SetupJSONSchema`
+- `jsonschema.Options{SchemaOpts: ...}` passed through `WithJSONSchema` or `SetupJSONSchema`
 
 ## Human-readable help topics
 
-`SetupHelpTopics` adds two reference commands to the root: `env-vars` and `config-keys`. These list every environment variable binding and every valid configuration file key across the command tree.
+`WithHelpTopics` (or standalone `SetupHelpTopics`) adds two reference commands to the root: `env-vars` and `config-keys`. These list every environment variable binding and every valid configuration file key across the command tree.
 
 Unlike `--jsonschema` (machine-readable), help topics produce plain text grouped by command with aligned columns — useful for humans and for agents that prefer scanning text over parsing JSON.
 
@@ -78,11 +82,11 @@ Unlike `--jsonschema` (machine-readable), help topics produce plain text grouped
 - Config keys derived from embedded struct paths appear as aliases.
 - By default, help topics appear as regular subcommands. Set `ReferenceSection: true` to move them into a dedicated "Reference:" section in `--help` output.
 
-Call `SetupHelpTopics` after all subcommands and flags are defined.
+Call `Setup` (or `SetupHelpTopics`) after all subcommands and flags are defined.
 
 ## MCP server mode
 
-`SetupMCP` adds a `--mcp` flag to the root command. When requested, structcli serves the same command tree over stdio as an MCP server.
+`WithMCP` (or standalone `SetupMCP`) adds a `--mcp` flag to the root command. When requested, structcli serves the same command tree over stdio as an MCP server.
 
 That means an agent can use the CLI as a live tool host instead of only consuming generated markdown:
 
@@ -93,10 +97,10 @@ That means an agent can use the CLI as a live tool host instead of only consumin
 Minimal wiring:
 
 ```go
-structcli.SetupMCP(rootCmd, mcp.Options{
+structcli.Setup(rootCmd, structcli.WithMCP(mcp.Options{
     Name:    "mycli",
     Version: "1.0.0",
-})
+}))
 ```
 
 The default transport is stdio, which fits Claude Code and similar agent runners. Command execution, typed inputs, and structured failures all reuse the existing structcli contract, so the MCP surface stays aligned with the CLI surface.
@@ -104,7 +108,7 @@ The default transport is stdio, which fits Claude Code and similar agent runners
 For CLIs that capture output streams during command construction, provide a fresh command factory:
 
 ```go
-structcli.SetupMCP(rootCmd, mcp.Options{
+structcli.Setup(rootCmd, structcli.WithMCP(mcp.Options{
     Name: "streamed",
     CommandFactory: func(argv []string, stdout io.Writer, stderr io.Writer) (*cobra.Command, error) {
         return NewRootCommand(Streams{
@@ -113,7 +117,7 @@ structcli.SetupMCP(rootCmd, mcp.Options{
             ErrOut: stderr,
         }), nil
     },
-})
+}))
 ```
 
 Use `CommandFactory` when the CLI stores output streams in option structs or command constructors. The factory should build the command tree, while structcli sets the MCP call's argv before execution. MCP tool calls are non-interactive; if your command constructor requires stdin, wire a non-interactive reader such as `strings.NewReader("")`. The default MCP executor still reuses and resets the original Cobra tree, which is simpler for CLIs that only write through `cmd.OutOrStdout()` and `cmd.ErrOrStderr()`.
@@ -129,7 +133,7 @@ Use `CommandFactory` when the CLI stores output streams in option structs or com
 - writes structured JSON to `stderr`
 - exits with the semantic code
 
-`SetupFlagErrors` is optional, but recommended. It intercepts Cobra flag parse errors and upgrades them into typed flag errors, so classification does not have to rely on regex fallback for invalid values and unknown flags.
+`WithFlagErrors` (or standalone `SetupFlagErrors`) is optional, but recommended. It intercepts Cobra flag parse errors and upgrades them into typed flag errors, so classification does not have to rely on regex fallback for invalid values and unknown flags.
 
 Structured errors can include fields such as:
 
@@ -179,7 +183,7 @@ Helpers:
 
 ## Static discovery files
 
-The `generate` package produces build-time discovery files from the same struct definitions that power `--jsonschema`, `SetupMCP`, and `HandleError`. No hand-written markdown to keep in sync.
+The `generate` package produces build-time discovery files from the same struct definitions that power `--jsonschema`, `--mcp`, and `HandleError`. No hand-written markdown to keep in sync.
 
 Three formats are supported:
 
@@ -232,11 +236,11 @@ See the [structured error example](../examples/structerr/README.md) for a runnab
 
 | Need | Tool |
 |------|------|
-| Runtime self-description (single command) | `--jsonschema` |
+| Runtime self-description (single command) | `--jsonschema` via `WithJSONSchema` |
 | Cross-tree structured data (all commands) | `--jsonschema=tree` |
-| Env var / config key reference (human-readable) | `SetupHelpTopics` |
-| Live agent tool access | `SetupMCP` |
-| Better flag-parse errors | `SetupFlagErrors` |
+| Env var / config key reference (human-readable) | `WithHelpTopics` |
+| Live agent tool access | `WithMCP` |
+| Better flag-parse errors | `WithFlagErrors` |
 | Manual error formatting | `HandleError` |
 | One-line production main | `ExecuteOrExit` |
 | Build-time discovery files | `generate.WriteAll` with `//go:generate` |

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -94,7 +94,7 @@ func (o *ServerOptions) Attach(c *cobra.Command) error {
 	return structcli.Define(c, o)
 }
 
-func makeSrvC(commonOpts *UtilityFlags) *cobra.Command {
+func makeSrvC(commonOpts *UtilityFlags) (*cobra.Command, error) {
 	opts := &ServerOptions{}
 
 	srvC := &cobra.Command{
@@ -124,7 +124,9 @@ func makeSrvC(commonOpts *UtilityFlags) *cobra.Command {
 	}
 	// Use Attach (not Bind) — srv has subcommands and ServerOptions should
 	// only be unmarshalled when srv itself runs, not for child commands.
-	opts.Attach(srvC)
+	if err := opts.Attach(srvC); err != nil {
+		return nil, fmt.Errorf("srv: attach options: %w", err)
+	}
 
 	versionC := &cobra.Command{
 		Use:   "version",
@@ -141,10 +143,12 @@ func makeSrvC(commonOpts *UtilityFlags) *cobra.Command {
 		},
 	}
 
-	structcli.Bind(versionC, commonOpts)
+	if err := structcli.Bind(versionC, commonOpts); err != nil {
+		return nil, fmt.Errorf("srv version: bind: %w", err)
+	}
 	srvC.AddCommand(versionC)
 
-	return srvC
+	return srvC, nil
 }
 
 var _ structcli.Validatable = (*UserConfig)(nil)
@@ -181,7 +185,7 @@ func (o *UserConfig) Transform(ctx context.Context) error {
 	return modifiers.New().Struct(ctx, o)
 }
 
-func makeUsrC(commonOpts *UtilityFlags) *cobra.Command {
+func makeUsrC(commonOpts *UtilityFlags) (*cobra.Command, error) {
 	opts := &UserConfig{}
 
 	usrC := &cobra.Command{
@@ -213,12 +217,16 @@ func makeUsrC(commonOpts *UtilityFlags) *cobra.Command {
 		},
 	}
 
-	structcli.Bind(addC, opts)
-	structcli.Bind(addC, commonOpts)
+	if err := structcli.Bind(addC, opts); err != nil {
+		return nil, fmt.Errorf("usr add: bind opts: %w", err)
+	}
+	if err := structcli.Bind(addC, commonOpts); err != nil {
+		return nil, fmt.Errorf("usr add: bind common: %w", err)
+	}
 
 	usrC.AddCommand(addC)
 
-	return usrC
+	return usrC, nil
 }
 
 var _ structcli.Validatable = (*PresetDemoOptions)(nil)
@@ -254,7 +262,7 @@ func (o *PresetDemoOptions) Transform(ctx context.Context) error {
 	return modifiers.New().Struct(ctx, o)
 }
 
-func makePresetC() *cobra.Command {
+func makePresetC() (*cobra.Command, error) {
 	opts := &PresetDemoOptions{}
 
 	presetC := &cobra.Command{
@@ -268,9 +276,11 @@ func makePresetC() *cobra.Command {
 			return nil
 		},
 	}
-	structcli.Bind(presetC, opts)
+	if err := structcli.Bind(presetC, opts); err != nil {
+		return nil, fmt.Errorf("preset: bind: %w", err)
+	}
 
-	return presetC
+	return presetC, nil
 }
 
 // LogsOptions demonstrates flagkit composition with multiple types.
@@ -292,7 +302,7 @@ func (o *LogsOptions) Attach(c *cobra.Command) error {
 	return nil
 }
 
-func makeLogsC() *cobra.Command {
+func makeLogsC() (*cobra.Command, error) {
 	opts := &LogsOptions{}
 
 	logsC := &cobra.Command{
@@ -325,11 +335,13 @@ func makeLogsC() *cobra.Command {
 	}
 	// LogsOptions.Attach has custom logic (flagkit.AnnotateCommand), so use Bind
 	// which delegates to Attach for Options implementors.
-	structcli.Bind(logsC, opts)
+	if err := structcli.Bind(logsC, opts); err != nil {
+		return nil, fmt.Errorf("logs: bind: %w", err)
+	}
 	// Narrow help/completion/schema to the formats this command supports.
 	opts.Output.RestrictFormats(logsC, flagkit.OutputText, flagkit.OutputJSON)
 
-	return logsC
+	return logsC, nil
 }
 
 var _ structcli.ContextInjector = (*UtilityFlags)(nil)
@@ -395,11 +407,33 @@ func NewRootC(exitOnDebug bool) (*cobra.Command, error) {
 		return nil, err
 	}
 
-	structcli.Bind(rootC, commonOpts)
-	rootC.AddCommand(makeSrvC(commonOpts))
-	rootC.AddCommand(makeUsrC(commonOpts))
-	rootC.AddCommand(makePresetC())
-	rootC.AddCommand(makeLogsC())
+	if err := structcli.Bind(rootC, commonOpts); err != nil {
+		return nil, fmt.Errorf("root: bind common: %w", err)
+	}
+
+	srvC, err := makeSrvC(commonOpts)
+	if err != nil {
+		return nil, err
+	}
+	rootC.AddCommand(srvC)
+
+	usrC, err := makeUsrC(commonOpts)
+	if err != nil {
+		return nil, err
+	}
+	rootC.AddCommand(usrC)
+
+	presetC, err := makePresetC()
+	if err != nil {
+		return nil, err
+	}
+	rootC.AddCommand(presetC)
+
+	logsC, err := makeLogsC()
+	if err != nil {
+		return nil, err
+	}
+	rootC.AddCommand(logsC)
 
 	return rootC, nil
 }

--- a/examples/minimal/main.go
+++ b/examples/minimal/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
@@ -24,6 +25,8 @@ func main() {
 		},
 	}
 
-	structcli.Bind(cli, opts)
+	if err := structcli.Bind(cli, opts); err != nil {
+		log.Fatalln(err)
+	}
 	structcli.ExecuteOrExit(cli)
 }

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -35,7 +35,9 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	structcli.Bind(cli, opts)
+	if err := structcli.Bind(cli, opts); err != nil {
+		log.Fatalln(err)
+	}
 
 	// Structured errors: JSON to stderr + semantic exit code on failure
 	structcli.ExecuteOrExit(cli)


### PR DESCRIPTION
## Description

Update documentation and examples to reflect the new ergonomic API. No runtime behavior changes — those are in PR #148.

PR 7 of 7 in the ergonomics spec (depends on PR #148 for runtime fixes).

### Commits

**1. `docs: update README to use Setup + Bind + ExecuteC API`**
- Quick Start: `Bind` + `ExecuteOrExit`.
- Build AI-Native CLIs: `Setup` with `WithJSONSchema`, `WithMCP`, etc.
- Config, Debug, Help Topics sections: `With*` via `Setup`.
- Sharing Options: `ContextInjector` + `Bind` pattern.
- Custom Type Handlers, Flag Kits: note `Bind` as preferred.

**2. `docs: update ai-native.md to use Setup functional options API`**
- All feature sections: `With*` as primary, standalone as fallback.

**3. `docs: add TraverseChildren caveat and fix ContextInjector reference`**
- Shared-options section references `ContextInjector` (not deprecated `ContextOptions`).
- Documents that `TraverseChildren = true` is needed when binding shared flags on root.

**4. `refactor: handle Bind errors in all examples`**
- Factory functions return `(*cobra.Command, error)` and propagate `Bind`/`Attach` errors.
- `main()` functions check `Bind` errors with `log.Fatalln`.

## How to test

```
go test -count=1 ./...
go test -count=1 ./examples/full/cli/
```

Documentation and example changes only. Full suite passes."