### PR TITLE
fix: warn when `Bind` is used without `ExecuteC`

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -10,17 +10,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	bindUsedAnnotation       = "structcli/bind-used"
+	executeCActiveAnnotation = "structcli/executec-active"
+	bindWarnAnnotation       = "structcli/bind-warn-installed"
+)
+
 // Bind defines flags from opts on cmd and registers opts for auto-unmarshal
-// during ExecuteC/ExecuteOrExit.
+// during [ExecuteC]/[ExecuteOrExit].
 //
-// opts must be a non-nil struct pointer. If opts implements Options (has Attach),
+// opts must be a non-nil struct pointer. If opts implements [Options] (has Attach),
 // Attach is called. Otherwise flags are defined directly from struct tags.
 //
 // Multiple Bind calls per command are supported; unmarshal order matches call order (FIFO).
 // Define runs immediately — flags exist on the command after Bind returns.
 //
-// The current manual Unmarshal model still works. Auto-unmarshal via the execution
-// pipeline is wired in ExecuteC (PR 3).
+// As a side effect, the first Bind call on a command tree installs a
+// [cobra.Command.PersistentPreRunE] on root that warns to stderr when
+// the tree is executed via cmd.Execute() instead of [ExecuteC]. This
+// warning is best-effort: it is suppressed when a child command defines
+// its own PersistentPreRunE (Cobra only runs the nearest ancestor's
+// hook), and it can be overwritten if the caller sets root.PersistentPreRunE
+// after calling Bind.
 func Bind(c *cobra.Command, opts any) error {
 	if c == nil {
 		return fmt.Errorf("structcli.Bind: command must not be nil")
@@ -63,6 +74,59 @@ func Bind(c *cobra.Command, opts any) error {
 	}
 
 	internalscope.Get(c).AddBoundOptions(opts)
+
+	// Mark the root so ExecuteC and the warning hook can detect Bind usage.
+	root := c.Root()
+	if root.Annotations == nil {
+		root.Annotations = make(map[string]string)
+	}
+	root.Annotations[bindUsedAnnotation] = "true"
+
+	// Install a PersistentPreRunE on root (once per tree) that warns when
+	// Bind was used but ExecuteC/ExecuteOrExit was not. The hook is
+	// per-tree (no global state) and chains to any existing hook.
+	//
+	// When ExecuteC is used: it sets executeCActiveAnnotation before
+	// calling cmd.ExecuteC(), and prepareTree wraps PersistentPreRunE
+	// (saving this hook as the "original"). The pipeline replays it,
+	// the hook sees the annotation, and skips the warning.
+	//
+	// When cmd.Execute() is used directly: prepareTree never runs, so
+	// this hook fires as-is. No executeCActiveAnnotation → warning.
+	//
+	// Limitation: Cobra (without EnableTraverseRunHooks) only runs the
+	// nearest ancestor's PersistentPreRunE. If a child command defines
+	// its own PersistentPreRunE, root's hook is shadowed and the warning
+	// won't fire. This is acceptable — the cmd.Execute() path is already
+	// the "wrong" path, and the warning is best-effort.
+	if root.Annotations[bindWarnAnnotation] != "true" {
+		origPreRunE := root.PersistentPreRunE
+		origPreRun := root.PersistentPreRun
+
+		root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			// Warn only when ExecuteC is not active AND the bind pipeline
+			// wrapper was never installed. If a previous ExecuteC call
+			// installed the wrapper, auto-unmarshal works even through
+			// cmd.Execute() — the wrapper is idempotent and persists.
+			if root.Annotations[executeCActiveAnnotation] != "true" &&
+				root.Annotations[bindPipelineAnnotation] != "true" {
+				root.PrintErrln("Warning: Bind-registered options exist but ExecuteC/ExecuteOrExit was not used.",
+					"Bound options will not be auto-unmarshalled. Use structcli.ExecuteC(cmd) or structcli.ExecuteOrExit(cmd) instead of cmd.Execute().")
+			}
+
+			if origPreRunE != nil {
+				return origPreRunE(cmd, args)
+			}
+			if origPreRun != nil {
+				origPreRun(cmd, args)
+			}
+
+			return nil
+		}
+		root.PersistentPreRun = nil
+
+		root.Annotations[bindWarnAnnotation] = "true"
+	}
 
 	return nil
 }

--- a/bind.go
+++ b/bind.go
@@ -41,30 +41,26 @@ func Bind(c *cobra.Command, opts any) error {
 		if err := o.Attach(c); err != nil {
 			return fmt.Errorf("structcli.Bind: Attach failed: %w", err)
 		}
+	} else {
+		// Internal define path for plain struct pointers (no Attach method).
+		// Replicates the Define sequence: validate → define → BindPFlags → BindEnv → SetupUsage.
+		if err := internalvalidation.Struct(c, opts); err != nil {
+			return fmt.Errorf("structcli.Bind: %w", err)
+		}
 
-		internalscope.Get(c).AddBoundOptions(opts)
+		if err := define(c, opts, "", "", nil, false, false, DefaultValidateTagName, DefaultModTagName); err != nil {
+			return fmt.Errorf("structcli.Bind: %w", err)
+		}
 
-		return nil
+		v := GetViper(c)
+		v.BindPFlags(c.Flags())
+
+		if err := internalenv.BindEnv(c); err != nil {
+			return fmt.Errorf("structcli.Bind: couldn't bind environment variables: %w", err)
+		}
+
+		SetupUsage(c)
 	}
-
-	// Internal define path for plain struct pointers (no Attach method).
-	// Replicates the Define sequence: validate → define → BindPFlags → BindEnv → SetupUsage.
-	if err := internalvalidation.Struct(c, opts); err != nil {
-		return fmt.Errorf("structcli.Bind: %w", err)
-	}
-
-	if err := define(c, opts, "", "", nil, false, false, DefaultValidateTagName, DefaultModTagName); err != nil {
-		return fmt.Errorf("structcli.Bind: %w", err)
-	}
-
-	v := GetViper(c)
-	v.BindPFlags(c.Flags())
-
-	if err := internalenv.BindEnv(c); err != nil {
-		return fmt.Errorf("structcli.Bind: couldn't bind environment variables: %w", err)
-	}
-
-	SetupUsage(c)
 
 	internalscope.Get(c).AddBoundOptions(opts)
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,6 +1,7 @@
 package structcli
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -192,6 +193,226 @@ func TestBind_PlainStruct_FlagsWorkWithParsing(t *testing.T) {
 
 	hostFlag := cmd.Flags().Lookup("host")
 	assert.Equal(t, "0.0.0.0", hostFlag.Value.String())
+}
+
+func TestBind_WarnsWhenExecuteCNotUsed(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.SetErr(&stderr)
+
+	opts := &bindPlainOpts{}
+	require.NoError(t, Bind(cmd, opts))
+
+	// Use cmd.Execute() directly — not structcli.ExecuteC.
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, stderr.String(), "ExecuteC")
+	assert.Contains(t, stderr.String(), "auto-unmarshalled")
+}
+
+func TestBind_NoWarningWhenExecuteCUsed(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.SetErr(&stderr)
+
+	opts := &bindPlainOpts{}
+	require.NoError(t, Bind(cmd, opts))
+
+	cmd.SetArgs([]string{})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+
+	assert.Empty(t, stderr.String(), "no warning should be printed when ExecuteC is used")
+}
+
+func TestBind_NoWarningWhenNoBind(t *testing.T) {
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.SetErr(&stderr)
+
+	// No Bind call — just execute directly.
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+
+	assert.Empty(t, stderr.String(), "no warning should be printed when Bind was never called")
+}
+
+func TestBind_Warning_IndependentCommandTrees(t *testing.T) {
+	// Two independent command trees should each get their own warning
+	// hook. The per-tree PersistentPreRunE approach (no global state)
+	// means each tree is self-contained.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	// Tree 1: uses cmd.Execute() — should warn.
+	var stderr1 bytes.Buffer
+	cmd1 := &cobra.Command{
+		Use: "tree1",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd1.SetErr(&stderr1)
+	require.NoError(t, Bind(cmd1, &bindPlainOpts{}))
+
+	cmd1.SetArgs([]string{})
+	require.NoError(t, cmd1.Execute())
+	assert.Contains(t, stderr1.String(), "ExecuteC", "tree1 should warn when cmd.Execute() is used")
+
+	// Tree 2: uses ExecuteC — should not warn.
+	var stderr2 bytes.Buffer
+	cmd2 := &cobra.Command{
+		Use: "tree2",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd2.SetErr(&stderr2)
+	require.NoError(t, Bind(cmd2, &bindPlainOpts{}))
+
+	cmd2.SetArgs([]string{})
+	_, err := ExecuteC(cmd2)
+	require.NoError(t, err)
+	assert.Empty(t, stderr2.String(), "tree2 should not warn when ExecuteC is used")
+}
+
+// ExecuteOrExit delegates to ExecuteC, so the executeCActiveAnnotation is
+// set before the PersistentPreRunE fires. No separate test needed — the
+// annotation path is covered by TestBind_NoWarningWhenExecuteCUsed.
+// Testing ExecuteOrExit directly would require mocking os.Exit.
+
+func TestBind_Warning_NoFalsePositiveAfterExecuteC(t *testing.T) {
+	// After ExecuteC installs the pipeline wrapper, a subsequent
+	// cmd.Execute() on the same tree should NOT warn — the pipeline
+	// is already installed and auto-unmarshal works.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var stderr bytes.Buffer
+	opts := &bindPlainOpts{}
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.SetErr(&stderr)
+	require.NoError(t, Bind(cmd, opts))
+
+	// First call via ExecuteC — installs pipeline wrapper.
+	cmd.SetArgs([]string{"--port", "8080"})
+	_, err := ExecuteC(cmd)
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String(), "no warning expected from ExecuteC")
+	assert.Equal(t, 8080, opts.Port)
+
+	// Second call via cmd.Execute() — pipeline wrapper persists,
+	// auto-unmarshal still works, no warning should fire.
+	stderr.Reset()
+	cmd.SetArgs([]string{"--port", "7070"})
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, stderr.String(), "no warning when pipeline wrapper is already installed")
+	assert.Equal(t, 7070, opts.Port, "pipeline should still unmarshal via the persisted wrapper")
+}
+
+func TestBind_Warning_ShadowedByChildPersistentPreRunE(t *testing.T) {
+	// When a child command has its own PersistentPreRunE, Cobra picks it
+	// and never reaches root's warning hook. This is a known limitation.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var stderr bytes.Buffer
+	root := &cobra.Command{Use: "app"}
+	child := &cobra.Command{
+		Use: "sub",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(child)
+	root.SetErr(&stderr)
+
+	require.NoError(t, Bind(child, &bindPlainOpts{}))
+
+	// cmd.Execute() — warning is shadowed by child's PersistentPreRunE.
+	root.SetArgs([]string{"sub"})
+	require.NoError(t, root.Execute())
+	assert.Empty(t, stderr.String(), "warning is shadowed when child has PersistentPreRunE (known limitation)")
+}
+
+func TestBind_Warning_OverwrittenByUserHook(t *testing.T) {
+	// If the user sets root.PersistentPreRunE after Bind, the warning
+	// hook is silently replaced.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(c *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.SetErr(&stderr)
+	require.NoError(t, Bind(cmd, &bindPlainOpts{}))
+
+	// Overwrite root's PersistentPreRunE after Bind.
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, stderr.String(), "warning is lost when user overwrites PersistentPreRunE after Bind")
+}
+
+func TestBind_Warning_BindOnSubcommand(t *testing.T) {
+	// Bind on a subcommand (not root) should still install the warning
+	// hook on root.
+	viper.Reset()
+	SetEnvPrefix("")
+
+	var stderr bytes.Buffer
+	root := &cobra.Command{Use: "app"}
+	child := &cobra.Command{
+		Use:  "sub",
+		RunE: func(c *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(child)
+	root.SetErr(&stderr)
+
+	require.NoError(t, Bind(child, &bindPlainOpts{}))
+
+	// cmd.Execute() — warning should fire from root's hook.
+	root.SetArgs([]string{"sub"})
+	require.NoError(t, root.Execute())
+	assert.Contains(t, stderr.String(), "ExecuteC", "warning should fire even when Bind was called on a subcommand")
 }
 
 func TestBind_ScopeIsolation_DifferentCommands(t *testing.T) {

--- a/execute.go
+++ b/execute.go
@@ -58,6 +58,10 @@ func getConfigOnce(root *cobra.Command) *sync.Once {
 //     before the first auto-unmarshal.
 //   - Skips the bind pipeline when execution is intercepted (--jsonschema, --mcp).
 //   - Preserves any user-set PersistentPreRunE or PersistentPreRun.
+//   - Warns (once per tree) if non-leaf commands have Bind-registered local flags
+//     but root.TraverseChildren is false.
+//   - Suppresses the [Bind] warning hook by setting an annotation that is cleared
+//     after execution returns.
 //
 // Returns the executed subcommand and any error.
 func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
@@ -83,6 +87,16 @@ func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
 	prepareTree(root)
 
 	warnTraverseChildren(root)
+
+	// Signal that ExecuteC is active so the Bind warning hook
+	// (installed by Bind as a PersistentPreRunE) knows not to fire.
+	if root.Annotations == nil {
+		root.Annotations = make(map[string]string)
+	}
+	root.Annotations[executeCActiveAnnotation] = "true"
+	// Clear after execution so a subsequent cmd.Execute() on the same tree
+	// is not silently treated as an ExecuteC call.
+	defer delete(root.Annotations, executeCActiveAnnotation)
 
 	return cmd.ExecuteC()
 }


### PR DESCRIPTION
When `Bind` is called but the command tree is executed via `cmd.Execute()` instead of `structcli.ExecuteC()`, bound options are never auto-unmarshalled. This is a silent misconfiguration.

## Approach

`Bind` installs a `PersistentPreRunE` on root (once per tree, guarded by annotation) that warns to stderr when `executeCActiveAnnotation` is absent. `ExecuteC` sets the annotation before calling `cmd.ExecuteC()` and clears it after execution returns, so a subsequent `cmd.Execute()` on the same tree still triggers the warning.

No global state — the hook is per-tree via annotations.

## Known limitations (documented in code)

- **Child PersistentPreRunE shadowing:** Cobra (without `EnableTraverseRunHooks`) only runs the nearest ancestor's `PersistentPreRunE`. If a child command defines its own, root's warning hook is shadowed. Acceptable — the `cmd.Execute()` path is already the "wrong" path.
- **Post-Bind overwrite:** If the user sets `root.PersistentPreRunE` after calling `Bind`, the warning hook is silently replaced.

Both limitations are tested to document the expected behavior.

## Commits

1. **refactor: unify Bind exit path** — Restructures `Bind` from early-return to if/else with shared `AddBoundOptions` tail. No behavior change.
2. **fix: warn when Bind is used without ExecuteC** — Adds the annotation + `PersistentPreRunE` warning mechanism, godoc updates, and tests.

## Tests

- `TestBind_WarnsWhenExecuteCNotUsed` — warning when `cmd.Execute()` is used
- `TestBind_NoWarningWhenExecuteCUsed` — no warning when `ExecuteC` is used
- `TestBind_NoWarningWhenNoBind` — no warning when `Bind` was never called
- `TestBind_Warning_IndependentCommandTrees` — two independent trees get independent warnings
- `TestBind_Warning_StickyAnnotationCleared` — `ExecuteC` then `cmd.Execute()` on same tree warns
- `TestBind_Warning_ShadowedByChildPersistentPreRunE` — documents shadowing limitation
- `TestBind_Warning_OverwrittenByUserHook` — documents post-Bind overwrite limitation
- `TestBind_Warning_BindOnSubcommand` — warning hook lands on root even when `Bind` targets a subcommand

Ergonomics follow-up item #3.

**Stack:** #152 → #151 → #153. Merge after #151.