### PR TITLE
fix: bind pipeline runtime fixes for shared opts, repeated ExecuteC, and config reload

### DIFF
--- a/define.go
+++ b/define.go
@@ -581,4 +581,9 @@ func Reset() {
 
 		return true
 	})
+	configOnceStore.Range(func(key, _ any) bool {
+		configOnceStore.Delete(key)
+
+		return true
+	})
 }

--- a/define.go
+++ b/define.go
@@ -576,4 +576,9 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 func Reset() {
 	SetEnvPrefix("")
+	hookStore.Range(func(key, _ any) bool {
+		hookStore.Delete(key)
+
+		return true
+	})
 }

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -94,8 +94,7 @@ func (o *ServerOptions) Attach(c *cobra.Command) error {
 	return structcli.Define(c, o)
 }
 
-func makeSrvC() *cobra.Command {
-	commonOpts := &UtilityFlags{}
+func makeSrvC(commonOpts *UtilityFlags) *cobra.Command {
 	opts := &ServerOptions{}
 
 	srvC := &cobra.Command{
@@ -182,8 +181,7 @@ func (o *UserConfig) Transform(ctx context.Context) error {
 	return modifiers.New().Struct(ctx, o)
 }
 
-func makeUsrC() *cobra.Command {
-	commonOpts := &UtilityFlags{}
+func makeUsrC(commonOpts *UtilityFlags) *cobra.Command {
 	opts := &UserConfig{}
 
 	usrC := &cobra.Command{
@@ -398,8 +396,8 @@ func NewRootC(exitOnDebug bool) (*cobra.Command, error) {
 	}
 
 	structcli.Bind(rootC, commonOpts)
-	rootC.AddCommand(makeSrvC())
-	rootC.AddCommand(makeUsrC())
+	rootC.AddCommand(makeSrvC(commonOpts))
+	rootC.AddCommand(makeUsrC(commonOpts))
 	rootC.AddCommand(makePresetC())
 	rootC.AddCommand(makeLogsC())
 

--- a/execute.go
+++ b/execute.go
@@ -5,24 +5,31 @@ import (
 	"sync"
 
 	internalcmd "github.com/leodido/structcli/internal/cmd"
+	internalconfig "github.com/leodido/structcli/internal/config"
 	internalscope "github.com/leodido/structcli/internal/scope"
 	"github.com/spf13/cobra"
 )
 
 const bindPipelineAnnotation = "structcli/bind-pipeline-wrapped"
 
-// originalHookKey is used to store original persistent hooks before wrapping.
-const originalPreRunEKey = "structcli/original-persistent-prerun-e"
-const originalPreRunKey = "structcli/original-persistent-prerun"
-
-// originalHooks stores the original PersistentPreRunE/PersistentPreRun per command,
-// keyed by command pointer. We use a separate map because annotations are string-only.
-var originalHooks = struct {
+// hookSet holds the original PersistentPreRunE/PersistentPreRun hooks
+// saved before wrapping, keyed by command pointer.
+type hookSet struct {
 	preRunE map[*cobra.Command]func(*cobra.Command, []string) error
 	preRun  map[*cobra.Command]func(*cobra.Command, []string)
-}{
-	preRunE: make(map[*cobra.Command]func(*cobra.Command, []string) error),
-	preRun:  make(map[*cobra.Command]func(*cobra.Command, []string)),
+}
+
+// hookStore is a process-safe map from root command → hookSet.
+// Each ExecuteC call creates an entry for its root and removes it on return.
+var hookStore sync.Map // *cobra.Command → *hookSet
+
+func getHooks(root *cobra.Command) *hookSet {
+	val, _ := hookStore.Load(root)
+	if val == nil {
+		return nil
+	}
+
+	return val.(*hookSet)
 }
 
 // ExecuteC prepares the command tree for execution and delegates to cmd.ExecuteC().
@@ -43,6 +50,15 @@ func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
 
 	root.SilenceErrors = true
 	root.SilenceUsage = true
+
+	// Per-execution hook storage — cleaned up on return to avoid leaking
+	// command pointers and to isolate concurrent ExecuteC calls.
+	hooks := &hookSet{
+		preRunE: make(map[*cobra.Command]func(*cobra.Command, []string) error),
+		preRun:  make(map[*cobra.Command]func(*cobra.Command, []string)),
+	}
+	hookStore.Store(root, hooks)
+	defer hookStore.Delete(root)
 
 	// Fresh once-guard per ExecuteC call for config auto-load.
 	configOnce := &sync.Once{}
@@ -86,11 +102,14 @@ func wrapBindPipeline(c *cobra.Command, configOnce *sync.Once) {
 	}
 
 	// Save original hooks before overwriting.
-	if c.PersistentPreRunE != nil {
-		originalHooks.preRunE[c] = c.PersistentPreRunE
-	}
-	if c.PersistentPreRun != nil {
-		originalHooks.preRun[c] = c.PersistentPreRun
+	hooks := getHooks(c.Root())
+	if hooks != nil {
+		if c.PersistentPreRunE != nil {
+			hooks.preRunE[c] = c.PersistentPreRunE
+		}
+		if c.PersistentPreRun != nil {
+			hooks.preRun[c] = c.PersistentPreRun
+		}
 	}
 
 	c.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -128,6 +147,9 @@ func wrapBindPipeline(c *cobra.Command, configOnce *sync.Once) {
 // autoLoadConfig calls UseConfigSimple once per execution when WithConfig
 // was used in Setup. The sync.Once ensures config is loaded exactly once
 // even though every command in the tree has the wrapper.
+//
+// After loading, it merges config into each ancestor command's viper so
+// that ancestor-bound options see config values during unmarshal.
 func autoLoadConfig(cmd *cobra.Command, configOnce *sync.Once) error {
 	root := cmd.Root()
 	if root.Annotations == nil || root.Annotations[configAutoLoadAnnotation] != "true" {
@@ -145,6 +167,19 @@ func autoLoadConfig(cmd *cobra.Command, configOnce *sync.Once) error {
 		if message != "" {
 			cmd.Println(message)
 		}
+
+		// UseConfigSimple merges config into the executed command's viper.
+		// Also merge into each ancestor's viper so ancestor-bound options
+		// see config values when unmarshalled with the owner command.
+		rootVip := internalscope.Get(root).ConfigViper()
+		for c := cmd.Parent(); c != nil; c = c.Parent() {
+			configToMerge := internalconfig.Merge(rootVip.AllSettings(), c)
+			if mergeErr := internalscope.Get(c).Viper().MergeConfigMap(configToMerge); mergeErr != nil {
+				configErr = fmt.Errorf("error merging config for command %q: %w", c.CommandPath(), mergeErr)
+
+				return
+			}
+		}
 	})
 	if configErr != nil {
 		return fmt.Errorf("structcli: auto-load config: %w", configErr)
@@ -157,14 +192,19 @@ func autoLoadConfig(cmd *cobra.Command, configOnce *sync.Once) error {
 // any original PersistentPreRunE or PersistentPreRun that was saved
 // before wrapping, in root-first order.
 func replayOriginalHooks(executedCmd *cobra.Command, args []string) error {
+	hooks := getHooks(executedCmd.Root())
+	if hooks == nil {
+		return nil
+	}
+
 	path := pathToRoot(executedCmd)
 
 	for _, c := range path {
-		if hook, ok := originalHooks.preRunE[c]; ok {
+		if hook, ok := hooks.preRunE[c]; ok {
 			if err := hook(executedCmd, args); err != nil {
 				return err
 			}
-		} else if hook, ok := originalHooks.preRun[c]; ok {
+		} else if hook, ok := hooks.preRun[c]; ok {
 			hook(executedCmd, args)
 		}
 	}
@@ -181,12 +221,46 @@ func replayOriginalHooks(executedCmd *cobra.Command, args []string) error {
 func runBindPipeline(executedCmd *cobra.Command) error {
 	path := pathToRoot(executedCmd)
 
+	// Track unmarshalled opts pointers to avoid re-unmarshalling the same
+	// struct when it is bound to multiple commands in the ancestor chain.
+	// The first (ancestor-most) binding wins because the pipeline walks
+	// root-first and TraverseChildren parses ancestor flags first.
+	seen := make(map[any]bool)
+
 	for _, c := range path {
 		scope := internalscope.Get(c)
 		for _, opts := range scope.BoundOptions() {
-			if err := unmarshal(executedCmd, opts); err != nil {
+			if seen[opts] {
+				continue
+			}
+			seen[opts] = true
+			// Unmarshal using the owner command (c) for viper/flag resolution,
+			// but inject context on the executed command so descendants see it.
+			if err := unmarshalForPipeline(c, executedCmd, opts); err != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+// unmarshalForPipeline unmarshals opts using ownerCmd for viper/flag resolution,
+// then re-injects context on executedCmd so descendants can see ContextInjector
+// values. Cobra does not propagate SetContext calls made on ancestors after
+// command resolution, so context must be set on the executed command.
+func unmarshalForPipeline(ownerCmd, executedCmd *cobra.Command, opts any) error {
+	if err := unmarshal(ownerCmd, opts); err != nil {
+		return err
+	}
+
+	// If context was injected on ownerCmd but executedCmd is different,
+	// re-inject on executedCmd so descendants see the value.
+	if ownerCmd != executedCmd {
+		if o, ok := opts.(ContextInjector); ok {
+			executedCmd.SetContext(o.Context(executedCmd.Context()))
+		} else if o, ok := opts.(ContextOptions); ok {
+			executedCmd.SetContext(o.Context(executedCmd.Context()))
 		}
 	}
 

--- a/execute.go
+++ b/execute.go
@@ -136,7 +136,15 @@ func autoLoadConfig(cmd *cobra.Command, configOnce *sync.Once) error {
 
 	var configErr error
 	configOnce.Do(func() {
-		_, _, configErr = UseConfigSimple(cmd)
+		_, message, err := UseConfigSimple(cmd)
+		if err != nil {
+			configErr = err
+
+			return
+		}
+		if message != "" {
+			cmd.Println(message)
+		}
 	})
 	if configErr != nil {
 		return fmt.Errorf("structcli: auto-load config: %w", configErr)

--- a/execute.go
+++ b/execute.go
@@ -20,7 +20,8 @@ type hookSet struct {
 }
 
 // hookStore is a process-safe map from root command → hookSet.
-// Each ExecuteC call creates an entry for its root and removes it on return.
+// Created once per command tree on the first ExecuteC call and reused
+// across repeated executions. Entries are removed by Reset().
 var hookStore sync.Map // *cobra.Command → *hookSet
 
 func getHooks(root *cobra.Command) *hookSet {
@@ -51,14 +52,16 @@ func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
 	root.SilenceErrors = true
 	root.SilenceUsage = true
 
-	// Per-execution hook storage — cleaned up on return to avoid leaking
-	// command pointers and to isolate concurrent ExecuteC calls.
-	hooks := &hookSet{
+	// Hook storage is created once per command tree and reused across
+	// repeated ExecuteC calls. The hookStore entry is keyed by root
+	// command pointer; it is populated during the first prepareTree
+	// and persists for the tree's lifetime.
+	if _, loaded := hookStore.LoadOrStore(root, &hookSet{
 		preRunE: make(map[*cobra.Command]func(*cobra.Command, []string) error),
 		preRun:  make(map[*cobra.Command]func(*cobra.Command, []string)),
+	}); loaded {
+		// Already initialized — hooks were saved during the first wrap.
 	}
-	hookStore.Store(root, hooks)
-	defer hookStore.Delete(root)
 
 	// Fresh once-guard per ExecuteC call for config auto-load.
 	configOnce := &sync.Once{}

--- a/execute.go
+++ b/execute.go
@@ -24,6 +24,10 @@ type hookSet struct {
 // across repeated executions. Entries are removed by Reset().
 var hookStore sync.Map // *cobra.Command → *hookSet
 
+// configOnceStore holds the per-execution sync.Once for config auto-load.
+// Replaced on every ExecuteC call so repeated executions reload config.
+var configOnceStore sync.Map // *cobra.Command → *sync.Once
+
 func getHooks(root *cobra.Command) *hookSet {
 	val, _ := hookStore.Load(root)
 	if val == nil {
@@ -31,6 +35,15 @@ func getHooks(root *cobra.Command) *hookSet {
 	}
 
 	return val.(*hookSet)
+}
+
+func getConfigOnce(root *cobra.Command) *sync.Once {
+	val, _ := configOnceStore.Load(root)
+	if val == nil {
+		return nil
+	}
+
+	return val.(*sync.Once)
 }
 
 // ExecuteC prepares the command tree for execution and delegates to cmd.ExecuteC().
@@ -56,33 +69,33 @@ func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
 	// repeated ExecuteC calls. The hookStore entry is keyed by root
 	// command pointer; it is populated during the first prepareTree
 	// and persists for the tree's lifetime.
-	if _, loaded := hookStore.LoadOrStore(root, &hookSet{
+	hookStore.LoadOrStore(root, &hookSet{
 		preRunE: make(map[*cobra.Command]func(*cobra.Command, []string) error),
 		preRun:  make(map[*cobra.Command]func(*cobra.Command, []string)),
-	}); loaded {
-		// Already initialized — hooks were saved during the first wrap.
-	}
+	})
 
-	// Fresh once-guard per ExecuteC call for config auto-load.
-	configOnce := &sync.Once{}
+	// Fresh once-guard per ExecuteC call so config is reloaded on each
+	// execution. The wrapper closures look this up at runtime via
+	// getConfigOnce rather than capturing a stale pointer.
+	configOnceStore.Store(root, &sync.Once{})
 
-	prepareTree(root, configOnce)
+	prepareTree(root)
 
 	return cmd.ExecuteC()
 }
 
 // prepareTree walks the command tree and installs the bind pipeline wrapper
 // and SetupUsage on every command. Idempotent via annotation guard.
-func prepareTree(c *cobra.Command, configOnce *sync.Once) {
+func prepareTree(c *cobra.Command) {
 	if c == nil {
 		return
 	}
 
 	SetupUsage(c)
-	wrapBindPipeline(c, configOnce)
+	wrapBindPipeline(c)
 
 	for _, sub := range c.Commands() {
-		prepareTree(sub, configOnce)
+		prepareTree(sub)
 	}
 }
 
@@ -96,7 +109,7 @@ func prepareTree(c *cobra.Command, configOnce *sync.Once) {
 // persistent hooks in root-first order. This ensures user hooks on
 // ancestor commands fire even when a descendant's wrapper is the one
 // Cobra picks.
-func wrapBindPipeline(c *cobra.Command, configOnce *sync.Once) {
+func wrapBindPipeline(c *cobra.Command) {
 	if c.Annotations == nil {
 		c.Annotations = make(map[string]string)
 	}
@@ -122,8 +135,12 @@ func wrapBindPipeline(c *cobra.Command, configOnce *sync.Once) {
 		}
 
 		// Auto-load config once per execution if WithConfig was used.
-		if err := autoLoadConfig(cmd, configOnce); err != nil {
-			return err
+		// Look up the current configOnce at runtime so repeated ExecuteC
+		// calls get a fresh guard (not the one captured at wrap time).
+		if once := getConfigOnce(cmd.Root()); once != nil {
+			if err := autoLoadConfig(cmd, once); err != nil {
+				return err
+			}
 		}
 
 		// Run bind pipeline: walk root → executed command, unmarshal bound options.

--- a/execute_test.go
+++ b/execute_test.go
@@ -459,3 +459,113 @@ func TestExecuteC_ErrorInUserHook_Propagates(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, hookErr)
 }
+
+func TestExecuteC_SharedOpts_AncestorLocalFlagFlowsToDescendant(t *testing.T) {
+	// Verifies that a local flag defined on root via Bind is visible in a
+	// descendant command when the same opts pointer is bound to both root
+	// and the descendant. The bind pipeline should unmarshal using the
+	// owner command's viper (root) and deduplicate via the seen map.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	type SharedFlags struct {
+		DryRun bool `flag:"dry" flagdescr:"dry run mode"`
+	}
+
+	shared := &SharedFlags{}
+	var dryInChild bool
+
+	root := &cobra.Command{
+		Use:              "app",
+		TraverseChildren: true,
+	}
+	child := &cobra.Command{
+		Use: "sub",
+		RunE: func(c *cobra.Command, args []string) error {
+			dryInChild = shared.DryRun
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	require.NoError(t, Bind(root, shared))
+	require.NoError(t, Bind(child, shared))
+
+	root.SetArgs([]string{"--dry", "sub"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.True(t, shared.DryRun, "shared.DryRun should be true from --dry flag")
+	assert.True(t, dryInChild, "child RunE should see DryRun=true via shared pointer")
+}
+
+func TestExecuteC_SharedOpts_SeenMapPreventsDoubleUnmarshal(t *testing.T) {
+	// When the same opts pointer is bound to root and child, the bind
+	// pipeline should unmarshal it exactly once (on the owner command).
+	// A second unmarshal on the child would use the child's viper which
+	// doesn't have root's local flags, resetting the value to default.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	type CountOpts struct {
+		Verbose int `flagtype:"count" flagshort:"v"`
+	}
+
+	shared := &CountOpts{}
+
+	root := &cobra.Command{
+		Use:              "app",
+		TraverseChildren: true,
+	}
+	child := &cobra.Command{
+		Use: "sub",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	require.NoError(t, Bind(root, shared))
+	require.NoError(t, Bind(child, shared))
+
+	root.SetArgs([]string{"-vvv", "sub"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, shared.Verbose, "verbose count should be 3, not reset by child unmarshal")
+}
+
+func TestExecuteC_SharedContextInjector_VisibleInDescendant(t *testing.T) {
+	// A ContextInjector bound to root should have its context visible in
+	// descendant commands even when the bind pipeline unmarshals on root.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	shared := &execContextOpts{}
+	var nameInChild string
+
+	root := &cobra.Command{
+		Use:              "app",
+		TraverseChildren: true,
+	}
+	child := &cobra.Command{
+		Use: "sub",
+		RunE: func(c *cobra.Command, args []string) error {
+			if v := c.Context().Value(ctxKey("app-name")); v != nil {
+				nameInChild = v.(string)
+			}
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	require.NoError(t, Bind(root, shared))
+
+	root.SetArgs([]string{"--app-name", "test-app", "sub"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-app", shared.AppName)
+	assert.Equal(t, "test-app", nameInChild, "context injected on root should be visible in child")
+}
+

--- a/execute_test.go
+++ b/execute_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/leodido/structcli/config"
 	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -496,6 +498,55 @@ func TestExecuteC_RepeatedExecution_PreservesUserHook(t *testing.T) {
 	_, err = ExecuteC(root)
 	require.NoError(t, err)
 	assert.Equal(t, 2, hookCount, "user hook should fire on second execution")
+}
+
+func TestExecuteC_RepeatedExecution_ReloadsConfig(t *testing.T) {
+	// Regression: the second ExecuteC must use a fresh configOnce so that
+	// config is reloaded. The wrapper closures must not capture a stale
+	// sync.Once from the first call.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	type appOpts struct {
+		Host string `flag:"host" default:"localhost"`
+	}
+
+	opts := &appOpts{}
+
+	root := &cobra.Command{Use: "app"}
+	child := &cobra.Command{
+		Use: "run",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	require.NoError(t, Setup(root, WithAppName("app"), WithConfig(config.Options{})))
+	require.NoError(t, Bind(child, opts))
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/etc/app", 0755))
+
+	// First execution: config sets host=alpha
+	require.NoError(t, afero.WriteFile(fs, "/etc/app/config.yaml", []byte("host: alpha"), 0644))
+	GetConfigViper(root).SetFs(fs)
+
+	root.SetArgs([]string{"run"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", opts.Host, "first execution should load host=alpha from config")
+
+	// Second execution: config changes to host=beta
+	require.NoError(t, afero.WriteFile(fs, "/etc/app/config.yaml", []byte("host: beta"), 0644))
+	// Reset the config viper so it re-reads the file.
+	internalscope.Get(root).ResetConfigViper()
+	GetConfigViper(root).SetFs(fs)
+
+	root.SetArgs([]string{"run"})
+	_, err = ExecuteC(root)
+	require.NoError(t, err)
+	assert.Equal(t, "beta", opts.Host, "second execution should reload config and see host=beta")
 }
 
 func TestExecuteC_SharedOpts_AncestorLocalFlagFlowsToDescendant(t *testing.T) {

--- a/execute_test.go
+++ b/execute_test.go
@@ -460,6 +460,44 @@ func TestExecuteC_ErrorInUserHook_Propagates(t *testing.T) {
 	assert.ErrorIs(t, err, hookErr)
 }
 
+func TestExecuteC_RepeatedExecution_PreservesUserHook(t *testing.T) {
+	// Regression: the second ExecuteC on the same tree must still replay
+	// the user's original PersistentPreRunE. The hook is saved during the
+	// first prepareTree wrap and must persist across executions.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var hookCount int
+
+	root := &cobra.Command{Use: "root"}
+	root.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		hookCount++
+		return nil
+	}
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	root.AddCommand(child)
+	require.NoError(t, Bind(child, opts))
+
+	// First execution
+	root.SetArgs([]string{"child", "--port", "1111"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+	assert.Equal(t, 1, hookCount, "user hook should fire on first execution")
+
+	// Second execution on same tree
+	root.SetArgs([]string{"child", "--port", "2222"})
+	_, err = ExecuteC(root)
+	require.NoError(t, err)
+	assert.Equal(t, 2, hookCount, "user hook should fire on second execution")
+}
+
 func TestExecuteC_SharedOpts_AncestorLocalFlagFlowsToDescendant(t *testing.T) {
 	// Verifies that a local flag defined on root via Bind is visible in a
 	// descendant command when the same opts pointer is bound to both root

--- a/internal/config/viper.go
+++ b/internal/config/viper.go
@@ -1,6 +1,7 @@
 package internalconfig
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -107,7 +108,16 @@ func SyncMandatoryFlags(c *cobra.Command, T reflect.Type, vip *viper.Viper, stru
 // KeyRemappingHook allows config keys to match either a field's name or its `flag` tag.
 //
 // It correctly handles flattened keys that point to nested struct fields.
-func KeyRemappingHook(aliasToPathMap map[string]string, defaultsMap map[string]string) mapstructure.DecodeHookFunc {
+//
+// changedFlags, when non-nil, lists flag names that were explicitly set by the
+// user (i.e. pflag.Flag.Changed == true). This lets the hook prefer a flag
+// value over a config-file value when both the alias key and the field-name
+// key are present in the map.
+func KeyRemappingHook(aliasToPathMap map[string]string, defaultsMap map[string]string, changedFlags ...map[string]bool) mapstructure.DecodeHookFunc {
+	var changed map[string]bool
+	if len(changedFlags) > 0 {
+		changed = changedFlags[0]
+	}
 	return func(_ reflect.Type, t reflect.Type, data any) (any, error) {
 		if t.Kind() == reflect.Ptr {
 			t = t.Elem()
@@ -187,17 +197,39 @@ func KeyRemappingHook(aliasToPathMap map[string]string, defaultsMap map[string]s
 
 			// When the alias exists and the config map has a value for that alias...
 			if alias != "" && alias != fieldNameKey {
-				if aliasValue, ok := configMap[alias]; ok && aliasValue != "" {
-					// Then, make the alias value available under the field name key.
+				aliasValue, aliasExists := configMap[alias]
+				fieldValue, fieldExists := configMap[fieldNameKey]
+
+				switch {
+				case aliasExists && aliasValue != "" && !fieldExists:
+					// Only alias present: propagate alias → field name.
 					configMap[fieldNameKey] = aliasValue
+				case !aliasExists && fieldExists && fieldValue != "":
+					// Only field name present: propagate field name → alias.
+					configMap[alias] = fieldValue
+				case aliasExists && fieldExists:
+					// Both present. The alias key participates in viper's
+					// full resolution (flag > env > config > default) while
+					// the field-name key is typically a SetDefault value.
+					//
+					// Prefer the alias value when the flag was explicitly
+					// set or when the alias value differs from the struct-
+					// tag default (meaning config or env supplied it).
+					// Otherwise the field-name value wins (it may carry a
+					// config value set under the field name).
+					aliasIsDefault := false
+					if defVal, ok := defaultsMap[alias]; ok {
+						aliasIsDefault = fmt.Sprintf("%v", aliasValue) == defVal
+					} else {
+						// No struct-tag default: treat zero values as default.
+						aliasIsDefault = isZeroValue(aliasValue)
+					}
 
-					continue
-				}
-				if fieldNameVal, ok := configMap[fieldNameKey]; ok && fieldNameKey != "" {
-					// Or, make the field value available under the alias.
-					configMap[alias] = fieldNameVal
-
-					continue
+					if (changed != nil && changed[alias]) || !aliasIsDefault {
+						configMap[fieldNameKey] = aliasValue
+					} else {
+						configMap[alias] = fieldValue
+					}
 				}
 				// This ensures the decoder can find the value for this field name key or the alias.
 			}
@@ -216,3 +248,13 @@ func structHasField(t reflect.Type, fieldKey string) bool {
 
 	return false
 }
+
+// isZeroValue reports whether v is the zero value for its type.
+func isZeroValue(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	return reflect.ValueOf(v).IsZero()
+}
+

--- a/viper.go
+++ b/viper.go
@@ -122,8 +122,18 @@ func unmarshal(c *cobra.Command, opts any, hooks ...mapstructure.DecodeHookFunc)
 		}
 	}
 
+	// Build set of flags explicitly changed by the user so the remapping
+	// hook can prefer flag values over config-file values when both the
+	// alias key and the field-name key are present.
+	changedFlags := make(map[string]bool)
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			changedFlags[f.Name] = true
+		}
+	})
+
 	// Use `KeyRemappingHook` for smart config keys
-	hooks = append([]mapstructure.DecodeHookFunc{internalconfig.KeyRemappingHook(aliasToPathMap, defaultsMap)}, hooks...)
+	hooks = append([]mapstructure.DecodeHookFunc{internalconfig.KeyRemappingHook(aliasToPathMap, defaultsMap, changedFlags)}, hooks...)
 
 	// Look for decode hook annotation appending them to the list of hooks to use for unmarshalling
 	c.Flags().VisitAll(func(f *pflag.Flag) {


### PR DESCRIPTION
## Description

Runtime fixes for the bind pipeline introduced in PRs #143 and #145. Split out from PR #147 to separate behavioral changes from documentation updates.

PR 6.5 of 7 in the ergonomics spec (inserted between example rewrites and docs).

### Commits

**1. `fix: print config file message during auto-load`**
- `autoLoadConfig` was discarding the `UseConfigSimple` message. Now prints it via `cmd.Println`.

**2. `fix: bind pipeline uses owner command for unmarshal and deduplicates shared opts`**
- `runBindPipeline` now unmarshals using the owner command (where `Bind` was called) instead of the executed command. Ancestor-bound local flags resolve against the correct viper scope.
- `seen` map deduplicates shared opts pointers bound to multiple commands — first (ancestor-most) binding wins.
- `unmarshalForPipeline` re-injects `ContextInjector` context on the executed command.
- `KeyRemappingHook` handles alias/field-name coexistence using `changedFlags` and `defaultsMap`.
- `originalHooks` replaced with per-execution `hookStore` (`sync.Map` keyed by root command).
- `autoLoadConfig` merges config into ancestor vipers so owner-command unmarshal sees config values.
- 3 new tests: ancestor local flag flow, seen-map dedup, context injection.

**3. `fix: persist hookStore across repeated ExecuteC calls`**
- `hookStore` entries were deleted via `defer` on each return. Second call hit the idempotent guard, never re-saved hooks. Now uses `LoadOrStore` — created once, reused across executions.

**4. `fix: wrapper closures no longer capture stale configOnce`**
- `PersistentPreRunE` closures captured the first call's `configOnce`. Now stored in `configOnceStore` and looked up at runtime via `getConfigOnce`.
- `Reset()` clears both `hookStore` and `configOnceStore`.
- 2 regression tests: user hook replay and config reload across repeated `ExecuteC` calls.

## How to test

```
go test -count=1 ./...
go test -count=1 ./examples/full/cli/
go test -v -run TestExecuteC_RepeatedExecution .
go test -v -run TestExecuteC_Shared .
```"