### PR TITLE
feat: add `ExecuteC` + bind pipeline for auto-unmarshal

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -1,0 +1,167 @@
+package structcli
+
+import (
+	internalcmd "github.com/leodido/structcli/internal/cmd"
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+const bindPipelineAnnotation = "structcli/bind-pipeline-wrapped"
+
+// originalHookKey is used to store original persistent hooks before wrapping.
+const originalPreRunEKey = "structcli/original-persistent-prerun-e"
+const originalPreRunKey = "structcli/original-persistent-prerun"
+
+// originalHooks stores the original PersistentPreRunE/PersistentPreRun per command,
+// keyed by command pointer. We use a separate map because annotations are string-only.
+var originalHooks = struct {
+	preRunE map[*cobra.Command]func(*cobra.Command, []string) error
+	preRun  map[*cobra.Command]func(*cobra.Command, []string)
+}{
+	preRunE: make(map[*cobra.Command]func(*cobra.Command, []string) error),
+	preRun:  make(map[*cobra.Command]func(*cobra.Command, []string)),
+}
+
+// ExecuteC prepares the command tree for execution and delegates to cmd.ExecuteC().
+//
+// Preparation (idempotent — safe to call multiple times on the same tree):
+//   - Sets SilenceErrors and SilenceUsage on the root command.
+//   - Runs SetupUsage on every command in the tree.
+//   - Recursively wraps PersistentPreRunE on every command to run the bind pipeline
+//     (auto-unmarshal for all Bind-registered options, root-to-leaf, FIFO per command).
+//   - Skips the bind pipeline when execution is intercepted (--jsonschema, --mcp).
+//   - Preserves any user-set PersistentPreRunE or PersistentPreRun.
+//
+// Returns the executed subcommand and any error.
+func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
+	root := cmd.Root()
+
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+
+	prepareTree(root)
+
+	return cmd.ExecuteC()
+}
+
+// prepareTree walks the command tree and installs the bind pipeline wrapper
+// and SetupUsage on every command. Idempotent via annotation guard.
+func prepareTree(c *cobra.Command) {
+	if c == nil {
+		return
+	}
+
+	SetupUsage(c)
+	wrapBindPipeline(c)
+
+	for _, sub := range c.Commands() {
+		prepareTree(sub)
+	}
+}
+
+// wrapBindPipeline installs a PersistentPreRunE on c that runs the bind
+// pipeline before chaining to original hooks. Idempotent.
+//
+// Because Cobra (without EnableTraverseRunHooks) only executes the first
+// PersistentPreRunE it finds walking from the executed command upward,
+// every command in the tree gets a wrapper. The wrapper itself runs the
+// full root-to-leaf pipeline and then replays all original ancestor
+// persistent hooks in root-first order. This ensures user hooks on
+// ancestor commands fire even when a descendant's wrapper is the one
+// Cobra picks.
+func wrapBindPipeline(c *cobra.Command) {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string)
+	}
+	if c.Annotations[bindPipelineAnnotation] == "true" {
+		return
+	}
+
+	// Save original hooks before overwriting.
+	if c.PersistentPreRunE != nil {
+		originalHooks.preRunE[c] = c.PersistentPreRunE
+	}
+	if c.PersistentPreRun != nil {
+		originalHooks.preRun[c] = c.PersistentPreRun
+	}
+
+	c.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// Skip pipeline on intercepted execution (--jsonschema, --mcp, etc.)
+		if internalcmd.IsExecutionIntercepted(cmd) {
+			return nil
+		}
+
+		// Run bind pipeline: walk root → executed command, unmarshal bound options.
+		if err := runBindPipeline(cmd); err != nil {
+			return err
+		}
+
+		// Replay original persistent hooks from root to the command whose
+		// wrapper Cobra selected (which is cmd's closest ancestor with a
+		// PersistentPreRunE — i.e., this command c, since we wrapped it).
+		// We replay all ancestors' original hooks in root-first order so
+		// user hooks on parent commands still fire.
+		if err := replayOriginalHooks(cmd, args); err != nil {
+			return err
+		}
+
+		return nil
+	}
+	c.PersistentPreRun = nil
+
+	c.Annotations[bindPipelineAnnotation] = "true"
+}
+
+// replayOriginalHooks walks from root to the executed command and calls
+// any original PersistentPreRunE or PersistentPreRun that was saved
+// before wrapping, in root-first order.
+func replayOriginalHooks(executedCmd *cobra.Command, args []string) error {
+	path := pathToRoot(executedCmd)
+
+	for _, c := range path {
+		if hook, ok := originalHooks.preRunE[c]; ok {
+			if err := hook(executedCmd, args); err != nil {
+				return err
+			}
+		} else if hook, ok := originalHooks.preRun[c]; ok {
+			hook(executedCmd, args)
+		}
+	}
+
+	return nil
+}
+
+// runBindPipeline walks from root to the executed command, collecting bound
+// options from each command's scope, and calls unmarshal for each in FIFO order.
+//
+// Every Unmarshal call receives the executed command (not the owning command),
+// because Unmarshal rebuilds flag metadata by walking from the passed command
+// upward through its ancestors.
+func runBindPipeline(executedCmd *cobra.Command) error {
+	path := pathToRoot(executedCmd)
+
+	for _, c := range path {
+		scope := internalscope.Get(c)
+		for _, opts := range scope.BoundOptions() {
+			if err := unmarshal(executedCmd, opts); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// pathToRoot returns the path from root to cmd (root-first order).
+func pathToRoot(cmd *cobra.Command) []*cobra.Command {
+	var path []*cobra.Command
+	for c := cmd; c != nil; c = c.Parent() {
+		path = append(path, c)
+	}
+	// Reverse to get root-first order.
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+
+	return path
+}

--- a/execute_test.go
+++ b/execute_test.go
@@ -1,0 +1,461 @@
+package structcli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	internalscope "github.com/leodido/structcli/internal/scope"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test option types ---
+
+type execPlainOpts struct {
+	Port int    `flag:"port" flagshort:"p" flagdescr:"server port" default:"3000"`
+	Host string `flag:"host" flagdescr:"server host" default:"localhost"`
+}
+
+type execAttachOpts struct {
+	Verbose bool `flag:"verbose" flagshort:"v" flagdescr:"verbose output"`
+}
+
+func (o *execAttachOpts) Attach(c *cobra.Command) error {
+	return Define(c, o)
+}
+
+type execContextOpts struct {
+	AppName string `flag:"app-name" flagdescr:"application name" default:"myapp"`
+}
+
+func (o *execContextOpts) Context(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKey("app-name"), o.AppName)
+}
+
+type ctxKey string
+
+type execChildOpts struct {
+	Debug bool `flag:"debug" flagshort:"d" flagdescr:"enable debug"`
+}
+
+// --- Tests ---
+
+func TestExecuteC_BasicExecution(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var ran bool
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			ran = true
+			return nil
+		},
+	}
+
+	c, err := ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.True(t, ran)
+	assert.Equal(t, "test", c.Name())
+}
+
+func TestExecuteC_AutoUnmarshal_PlainStruct(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{"--port", "8080", "--host", "0.0.0.0"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 8080, opts.Port)
+	assert.Equal(t, "0.0.0.0", opts.Host)
+}
+
+func TestExecuteC_AutoUnmarshal_OptionsImplementor(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execAttachOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{"--verbose"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, opts.Verbose)
+}
+
+func TestExecuteC_AutoUnmarshal_Defaults(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3000, opts.Port)
+	assert.Equal(t, "localhost", opts.Host)
+}
+
+func TestExecuteC_PopulatedBeforePreRunE(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var portInPreRun int
+
+	cmd := &cobra.Command{
+		Use: "test",
+		PreRunE: func(c *cobra.Command, args []string) error {
+			portInPreRun = opts.Port
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{"--port", "9090"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 9090, portInPreRun, "opts should be populated before PreRunE")
+}
+
+func TestExecuteC_MultipleBind_FIFOOrder(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	plain := &execPlainOpts{}
+	attach := &execAttachOpts{}
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, plain))
+	require.NoError(t, Bind(cmd, attach))
+
+	cmd.SetArgs([]string{"--port", "4000", "--verbose"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4000, plain.Port)
+	assert.True(t, attach.Verbose)
+}
+
+func TestExecuteC_AncestorBeforeDescendant(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	rootOpts := &execContextOpts{}
+	childOpts := &execChildOpts{}
+
+	var ctxValueInRun string
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			// rootOpts.Context() should have been called before childOpts unmarshal
+			if v := c.Context().Value(ctxKey("app-name")); v != nil {
+				ctxValueInRun = v.(string)
+			}
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	// Bind rootOpts on child too — flags are local per command.
+	// The ancestor-before-descendant contract is about unmarshal order
+	// when both root and child have bound options.
+	require.NoError(t, Bind(root, rootOpts))
+	require.NoError(t, Bind(child, childOpts))
+
+	// rootOpts flags are on root (local), childOpts flags are on child (local).
+	// Execute child with child-local flags only; root opts get defaults.
+	root.SetArgs([]string{"child", "--debug"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, "myapp", rootOpts.AppName, "root opts should get default value")
+	assert.True(t, childOpts.Debug)
+	assert.Equal(t, "myapp", ctxValueInRun, "root context injection should be visible in child RunE")
+}
+
+func TestExecuteC_PreservesUserPersistentPreRunE(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var userHookRan bool
+	var portInUserHook int
+
+	cmd := &cobra.Command{
+		Use: "root",
+	}
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		userHookRan = true
+		portInUserHook = opts.Port
+		return nil
+	}
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.AddCommand(child)
+
+	// Bind on child so flags are local to child
+	require.NoError(t, Bind(child, opts))
+
+	cmd.SetArgs([]string{"child", "--port", "5555"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, userHookRan, "user PersistentPreRunE should still run")
+	assert.Equal(t, 5555, portInUserHook, "opts should be populated before user hook")
+}
+
+func TestExecuteC_PreservesUserPersistentPreRun(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var userHookRan bool
+
+	cmd := &cobra.Command{
+		Use: "root",
+	}
+	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+		userHookRan = true
+	}
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.AddCommand(child)
+
+	// Bind on child so flags are local to child
+	require.NoError(t, Bind(child, opts))
+
+	cmd.SetArgs([]string{"child", "--port", "5555"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, userHookRan, "user PersistentPreRun should still run")
+}
+
+func TestExecuteC_SilencesErrorsAndUsage(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.True(t, cmd.SilenceErrors)
+	assert.True(t, cmd.SilenceUsage)
+}
+
+func TestExecuteC_Idempotent(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	var runCount int
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			runCount++
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	// First execution
+	cmd.SetArgs([]string{"--port", "1111"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, 1111, opts.Port)
+	assert.Equal(t, 1, runCount)
+
+	// Second execution on same tree — wrappers should not stack
+	cmd.SetArgs([]string{"--port", "2222"})
+	_, err = ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, 2222, opts.Port)
+	assert.Equal(t, 2, runCount)
+}
+
+func TestExecuteC_NoBoundOptions_StillWorks(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var ran bool
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			ran = true
+			return nil
+		},
+	}
+
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.True(t, ran)
+}
+
+func TestExecuteC_AutoSetupUsage(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	// No manual SetupUsage call needed
+	root.SetArgs([]string{"child"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	// Verify annotation was set (proves prepareTree ran)
+	assert.Equal(t, "true", root.Annotations[bindPipelineAnnotation])
+	assert.Equal(t, "true", child.Annotations[bindPipelineAnnotation])
+}
+
+func TestExecuteC_ChildPersistentPreRunE_DoesNotShadowPipeline(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	rootOpts := &execPlainOpts{}
+	childOpts := &execChildOpts{}
+	var childHookRan bool
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	child.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		childHookRan = true
+		return nil
+	}
+	root.AddCommand(child)
+
+	// Bind rootOpts on root (gets defaults), childOpts on child (gets flags)
+	require.NoError(t, Bind(root, rootOpts))
+	require.NoError(t, Bind(child, childOpts))
+
+	root.SetArgs([]string{"child", "--debug"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	// Root opts should be unmarshalled with defaults even though child has its own PersistentPreRunE
+	assert.Equal(t, 3000, rootOpts.Port, "root bound opts should be unmarshalled with defaults")
+	assert.True(t, childOpts.Debug, "child bound opts should be unmarshalled")
+	assert.True(t, childHookRan, "child's original PersistentPreRunE should still run")
+}
+
+func TestExecuteC_ErrorInUnmarshal_Propagates(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	// Bind an opts struct, then corrupt the scope to force an unmarshal error.
+	opts := &execPlainOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	// Manually add a non-struct to bound options to trigger unmarshal error
+	internalscope.Get(cmd).AddBoundOptions("not-a-struct-pointer")
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.Error(t, err, "unmarshal of invalid bound option should propagate error")
+}
+
+func TestExecuteC_ErrorInUserHook_Propagates(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	opts := &execPlainOpts{}
+	hookErr := fmt.Errorf("user hook failed")
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		return hookErr
+	}
+
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, hookErr)
+}

--- a/structerr.go
+++ b/structerr.go
@@ -159,25 +159,15 @@ func HandleError(cmd *cobra.Command, err error, w io.Writer) int {
 	return se.ExitCode
 }
 
-// ExecuteOrExit runs cmd.Execute(). On error it writes structured JSON to stderr
-// and exits with a semantic exit code. On success it exits 0.
-//
-// It automatically sets SilenceErrors and SilenceUsage on the root command
-// so cobra doesn't print its own error messages or usage text — structcli
-// handles all error output as structured JSON.
-//
-// This is a convenience wrapper for the common main() pattern:
+// ExecuteOrExit is a convenience wrapper around ExecuteC for the common main() pattern.
+// On error it writes structured JSON to stderr and exits with a semantic exit code.
+// On success it exits 0.
 //
 //	func main() {
 //	    structcli.ExecuteOrExit(buildMyCLI())
 //	}
 func ExecuteOrExit(cmd *cobra.Command) {
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-
-	// ExecuteC returns the actual subcommand that ran (or failed),
-	// giving HandleError the correct flag set for metadata lookups.
-	c, err := cmd.ExecuteC()
+	c, err := ExecuteC(cmd)
 	if err != nil {
 		os.Exit(HandleError(c, err, os.Stderr))
 	}

--- a/viper.go
+++ b/viper.go
@@ -88,6 +88,13 @@ func GetConfigViper(c *cobra.Command) *viper.Viper {
 // Before decoding, Unmarshal merges command-relevant config from the root-scoped
 // config-source viper (GetConfigViper(c)).
 func Unmarshal(c *cobra.Command, opts Options, hooks ...mapstructure.DecodeHookFunc) error {
+	return unmarshal(c, opts, hooks...)
+}
+
+// unmarshal is the internal implementation that accepts any (struct pointer).
+// The public Unmarshal constrains to Options for API compatibility;
+// the bind pipeline uses this directly for plain struct pointers.
+func unmarshal(c *cobra.Command, opts any, hooks ...mapstructure.DecodeHookFunc) error {
 	// Reject CLI usage of env-only flags before any resolution.
 	if err := rejectEnvOnlyCLIUsage(c); err != nil {
 		return err


### PR DESCRIPTION
## Description

Add `ExecuteC` as the non-exiting execution entry point and wire the bind pipeline that makes `Bind` actually ergonomic. PR 3 of 7 in the ergonomics spec.

Replaces #143 (auto-closed when its base branch was deleted).

### Commits

**1. `refactor: extract internal unmarshal accepting any`**
Split `Unmarshal` into a public wrapper (`Options` constraint) and an internal `unmarshal` function (`any`). The bind pipeline needs to call unmarshal for plain struct pointers that don't implement `Options`.

**2. `feat: add ExecuteC and refactor ExecuteOrExit`**
- `ExecuteC(cmd) (*cobra.Command, error)` — prepares the tree and delegates to `cmd.ExecuteC()`.
- Sets `SilenceErrors`/`SilenceUsage` on root.
- Auto-`SetupUsage` on every command (idempotent).
- Recursively wraps `PersistentPreRunE` on every command in the tree (idempotent via `structcli/bind-pipeline-wrapped` annotation).
- Each wrapper: skips on intercepted execution → runs bind pipeline (root-to-leaf, FIFO per command) → replays original ancestor persistent hooks (root-first).
- `ExecuteOrExit` refactored to thin wrapper: `ExecuteC` → `HandleError` + `os.Exit`.

The recursive wrapping solves Cobra's hook-shadowing problem: without `EnableTraverseRunHooks`, Cobra only runs the first `PersistentPreRunE` it finds walking upward. By wrapping every command, whichever one Cobra picks runs the full pipeline and replays all ancestor hooks.

**3. `test: ExecuteC bind pipeline, hook preservation, idempotency`**
16 tests covering auto-unmarshal, defaults, populated-before-PreRunE, FIFO ordering, ancestor-before-descendant, user hook preservation (both `PersistentPreRunE` and `PersistentPreRun`), SilenceErrors, idempotency, auto-SetupUsage, child hook shadowing, and error propagation.

## How to test

```
go test -v -run TestExecuteC .
go test ./... -count=1
```"