### PR TITLE
refactor: unify annotation prefix

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	bindUsedAnnotation       = "structcli/bind-used"
-	executeCActiveAnnotation = "structcli/executec-active"
-	bindWarnAnnotation       = "structcli/bind-warn-installed"
+	bindUsedAnnotation = "leodido/structcli/bind-used"
+	// executeCActiveAnnotation uses "executec" (not "execute-c") to match
+	// the Go function name ExecuteC as a single token.
+	executeCActiveAnnotation = "leodido/structcli/executec-active"
+	bindWarnAnnotation = "leodido/structcli/bind-warn-installed"
 )
 
 // Bind defines flags from opts on cmd and registers opts for auto-unmarshal

--- a/config.go
+++ b/config.go
@@ -25,8 +25,11 @@ var (
 )
 
 const (
-	configValidateKeysAnnotation = "___leodido_structcli_config_validate_keys"
-	configFlagAnnotation         = "___leodido_structcli_configflagname"
+	configValidateKeysAnnotation = "leodido/structcli/config-validate-keys"
+
+	// ConfigFlagAnnotation is the command annotation key that stores the
+	// config flag name set by WithConfig. Exported for use by generate/.
+	ConfigFlagAnnotation = "leodido/structcli/config-flag"
 )
 
 func setConfigRoot(rootC *cobra.Command) {
@@ -117,7 +120,7 @@ func SetupConfig(rootC *cobra.Command, cfgOpts config.Options) error {
 	if rootC.Annotations == nil {
 		rootC.Annotations = make(map[string]string)
 	}
-	rootC.Annotations[configFlagAnnotation] = cfgOpts.FlagName
+	rootC.Annotations[ConfigFlagAnnotation] = cfgOpts.FlagName
 	if cfgOpts.ValidateKeys {
 		rootC.Annotations[configValidateKeysAnnotation] = "true"
 	} else {

--- a/execute.go
+++ b/execute.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const bindPipelineAnnotation = "structcli/bind-pipeline-wrapped"
+const bindPipelineAnnotation = "leodido/structcli/bind-pipeline-wrapped"
 
 // hookSet holds the original PersistentPreRunE/PersistentPreRun hooks
 // saved before wrapping, keyed by command pointer.
@@ -101,7 +101,7 @@ func ExecuteC(cmd *cobra.Command) (*cobra.Command, error) {
 	return cmd.ExecuteC()
 }
 
-const traverseChildrenWarnAnnotation = "structcli/traverse-children-warned"
+const traverseChildrenWarnAnnotation = "leodido/structcli/traverse-children-warned"
 
 // warnTraverseChildren prints a diagnostic (once per tree) when non-leaf
 // commands have Bind-registered local flags but the root's TraverseChildren

--- a/flagkit/follow.go
+++ b/flagkit/follow.go
@@ -8,7 +8,7 @@ import (
 // FlagKitAnnotation is the pflag annotation key set on flags defined by
 // flagkit types. The generate package uses this to detect flagkit usage
 // and emit development guidance in generated docs.
-const FlagKitAnnotation = "___leodido_structcli_flagkit"
+const FlagKitAnnotation = "leodido/structcli/flag-kit"
 
 // flagKitFlags is the registry of flag names owned by flagkit types.
 // Each type registers its flag name via registerFlag in its own file's init().

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -8,8 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// flagEnumAnnotation mirrors the structcli annotation key for enum values.
-const flagEnumAnnotation = "___leodido_structcli_flagenum"
+// FlagEnumAnnotation mirrors flagEnumAnnotation (unexported, in viper.go)
+// from the root structcli package. Duplicated here to avoid an import
+// cycle (flagkit → structcli → flagkit).
+const FlagEnumAnnotation = "leodido/structcli/flag-enum"
 
 func init() {
 	registerFlag("output")
@@ -109,7 +111,7 @@ func (o *Output) RestrictFormats(c *cobra.Command, allowed ...OutputFormat) {
 	f.Usage = fmt.Sprintf("Output format {%s}", strings.Join(names, ","))
 
 	// Update the enum annotation used by JSON Schema generation.
-	_ = c.Flags().SetAnnotation("output", flagEnumAnnotation, names)
+	_ = c.Flags().SetAnnotation("output", FlagEnumAnnotation, names)
 }
 
 // ValidFormat returns nil if the current output format is allowed, or an

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -220,7 +220,7 @@ func TestOutput_RestrictFormats_Annotation(t *testing.T) {
 
 	f := cmd.Flags().Lookup("output")
 	require.NotNil(t, f)
-	ann, ok := f.Annotations["___leodido_structcli_flagenum"]
+	ann, ok := f.Annotations[flagkit.FlagEnumAnnotation]
 	assert.True(t, ok, "enum annotation should be set")
 	assert.Equal(t, []string{"json", "text"}, ann)
 }

--- a/generate/agents.go
+++ b/generate/agents.go
@@ -14,7 +14,7 @@ import (
 
 // flagKitAnnotation mirrors [flagkit.FlagKitAnnotation] to avoid a dependency
 // from the generate package on the flagkit package.
-const flagKitAnnotation = "___leodido_structcli_flagkit"
+const flagKitAnnotation = "leodido/structcli/flag-kit"
 
 // AgentsOptions configures the AGENTS.md generator.
 type AgentsOptions struct {
@@ -218,7 +218,7 @@ func hasFlagKitFlags(root *cobra.Command) bool {
 func findConfigFlagName(rootCmd *cobra.Command) string {
 	// Check the annotation set by structcli.SetupConfig
 	if rootCmd.Annotations != nil {
-		if name, ok := rootCmd.Annotations["___leodido_structcli_configflagname"]; ok {
+		if name, ok := rootCmd.Annotations[structcli.ConfigFlagAnnotation]; ok {
 			return name
 		}
 	}

--- a/generate/agents_test.go
+++ b/generate/agents_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/leodido/structcli/flagkit"
 	"github.com/leodido/structcli/generate"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -215,7 +216,7 @@ func TestAgents_EnumValuesInDescription(t *testing.T) {
 	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}
 	root.Flags().String("output", "text", "Output format")
 	// Simulate enum annotation (as structcli sets it for registered enums)
-	require.NoError(t, root.Flags().SetAnnotation("output", "___leodido_structcli_flagenum", []string{"json", "text", "yaml"}))
+	require.NoError(t, root.Flags().SetAnnotation("output", flagkit.FlagEnumAnnotation, []string{"json", "text", "yaml"}))
 
 	out, err := generate.Agents(root, generate.AgentsOptions{})
 	require.NoError(t, err)
@@ -229,7 +230,7 @@ func TestAgents_FlagKitDevNotes(t *testing.T) {
 	root := &cobra.Command{Use: "app", Short: "A CLI", RunE: noop}
 	root.Flags().Bool("follow", false, "Stream output continuously")
 	// Simulate flagkit annotation
-	require.NoError(t, root.Flags().SetAnnotation("follow", "___leodido_structcli_flagkit", []string{"true"}))
+	require.NoError(t, root.Flags().SetAnnotation("follow", flagkit.FlagKitAnnotation, []string{"true"}))
 
 	out, err := generate.Agents(root, generate.AgentsOptions{})
 	require.NoError(t, err)
@@ -253,7 +254,7 @@ func TestAgents_FlagKitDevNotesOnSubcommand(t *testing.T) {
 	root := &cobra.Command{Use: "app", Short: "A CLI"}
 	sub := &cobra.Command{Use: "logs", Short: "Show logs", RunE: noop}
 	sub.Flags().Bool("follow", false, "Stream output continuously")
-	require.NoError(t, sub.Flags().SetAnnotation("follow", "___leodido_structcli_flagkit", []string{"true"}))
+	require.NoError(t, sub.Flags().SetAnnotation("follow", flagkit.FlagKitAnnotation, []string{"true"}))
 	root.AddCommand(sub)
 
 	out, err := generate.Agents(root, generate.AgentsOptions{})

--- a/helptopics.go
+++ b/helptopics.go
@@ -151,7 +151,7 @@ func buildConfigKeysTopic(rootC *cobra.Command) string {
 	b.WriteString("Configuration Keys\n")
 
 	// Show config file locations if SetupConfig was called.
-	if flagName, ok := rootC.Annotations[configFlagAnnotation]; ok {
+	if flagName, ok := rootC.Annotations[ConfigFlagAnnotation]; ok {
 		if f := rootC.PersistentFlags().Lookup(flagName); f != nil {
 			b.WriteString(fmt.Sprintf("\n  Config flag: --%s\n", flagName))
 			if f.Usage != "" {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -16,8 +16,8 @@ type ExecutionInterceptor struct {
 }
 
 const (
-	wrappedRunAnnotation           = "structcli/debug-run-wrapped"
-	interceptedExecutionAnnotation = "structcli/execution-intercepted"
+	wrappedRunAnnotation           = "leodido/structcli/debug-run-wrapped"
+	interceptedExecutionAnnotation = "leodido/structcli/execution-intercepted"
 )
 
 var (

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -178,7 +178,7 @@ func TestRecursivelyWrapExecution_PreservesLifecycleWhenNotIntercepted(t *testin
 	root.AddCommand(srv)
 
 	RecursivelyWrapExecution(root, ExecutionInterceptor{
-		Annotation: "structcli/test-wrapped",
+		Annotation: "leodido/structcli/test-wrapped",
 		ShouldIntercept: func(_ *cobra.Command) bool {
 			return false
 		},
@@ -200,8 +200,8 @@ func TestRecursivelyWrapExecution_PreservesLifecycleWhenNotIntercepted(t *testin
 		"post",
 		"persistent-post",
 	}, calls)
-	assert.Equal(t, "true", root.Annotations["structcli/test-wrapped"])
-	assert.Equal(t, "true", srv.Annotations["structcli/test-wrapped"])
+	assert.Equal(t, "true", root.Annotations["leodido/structcli/test-wrapped"])
+	assert.Equal(t, "true", srv.Annotations["leodido/structcli/test-wrapped"])
 }
 
 func TestRecursivelyWrapExecution_InterceptsWithoutRunningCommand(t *testing.T) {
@@ -230,7 +230,7 @@ func TestRecursivelyWrapExecution_InterceptsWithoutRunningCommand(t *testing.T) 
 		}
 
 		RecursivelyWrapExecution(root, ExecutionInterceptor{
-			Annotation: "structcli/test-wrapped",
+			Annotation: "leodido/structcli/test-wrapped",
 			Intercept: func(_ *cobra.Command, _ []string) (bool, error) {
 				calls = append(calls, "intercept")
 				return true, nil
@@ -251,7 +251,7 @@ func TestRecursivelyWrapExecution_InterceptsWithoutRunningCommand(t *testing.T) 
 		}
 
 		RecursivelyWrapExecution(root, ExecutionInterceptor{
-			Annotation: "structcli/test-wrapped",
+			Annotation: "leodido/structcli/test-wrapped",
 			Intercept: func(_ *cobra.Command, _ []string) (bool, error) {
 				return false, errors.New("boom")
 			},
@@ -277,7 +277,7 @@ func TestEnsureRunnable_InterceptsCommandWithoutRunE(t *testing.T) {
 
 	EnsureRunnable(root)
 	RecursivelyWrapExecution(root, ExecutionInterceptor{
-		Annotation:      "structcli/test-wrapped",
+		Annotation:      "leodido/structcli/test-wrapped",
 		ShouldIntercept: func(_ *cobra.Command) bool { return true },
 		Intercept: func(_ *cobra.Command, _ []string) (bool, error) {
 			intercepted = true
@@ -301,7 +301,7 @@ func TestEnsureRunnable_ShowsHelpWhenNotIntercepted(t *testing.T) {
 
 	EnsureRunnable(root)
 	RecursivelyWrapExecution(root, ExecutionInterceptor{
-		Annotation:      "structcli/test-wrapped",
+		Annotation:      "leodido/structcli/test-wrapped",
 		ShouldIntercept: func(_ *cobra.Command) bool { return false },
 		Intercept: func(_ *cobra.Command, _ []string) (bool, error) {
 			return false, nil

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	FlagAnnotation = "___leodido_structcli_debugflagname"
+	FlagAnnotation = "leodido/structcli/debug-flag"
 )
 
 // normalizeFormat converts a raw debug flag/env value to "text", "json", or "".

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -19,8 +19,8 @@ var (
 )
 
 const (
-	FlagAnnotation        = "___leodido_structcli_flagenvs"
-	FlagEnvOnlyAnnotation = "___leodido_structcli_flagenvonly"
+	FlagAnnotation        = "leodido/structcli/flag-envs"
+	FlagEnvOnlyAnnotation = "leodido/structcli/flag-env-only"
 )
 
 func NormEnv(str string) string {

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	FlagDecodeHookAnnotation = "___leodido_structcli_flagdecodehooks"
+	FlagDecodeHookAnnotation = "leodido/structcli/flag-decode-hooks"
 )
 
 type DecodeHookFunc func(input any) (any, error)

--- a/internal/usage/groups.go
+++ b/internal/usage/groups.go
@@ -11,10 +11,10 @@ var (
 )
 
 const (
-	FlagGroupAnnotation       = "___leodido_structcli_flaggroups"
-	HelpTopicAnnotation       = "___leodido_structcli_helptopic"
-	HelpTopicReferenceSection = "___leodido_structcli_helptopic_refsection"
-	SyntheticRunAnnotation    = "___leodido_structcli_synthetic_run"
+	FlagGroupAnnotation       = "leodido/structcli/flag-groups"
+	HelpTopicAnnotation       = "leodido/structcli/help-topic"
+	HelpTopicReferenceSection = "leodido/structcli/help-topic-ref-section"
+	SyntheticRunAnnotation    = "leodido/structcli/synthetic-run"
 )
 
 // Groups returns a map of flag groups for the given command.

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -111,7 +111,7 @@ func jsonSchemaOne(c *cobra.Command, cfg *jsonschema.Config) (*CommandSchema, er
 	if rootAnnotations := c.Root().Annotations; rootAnnotations != nil {
 		jsonSchemaFlagName = rootAnnotations[jsonSchemaFlagAnnotation]
 
-		if cfgFlag, ok := rootAnnotations[configFlagAnnotation]; ok && cfgFlag != "" {
+		if cfgFlag, ok := rootAnnotations[ConfigFlagAnnotation]; ok && cfgFlag != "" {
 			schema.ConfigFlag = cfgFlag
 		}
 	}
@@ -133,7 +133,7 @@ func jsonSchemaOne(c *cobra.Command, cfg *jsonschema.Config) (*CommandSchema, er
 		// Skip structcli infrastructure flags (debug, config)
 		if rootAnnotations := c.Root().Annotations; rootAnnotations != nil {
 			if f.Name == rootAnnotations[internaldebug.FlagAnnotation] ||
-				f.Name == rootAnnotations[configFlagAnnotation] ||
+				f.Name == rootAnnotations[ConfigFlagAnnotation] ||
 				f.Name == rootAnnotations[mcpFlagAnnotation] {
 				return
 			}
@@ -514,7 +514,7 @@ func SetupJSONSchema(rootC *cobra.Command, opts jsonschema.Options) error {
 	return nil
 }
 
-const jsonSchemaFlagAnnotation = "___leodido_structcli_jsonschemaflagname"
+const jsonSchemaFlagAnnotation = "leodido/structcli/jsonschema-flag"
 
 // renderJSONSchemaIfRequested renders schema output when the setup flag is set.
 // It returns handled=true when the schema was rendered and the caller should stop.
@@ -616,7 +616,7 @@ func schemaOptsFromConfig(cfg *jsonschema.Config) []jsonschema.Opt {
 // wrapForJSONSchema recursively wraps commands to intercept --jsonschema.
 func wrapForJSONSchema(c *cobra.Command, flagName string, cfg *jsonschema.Config) {
 	internalcmd.RecursivelyWrapExecution(c, internalcmd.ExecutionInterceptor{
-		Annotation: "structcli/jsonschema-wrapped",
+		Annotation: "leodido/structcli/jsonschema-wrapped",
 		ShouldIntercept: func(cmd *cobra.Command) bool {
 			return isPersistentFlagChanged(cmd, flagName)
 		},

--- a/mcp.go
+++ b/mcp.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	mcpFlagAnnotation = "___leodido_structcli_mcpflagname"
+	mcpFlagAnnotation = "leodido/structcli/mcp-flag"
 
 	jsonrpcVersion = "2.0"
 
@@ -115,7 +115,7 @@ func resolveMCPConfig(rootC *cobra.Command, opts structclimcp.Options) *mcpConfi
 
 func wrapForMCP(rootC *cobra.Command, cfg *mcpConfig) {
 	internalcmd.RecursivelyWrapExecution(rootC, internalcmd.ExecutionInterceptor{
-		Annotation: "structcli/mcp-wrapped",
+		Annotation: "leodido/structcli/mcp-wrapped",
 		ShouldIntercept: func(cmd *cobra.Command) bool {
 			return isPersistentFlagChanged(cmd, cfg.flagName)
 		},

--- a/setup.go
+++ b/setup.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const configAutoLoadAnnotation = "structcli/config-auto-load"
+const configAutoLoadAnnotation = "leodido/structcli/config-auto-load"
 
 // setupConfig holds the resolved configuration from SetupOption functions.
 type setupConfig struct {

--- a/structerr_test.go
+++ b/structerr_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	structclierrors "github.com/leodido/structcli/errors"
 	"github.com/leodido/structcli/exitcode"
+	internalenv "github.com/leodido/structcli/internal/env"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,7 +52,7 @@ func TestHandleError_MissingRequiredFlagUsesUnsetEnvAsHintOnly(t *testing.T) {
 	// Create a flag with env annotation
 	cmd.Flags().IntP("port", "p", 0, "Server port")
 	_ = cmd.MarkFlagRequired("port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYCLI_PORT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYCLI_PORT"})
 
 	err := fmt.Errorf(`required flag(s) "port" not set`)
 	code := HandleError(cmd, err, &buf)
@@ -108,7 +109,7 @@ func TestHandleError_InvalidFlagValueFromEnvVar(t *testing.T) {
 
 	// Create a flag with env annotation
 	cmd.Flags().IntP("port", "p", 0, "Server port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYCLI_PORT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYCLI_PORT"})
 
 	// Simulate: flag NOT changed on CLI, but env var IS set
 	t.Setenv("MYCLI_PORT", "abc")
@@ -285,7 +286,7 @@ func TestHandleError_MissingRequiredFlagUsesFirstUnsetEnvBindingInHint(t *testin
 	// Flag with multiple env annotations, all unset
 	cmd.Flags().IntP("port", "p", 0, "Server port")
 	_ = cmd.MarkFlagRequired("port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYCLI_PORT", "MYCLI_PORT_ALT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYCLI_PORT", "MYCLI_PORT_ALT"})
 
 	// Make sure env var is unset
 	os.Unsetenv("MYCLI_PORT")
@@ -315,7 +316,7 @@ func TestHandleError_MissingRequiredFlagWithEnvVarSet(t *testing.T) {
 
 	cmd.Flags().IntP("port", "p", 0, "Server port")
 	_ = cmd.MarkFlagRequired("port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYCLI_PORT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYCLI_PORT"})
 
 	// Env var IS set with a valid value — cobra still complains because it doesn't check env vars
 	t.Setenv("MYCLI_PORT", "3000")
@@ -342,7 +343,7 @@ func TestHandleError_MissingRequiredFlagWithEmptyEnvVarSet_HidesEnvHint(t *testi
 
 	cmd.Flags().IntP("port", "p", 0, "Server port")
 	_ = cmd.MarkFlagRequired("port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYCLI_PORT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYCLI_PORT"})
 
 	t.Setenv("MYCLI_PORT", "")
 
@@ -363,7 +364,7 @@ func TestHandleError_UnmarshalDecodeError_FromEnvVar(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := &cobra.Command{Use: "myapp"}
 	cmd.Flags().IntP("port", "p", 0, "Server port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYAPP_PORT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYAPP_PORT"})
 
 	t.Setenv("MYAPP_PORT", "xyz")
 
@@ -385,7 +386,7 @@ func TestHandleError_UnmarshalDecodeError_FromEmptyEnvVar(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := &cobra.Command{Use: "myapp"}
 	cmd.Flags().IntP("port", "p", 0, "Server port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYAPP_PORT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYAPP_PORT"})
 
 	t.Setenv("MYAPP_PORT", "")
 
@@ -480,8 +481,8 @@ func TestHandleError_UnmarshalDecodeError_FieldPathAnnotation(t *testing.T) {
 	cmd := &cobra.Command{Use: "myapp"}
 	cmd.Flags().String("level", "info", "log level")
 	// Simulate structcli's field path annotation: flag "level" has path "loglevel"
-	_ = cmd.Flags().SetAnnotation("level", "___leodido_structcli_flagpath", []string{"loglevel"})
-	_ = cmd.Flags().SetAnnotation("level", "___leodido_structcli_flagenvs", []string{"MYAPP_LEVEL"})
+	_ = cmd.Flags().SetAnnotation("level", flagPathAnnotation, []string{"loglevel"})
+	_ = cmd.Flags().SetAnnotation("level", internalenv.FlagAnnotation, []string{"MYAPP_LEVEL"})
 
 	t.Setenv("MYAPP_LEVEL", "bogus")
 
@@ -560,7 +561,7 @@ func TestHandleError_InvalidFlagValueFromEnvVar_CobraPath(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := &cobra.Command{Use: "myapp"}
 	cmd.Flags().IntP("port", "p", 0, "Server port")
-	_ = cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"MYAPP_PORT"})
+	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYAPP_PORT"})
 
 	// Flag NOT changed on CLI, env var IS set
 	t.Setenv("MYAPP_PORT", "not_a_number")
@@ -590,7 +591,7 @@ func TestExtractLongFlagName_Fallback(t *testing.T) {
 func TestFindFlagForField(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("level", "", "log level")
-	_ = cmd.Flags().SetAnnotation("level", "___leodido_structcli_flagpath", []string{"loglevel"})
+	_ = cmd.Flags().SetAnnotation("level", flagPathAnnotation, []string{"loglevel"})
 	cmd.Flags().Int("port", 0, "port")
 
 	// Direct match
@@ -895,7 +896,7 @@ func TestHandleError_MissingRequiredFlagWithValidateHint(t *testing.T) {
 	cmd := &cobra.Command{Use: "mycli"}
 	cmd.Flags().String("email", "", "user email")
 	_ = cmd.MarkFlagRequired("email")
-	_ = cmd.Flags().SetAnnotation("email", "___leodido_structcli_flagenvs", []string{"MYCLI_EMAIL"})
+	_ = cmd.Flags().SetAnnotation("email", internalenv.FlagAnnotation, []string{"MYCLI_EMAIL"})
 	_ = cmd.Flags().SetAnnotation("email", flagValidateAnnotation, []string{"required,email"})
 
 	os.Unsetenv("MYCLI_EMAIL")
@@ -1091,7 +1092,7 @@ func TestSetupFlagErrors_FallbackWithoutSetup(t *testing.T) {
 func TestSetupFlagErrors_EnvVarSourceAttribution(t *testing.T) {
 	cmd := &cobra.Command{Use: "test", RunE: func(c *cobra.Command, args []string) error { return nil }}
 	cmd.Flags().IntP("port", "p", 3000, "Server port")
-	cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"TEST_PORT"})
+	cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"TEST_PORT"})
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 
@@ -1134,7 +1135,7 @@ func TestHandleError_ValidationFailed_EmptyDetailsWithErrors(t *testing.T) {
 func TestHandleError_InvalidFlagValue_FromEnvVarRegexFallback(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().IntP("port", "p", 3000, "Server port")
-	cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"TEST_PORT"})
+	cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"TEST_PORT"})
 
 	t.Setenv("TEST_PORT", "abc")
 
@@ -1153,7 +1154,7 @@ func TestHandleError_InvalidFlagValue_FromEnvVarRegexFallback(t *testing.T) {
 func TestHandleError_InvalidFlagValue_FromEmptyEnvVarRegexFallback(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().IntP("port", "p", 3000, "Server port")
-	cmd.Flags().SetAnnotation("port", "___leodido_structcli_flagenvs", []string{"TEST_PORT"})
+	cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"TEST_PORT"})
 
 	t.Setenv("TEST_PORT", "")
 

--- a/viper.go
+++ b/viper.go
@@ -16,12 +16,12 @@ import (
 )
 
 const (
-	flagPathAnnotation     = "___leodido_structcli_flagpath"
-	flagDefaultAnnotation  = "___leodido_structcli_flagdefault"
-	flagPresetsAnnotation  = "___leodido_structcli_flagpresets"
-	flagEnumAnnotation     = "___leodido_structcli_flagenum"
-	flagValidateAnnotation = "___leodido_structcli_flagvalidate"
-	flagModAnnotation      = "___leodido_structcli_flagmod"
+	flagPathAnnotation     = "leodido/structcli/flag-path"
+	flagDefaultAnnotation  = "leodido/structcli/flag-default"
+	flagPresetsAnnotation  = "leodido/structcli/flag-presets"
+	flagEnumAnnotation     = "leodido/structcli/flag-enum"
+	flagValidateAnnotation = "leodido/structcli/flag-validate"
+	flagModAnnotation      = "leodido/structcli/flag-mod"
 )
 
 func remappingMetadataFromCommand(c *cobra.Command) (map[string]string, map[string]string) {


### PR DESCRIPTION
Renames all annotation keys from the legacy `___leodido_structcli_*` prefix and the intermediate `structcli/*` prefix to a unified `leodido/structcli/*` kebab-case convention. Mirrors the Go module path for unambiguous namespacing.

29 annotation keys across 20 files. No behavior change — all constants are unexported or internal, except two newly exported constants (see below).

## Naming convention

Old: `___leodido_structcli_flagenvs`, `structcli/bind-used`
New: `leodido/structcli/flag-envs`, `leodido/structcli/bind-used`

One intentional deviation: `executec-active` uses `executec` (not `execute-c`) to match the Go function name `ExecuteC` as a single token. Documented with a comment.

## New exported constants

- `structcli.ConfigFlagAnnotation` — was `configFlagAnnotation` in `config.go`. Exported to eliminate a hardcoded string in `generate/agents.go`. Also used by `helptopics.go` and `jsonschema.go`.
- `flagkit.FlagEnumAnnotation` — was `flagEnumAnnotation` in `flagkit/output.go`. Mirrors `flagEnumAnnotation` from root `structcli` (duplicated to avoid import cycle). Exported to eliminate hardcoded strings in `flagkit/output_test.go` and `generate/agents_test.go`.

Both are additive — no breaking changes.

## Mirror constants

Two annotation keys are duplicated across packages to avoid import cycles:
- `flagkit.FlagEnumAnnotation` mirrors `flagEnumAnnotation` (root, `viper.go`)
- `flagKitAnnotation` in `generate/agents.go` mirrors `flagkit.FlagKitAnnotation`

Both have comments explaining the duplication.

## Files changed

- `bind.go`, `config.go`, `execute.go`, `setup.go`, `viper.go`, `jsonschema.go`, `mcp.go`, `helptopics.go` — root package constants
- `flagkit/follow.go`, `flagkit/output.go` — flagkit constants
- `generate/agents.go` — agents generator annotation references
- `internal/cmd/cmd.go`, `internal/debug/debug.go`, `internal/env/env.go`, `internal/hooks/decode.go`, `internal/usage/groups.go` — internal package constants
- `structerr_test.go`, `flagkit/output_test.go`, `generate/agents_test.go`, `internal/cmd/cmd_test.go` — test files updated to use constants instead of string literals where possible