### PR TITLE
fix: warn when `Bind`-registered command has subcommands but `TraverseChildren` is false

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -2,6 +2,7 @@ package structcli
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	internalcmd "github.com/leodido/structcli/internal/cmd"
@@ -81,7 +82,67 @@ func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
 
 	prepareTree(root)
 
+	warnTraverseChildren(root)
+
 	return cmd.ExecuteC()
+}
+
+const traverseChildrenWarnAnnotation = "structcli/traverse-children-warned"
+
+// warnTraverseChildren prints a diagnostic (once per tree) when non-leaf
+// commands have Bind-registered local flags but the root's TraverseChildren
+// is false. Without TraverseChildren, Cobra does not parse ancestor local
+// flags when a subcommand is invoked, so bound local flags on parent
+// commands would be rejected as unknown.
+func warnTraverseChildren(root *cobra.Command) {
+	if root.TraverseChildren {
+		return
+	}
+	if root.Annotations != nil && root.Annotations[traverseChildrenWarnAnnotation] == "true" {
+		return
+	}
+
+	cmds := commandsWithBoundOptionsAndChildren(root)
+	if len(cmds) == 0 {
+		return
+	}
+
+	paths := make([]string, len(cmds))
+	for i, c := range cmds {
+		paths[i] = fmt.Sprintf("%q", c.CommandPath())
+	}
+
+	if len(cmds) == 1 {
+		root.PrintErrln(fmt.Sprintf("Warning: command %s has Bind-registered local flags and subcommands, but TraverseChildren is false.", paths[0]),
+			"Set TraverseChildren = true on the root command, or bind shared options on each leaf command.")
+	} else {
+		root.PrintErrln(fmt.Sprintf("Warning: commands %s have Bind-registered local flags and subcommands, but TraverseChildren is false.", strings.Join(paths, ", ")),
+			"Set TraverseChildren = true on the root command, or bind shared options on each leaf command.")
+	}
+
+	if root.Annotations == nil {
+		root.Annotations = make(map[string]string)
+	}
+	root.Annotations[traverseChildrenWarnAnnotation] = "true"
+}
+
+// commandsWithBoundOptionsAndChildren returns commands that have both
+// bound options and at least one subcommand.
+func commandsWithBoundOptionsAndChildren(c *cobra.Command) []*cobra.Command {
+	var result []*cobra.Command
+	var walk func(*cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		subs := cmd.Commands()
+		if len(subs) > 0 && len(internalscope.Get(cmd).BoundOptions()) > 0 {
+			result = append(result, cmd)
+		}
+		for _, sub := range subs {
+			walk(sub)
+		}
+	}
+	walk(c)
+
+	return result
 }
 
 // prepareTree walks the command tree and installs the bind pipeline wrapper

--- a/execute_test.go
+++ b/execute_test.go
@@ -1,8 +1,10 @@
 package structcli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/leodido/structcli/config"
@@ -656,5 +658,159 @@ func TestExecuteC_SharedContextInjector_VisibleInDescendant(t *testing.T) {
 
 	assert.Equal(t, "test-app", shared.AppName)
 	assert.Equal(t, "test-app", nameInChild, "context injected on root should be visible in child")
+}
+
+func TestExecuteC_WarnsWhenTraverseChildrenFalse(t *testing.T) {
+	// When a non-leaf command has Bind-registered local flags and
+	// TraverseChildren is false, ExecuteC should print a warning to stderr.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	type SharedFlags struct {
+		Verbose bool `flag:"verbose"`
+	}
+
+	root := &cobra.Command{Use: "app"}
+	child := &cobra.Command{
+		Use:  "sub",
+		RunE: func(c *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(child)
+
+	require.NoError(t, Bind(root, &SharedFlags{}))
+
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"sub"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "local flags")
+	assert.Contains(t, stderr.String(), "TraverseChildren is false")
+	assert.Contains(t, stderr.String(), `"app"`)
+}
+
+func TestExecuteC_NoWarningWhenTraverseChildrenTrue(t *testing.T) {
+	// No warning when TraverseChildren is true.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	type SharedFlags struct {
+		Verbose bool `flag:"verbose"`
+	}
+
+	root := &cobra.Command{
+		Use:              "app",
+		TraverseChildren: true,
+	}
+	child := &cobra.Command{
+		Use:  "sub",
+		RunE: func(c *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(child)
+
+	require.NoError(t, Bind(root, &SharedFlags{}))
+
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"sub"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Empty(t, stderr.String(), "no warning expected when TraverseChildren is true")
+}
+
+func TestExecuteC_NoWarningWhenLeafOnly(t *testing.T) {
+	// No warning when bound options are only on leaf commands.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	root := &cobra.Command{Use: "app"}
+	child := &cobra.Command{
+		Use:  "sub",
+		RunE: func(c *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(child)
+
+	require.NoError(t, Bind(child, &execPlainOpts{}))
+
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"sub", "--port", "8080"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	assert.Empty(t, stderr.String(), "no warning when only leaf commands have bound options")
+}
+
+func TestExecuteC_TraverseChildrenWarning_MultipleOffendingCommands(t *testing.T) {
+	// When multiple intermediate commands have bound options and children,
+	// a single warning should list all offending paths.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	type Flags struct {
+		Verbose bool `flag:"verbose"`
+	}
+
+	root := &cobra.Command{Use: "app"}
+	mid := &cobra.Command{Use: "mid"}
+	leaf := &cobra.Command{
+		Use:  "leaf",
+		RunE: func(c *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(mid)
+	mid.AddCommand(leaf)
+
+	// Both root and mid have bound options and children.
+	require.NoError(t, Bind(root, &Flags{}))
+	require.NoError(t, Bind(mid, &Flags{}))
+
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"mid", "leaf"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+
+	out := stderr.String()
+	assert.Contains(t, out, `"app"`, "warning should mention root")
+	assert.Contains(t, out, `"app mid"`, "warning should mention mid")
+	// Single warning line, not two separate ones.
+	assert.Equal(t, 1, strings.Count(out, "Warning:"), "should be a single deduplicated warning")
+}
+
+func TestExecuteC_TraverseChildrenWarning_OncePerTree(t *testing.T) {
+	// The warning should fire only once per tree, even across repeated
+	// ExecuteC calls.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	type Flags struct {
+		Verbose bool `flag:"verbose"`
+	}
+
+	root := &cobra.Command{Use: "app"}
+	child := &cobra.Command{
+		Use:  "sub",
+		RunE: func(c *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(child)
+	require.NoError(t, Bind(root, &Flags{}))
+
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+
+	// First execution — warning fires.
+	root.SetArgs([]string{"sub"})
+	_, err := ExecuteC(root)
+	require.NoError(t, err)
+	assert.Contains(t, stderr.String(), "TraverseChildren is false")
+
+	// Second execution — warning should not repeat.
+	stderr.Reset()
+	root.SetArgs([]string{"sub"})
+	_, err = ExecuteC(root)
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String(), "warning should not repeat on second ExecuteC call")
 }
 


### PR DESCRIPTION
`ExecuteC` now detects a common footgun: a command with both Bind-registered local flags and subcommands, but `TraverseChildren = false` on root. Without `TraverseChildren`, Cobra doesn't parse ancestor local flags when a subcommand is invoked — bound flags on parent commands are rejected as unknown.

Emits a single deduplicated warning listing all offending command paths (instead of one warning per command). Warning fires once per tree (annotation guard prevents repeats on subsequent `ExecuteC` calls).

No warning when:
- `TraverseChildren` is already true
- Bound options are only on leaf commands

## Tests

- `TestExecuteC_WarnsWhenTraverseChildrenFalse` — warning printed
- `TestExecuteC_NoWarningWhenTraverseChildrenTrue` — silent
- `TestExecuteC_NoWarningWhenLeafOnly` — silent
- `TestExecuteC_TraverseChildrenWarning_MultipleOffendingCommands` — single warning lists both paths
- `TestExecuteC_TraverseChildrenWarning_OncePerTree` — no repeat on second `ExecuteC`

Ergonomics follow-up item #4.

**Stack:** #152 → #151 → #153. Merge after #152.