### PR TITLE
docs: remove em/en dashes and undeprecate composite interfaces

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -25,7 +25,7 @@ const (
 // Attach is called. Otherwise flags are defined directly from struct tags.
 //
 // Multiple Bind calls per command are supported; unmarshal order matches call order (FIFO).
-// Define runs immediately — flags exist on the command after Bind returns.
+// Define runs immediately; flags exist on the command after Bind returns.
 //
 // As a side effect, the first Bind call on a command tree installs a
 // [cobra.Command.PersistentPreRunE] on root that warns to stderr when
@@ -99,7 +99,7 @@ func Bind(c *cobra.Command, opts any) error {
 	// Limitation: Cobra (without EnableTraverseRunHooks) only runs the
 	// nearest ancestor's PersistentPreRunE. If a child command defines
 	// its own PersistentPreRunE, root's hook is shadowed and the warning
-	// won't fire. This is acceptable — the cmd.Execute() path is already
+	// won't fire. This is acceptable because the cmd.Execute() path is already
 	// the "wrong" path, and the warning is best-effort.
 	if root.Annotations[bindWarnAnnotation] != "true" {
 		origPreRunE := root.PersistentPreRunE
@@ -109,7 +109,7 @@ func Bind(c *cobra.Command, opts any) error {
 			// Warn only when ExecuteC is not active AND the bind pipeline
 			// wrapper was never installed. If a previous ExecuteC call
 			// installed the wrapper, auto-unmarshal works even through
-			// cmd.Execute() — the wrapper is idempotent and persists.
+			// cmd.Execute(). The wrapper is idempotent and persists.
 			if root.Annotations[executeCActiveAnnotation] != "true" &&
 				root.Annotations[bindPipelineAnnotation] != "true" {
 				root.PrintErrln("Warning: Bind-registered options exist but ExecuteC/ExecuteOrExit was not used.",

--- a/bind_test.go
+++ b/bind_test.go
@@ -153,7 +153,7 @@ func TestBind_PlainStruct_WithCapabilityInterfaces(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	opts := &bindValidatableOpts{}
 
-	// Should succeed — Validatable and Transformable don't require Attach
+	// Should succeed. Validatable and Transformable don't require Attach.
 	err := Bind(cmd, opts)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestBind_WarnsWhenExecuteCNotUsed(t *testing.T) {
 	opts := &bindPlainOpts{}
 	require.NoError(t, Bind(cmd, opts))
 
-	// Use cmd.Execute() directly — not structcli.ExecuteC.
+	// Use cmd.Execute() directly, not structcli.ExecuteC.
 	cmd.SetArgs([]string{})
 	require.NoError(t, cmd.Execute())
 
@@ -255,7 +255,7 @@ func TestBind_NoWarningWhenNoBind(t *testing.T) {
 	}
 	cmd.SetErr(&stderr)
 
-	// No Bind call — just execute directly.
+	// No Bind call; just execute directly.
 	cmd.SetArgs([]string{})
 	require.NoError(t, cmd.Execute())
 
@@ -269,7 +269,7 @@ func TestBind_Warning_IndependentCommandTrees(t *testing.T) {
 	viper.Reset()
 	SetEnvPrefix("")
 
-	// Tree 1: uses cmd.Execute() — should warn.
+	// Tree 1: uses cmd.Execute(), should warn.
 	var stderr1 bytes.Buffer
 	cmd1 := &cobra.Command{
 		Use: "tree1",
@@ -284,7 +284,7 @@ func TestBind_Warning_IndependentCommandTrees(t *testing.T) {
 	require.NoError(t, cmd1.Execute())
 	assert.Contains(t, stderr1.String(), "ExecuteC", "tree1 should warn when cmd.Execute() is used")
 
-	// Tree 2: uses ExecuteC — should not warn.
+	// Tree 2: uses ExecuteC, should not warn.
 	var stderr2 bytes.Buffer
 	cmd2 := &cobra.Command{
 		Use: "tree2",
@@ -302,13 +302,13 @@ func TestBind_Warning_IndependentCommandTrees(t *testing.T) {
 }
 
 // ExecuteOrExit delegates to ExecuteC, so the executeCActiveAnnotation is
-// set before the PersistentPreRunE fires. No separate test needed — the
+// set before the PersistentPreRunE fires. No separate test needed; the
 // annotation path is covered by TestBind_NoWarningWhenExecuteCUsed.
 // Testing ExecuteOrExit directly would require mocking os.Exit.
 
 func TestBind_Warning_NoFalsePositiveAfterExecuteC(t *testing.T) {
 	// After ExecuteC installs the pipeline wrapper, a subsequent
-	// cmd.Execute() on the same tree should NOT warn — the pipeline
+	// cmd.Execute() on the same tree should NOT warn because the pipeline
 	// is already installed and auto-unmarshal works.
 	viper.Reset()
 	SetEnvPrefix("")
@@ -324,14 +324,14 @@ func TestBind_Warning_NoFalsePositiveAfterExecuteC(t *testing.T) {
 	cmd.SetErr(&stderr)
 	require.NoError(t, Bind(cmd, opts))
 
-	// First call via ExecuteC — installs pipeline wrapper.
+	// First call via ExecuteC installs pipeline wrapper.
 	cmd.SetArgs([]string{"--port", "8080"})
 	_, err := ExecuteC(cmd)
 	require.NoError(t, err)
 	assert.Empty(t, stderr.String(), "no warning expected from ExecuteC")
 	assert.Equal(t, 8080, opts.Port)
 
-	// Second call via cmd.Execute() — pipeline wrapper persists,
+	// Second call via cmd.Execute(). Pipeline wrapper persists,
 	// auto-unmarshal still works, no warning should fire.
 	stderr.Reset()
 	cmd.SetArgs([]string{"--port", "7070"})
@@ -360,7 +360,7 @@ func TestBind_Warning_ShadowedByChildPersistentPreRunE(t *testing.T) {
 
 	require.NoError(t, Bind(child, &bindPlainOpts{}))
 
-	// cmd.Execute() — warning is shadowed by child's PersistentPreRunE.
+	// cmd.Execute(): warning is shadowed by child's PersistentPreRunE.
 	root.SetArgs([]string{"sub"})
 	require.NoError(t, root.Execute())
 	assert.Empty(t, stderr.String(), "warning is shadowed when child has PersistentPreRunE (known limitation)")
@@ -409,7 +409,7 @@ func TestBind_Warning_BindOnSubcommand(t *testing.T) {
 
 	require.NoError(t, Bind(child, &bindPlainOpts{}))
 
-	// cmd.Execute() — warning should fire from root's hook.
+	// cmd.Execute(): warning should fire from root's hook.
 	root.SetArgs([]string{"sub"})
 	require.NoError(t, root.Execute())
 	assert.Contains(t, stderr.String(), "ExecuteC", "warning should fire even when Bind was called on a subcommand")

--- a/contract.go
+++ b/contract.go
@@ -16,7 +16,7 @@ type Options interface {
 // Validatable is a struct that supports validation after unmarshalling.
 //
 // Validate is called automatically during Unmarshal(), after Transform.
-// Does not require Options (Attach) — works with plain struct pointers via Bind.
+// Does not require [Options] (Attach). Works with plain struct pointers via Bind.
 type Validatable interface {
 	Validate(context.Context) []error
 }
@@ -24,7 +24,7 @@ type Validatable interface {
 // Transformable is a struct that supports transformation after unmarshalling.
 //
 // Transform is called automatically during Unmarshal(), before Validate.
-// Does not require Options (Attach) — works with plain struct pointers via Bind.
+// Does not require [Options] (Attach). Works with plain struct pointers via Bind.
 type Transformable interface {
 	Transform(context.Context) error
 }
@@ -32,18 +32,20 @@ type Transformable interface {
 // ContextInjector is a struct that propagates values into the command context after unmarshalling.
 //
 // Context is called automatically during Unmarshal() to derive a new context.
-// Does not require Options (Attach) — works with plain struct pointers via Bind.
+// Does not require [Options] (Attach). Works with plain struct pointers via Bind.
 //
-// FromContext (reading values back from context) is a user-side pattern, not part of this interface.
+// Reading values back from context (FromContext) is a user-side pattern,
+// not part of this interface.
 type ContextInjector interface {
 	Context(context.Context) context.Context
 }
 
 // ValidatableOptions extends Options with validation capabilities.
 //
-// Deprecated: Use Validatable instead. ValidatableOptions requires implementing Attach,
-// which is unnecessary for validation. Validatable works with both Options implementors
-// and plain struct pointers.
+// For the Bind API, consider using [Validatable] instead. It does not
+// require implementing Attach and works with plain struct pointers.
+// ValidatableOptions remains the right choice when using Define/Unmarshal
+// directly or when the type already implements [Options].
 type ValidatableOptions interface {
 	Options
 	Validate(context.Context) []error
@@ -51,20 +53,22 @@ type ValidatableOptions interface {
 
 // TransformableOptions extends Options with transformation capabilities.
 //
-// Deprecated: Use Transformable instead. TransformableOptions requires implementing Attach,
-// which is unnecessary for transformation. Transformable works with both Options implementors
-// and plain struct pointers.
+// For the Bind API, consider using [Transformable] instead. It does not
+// require implementing Attach and works with plain struct pointers.
+// TransformableOptions remains the right choice when using Define/Unmarshal
+// directly or when the type already implements [Options].
 type TransformableOptions interface {
 	Options
 	Transform(context.Context) error
 }
 
-// EnumValuer is an optional interface that pflag.Value implementations can satisfy
-// to declare their allowed values at the type level.
+// EnumValuer is an optional interface that pflag.Value implementations can
+// satisfy to declare their allowed values at the type level.
 //
-// When a pflag.Value returned by a DefineHookFunc (built-in or custom) implements
-// EnumValuer, structcli stores the allowed values as a flag annotation during Define().
-// This is the authoritative source of enum values — no description string parsing needed.
+// When a pflag.Value returned by a DefineHookFunc (built-in or custom)
+// implements EnumValuer, structcli stores the allowed values as a flag
+// annotation during Define(). This is the authoritative source of enum
+// values; no description string parsing is needed.
 //
 // Example:
 //
@@ -79,9 +83,11 @@ type EnumValuer interface {
 
 // ContextOptions extends Options with context manipulation capabilities.
 //
-// Deprecated: Use ContextInjector instead. ContextInjector only requires the Context method
-// (propagation). FromContext is a user-side pattern — structcli never calls it internally.
-// ContextInjector works with both Options implementors and plain struct pointers.
+// For the Bind API, consider using [ContextInjector] instead. It only
+// requires the Context method (propagation) and works with plain struct
+// pointers. FromContext is a user-side pattern; structcli never calls it
+// internally. ContextOptions remains the right choice when using
+// Define/Unmarshal directly or when the type already implements [Options].
 type ContextOptions interface {
 	Options
 	Context(context.Context) context.Context

--- a/debug_test.go
+++ b/debug_test.go
@@ -204,7 +204,7 @@ func TestSetupDebug_WorksWithoutRunE(t *testing.T) {
 
 	output := out.String()
 	// The wrapped RunE returns nil when debug is active, so the synthetic
-	// Help() body never runs — output should be empty (no help text).
+	// Help() body never runs; output should be empty (no help text).
 	assert.NotContains(t, output, "Usage:", "debug interception should prevent help output")
 }
 

--- a/define.go
+++ b/define.go
@@ -223,7 +223,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 		// Determine whether to represent hierarchy with the command name.
 		// Context-injecting options are treated as shared/common (no command name prefix in env vars).
-		// Prefer ContextInjector (standalone); fall back to deprecated ContextOptions.
+		// Prefer ContextInjector (standalone); fall back to ContextOptions.
 		cName := ""
 		_, isContextInjector := o.(ContextInjector)
 		_, isContextOptions := o.(ContextOptions)
@@ -437,7 +437,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				// We fallback to look up the hooks registries to avoid erroring out
 				if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
 				// Best-effort: attach a decode hook if one exists, but don't
-					// hard-error when missing — this is a fallback path, not a
+					// hard-error when missing. This is a fallback path, not a
 					// mandatory one like the other two call sites.
 					internalhooks.InferDecodeHooks(c, name, f.Type.String())
 

--- a/define_test.go
+++ b/define_test.go
@@ -3594,7 +3594,7 @@ func (f *enumValuerFlag) String() string   { return f.val }
 func (f *enumValuerFlag) Set(s string) error { f.val = s; return nil }
 func (f *enumValuerFlag) Type() string     { return "string" }
 func (f *enumValuerFlag) EnumValues() []string {
-	// These are the REAL allowed values — intentionally different from the description
+	// These are the REAL allowed values, intentionally different from the description.
 	return []string{"alpha", "beta", "gamma"}
 }
 
@@ -3849,7 +3849,7 @@ func (suite *structcliSuite) TestDefine_ValidateAnnotation_CustomTagNames() {
 	assert.Equal(suite.T(), []string{"min=3"}, bothFlag.Annotations[flagValidateAnnotation])
 	assert.Equal(suite.T(), []string{"lcase"}, bothFlag.Annotations[flagModAnnotation])
 
-	// No custom tags — annotations should not be present
+	// No custom tags; annotations should not be present.
 	plainFlag := cmd.Flags().Lookup("plain")
 	require.NotNil(suite.T(), plainFlag)
 	_, hasVal := plainFlag.Annotations[flagValidateAnnotation]

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -92,7 +92,7 @@ func (e *ValidationError) Details() []ValidationDetail {
 // Unwrap returns the inner errors so that errors.Is and errors.As
 // traverse into individual validation failures.
 //
-// The returned slice is the live internal slice — callers that need
+// The returned slice is the live internal slice. Callers that need
 // mutation-safe access should use [ValidationError.UnderlyingErrors] instead.
 func (e *ValidationError) Unwrap() []error {
 	return e.Errors
@@ -586,7 +586,7 @@ func NewInputError(inputType, message string) error {
 
 // FlagError represents a flag parsing error intercepted by [SetupFlagErrors].
 //
-// It carries only what's needed to identify the error — flag name, bad value,
+// It carries only what's needed to identify the error: flag name, bad value,
 // and error kind. Metadata enrichment (expected type, enum values, env vars)
 // happens at classification time in [HandleError], which receives the correct
 // subcommand from [ExecuteC].

--- a/examples/full/cli/cli.go
+++ b/examples/full/cli/cli.go
@@ -122,7 +122,7 @@ func makeSrvC(commonOpts *UtilityFlags) (*cobra.Command, error) {
 			fmt.Fprintln(c.OutOrStdout(), "|--srvC.RunE")
 		},
 	}
-	// Use Attach (not Bind) — srv has subcommands and ServerOptions should
+	// Use Attach (not Bind) because srv has subcommands and ServerOptions should
 	// only be unmarshalled when srv itself runs, not for child commands.
 	if err := opts.Attach(srvC); err != nil {
 		return nil, fmt.Errorf("srv: attach options: %w", err)
@@ -315,7 +315,7 @@ func makeLogsC() (*cobra.Command, error) {
   full logs -s api --quiet`,
 		RunE: func(c *cobra.Command, args []string) error {
 			// opts is already populated by the bind pipeline.
-			// Per-command format validation — uses the set from RestrictFormats
+			// Per-command format validation. Uses the set from RestrictFormats.
 			if err := opts.Output.ValidFormat(); err != nil {
 				return err
 			}
@@ -382,7 +382,7 @@ func NewRootC(exitOnDebug bool) (*cobra.Command, error) {
 		TraverseChildren: true,
 	}
 
-	// User hook — config loading and unmarshal are handled by the bind pipeline,
+	// User hook. Config loading and unmarshal are handled by the bind pipeline,
 	// but we keep this hook for observable output in tests.
 	rootC.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		fmt.Fprintln(c.OutOrStdout(), "|-rootC.PersistentPreRunE")

--- a/examples/structerr/main.go
+++ b/examples/structerr/main.go
@@ -14,19 +14,19 @@
 //	# Missing required flag (StructuredError exit_code 10)
 //	go run . srv
 //
-//	# Invalid flag value — wrong type (StructuredError exit_code 11)
+//	# Invalid flag value: wrong type (StructuredError exit_code 11)
 //	go run . srv --port abc
 //
-//	# Invalid flag value — via short flag (StructuredError exit_code 11)
+//	# Invalid flag value: via short flag (StructuredError exit_code 11)
 //	go run . srv -p xyz
 //
 //	# Unknown flag (StructuredError exit_code 12)
 //	go run . srv --nonexistent
 //
-//	# Validation failed — invalid email (StructuredError exit_code 13)
+//	# Validation failed: invalid email (StructuredError exit_code 13)
 //	go run . usr add --email notanemail --age 25 --name "John"
 //
-//	# Validation failed — age out of range (StructuredError exit_code 13)
+//	# Validation failed: age out of range (StructuredError exit_code 13)
 //	go run . usr add --email test@example.com --age 10 --name "John"
 //
 //	# Unknown command (StructuredError exit_code 14)
@@ -105,7 +105,7 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "myapp",
 		Short: "Structured error demo",
-		// No need for SilenceErrors/SilenceUsage — ExecuteOrExit sets them automatically
+		// No need for SilenceErrors/SilenceUsage; ExecuteOrExit sets them automatically.
 	}
 
 	// AI-native features: JSON Schema + typed flag errors

--- a/execute.go
+++ b/execute.go
@@ -49,7 +49,7 @@ func getConfigOnce(root *cobra.Command) *sync.Once {
 
 // ExecuteC prepares the command tree for execution and delegates to cmd.ExecuteC().
 //
-// Preparation (idempotent — safe to call multiple times on the same tree):
+// Preparation (idempotent, safe to call multiple times on the same tree):
 //   - Sets SilenceErrors and SilenceUsage on the root command.
 //   - Runs SetupUsage on every command in the tree.
 //   - Recursively wraps PersistentPreRunE on every command to run the bind pipeline
@@ -225,7 +225,7 @@ func wrapBindPipeline(c *cobra.Command) {
 
 		// Replay original persistent hooks from root to the command whose
 		// wrapper Cobra selected (which is cmd's closest ancestor with a
-		// PersistentPreRunE — i.e., this command c, since we wrapped it).
+		// PersistentPreRunE, i.e. this command c since we wrapped it).
 		// We replay all ancestors' original hooks in root-first order so
 		// user hooks on parent commands still fire.
 		if err := replayOriginalHooks(cmd, args); err != nil {

--- a/execute_test.go
+++ b/execute_test.go
@@ -205,7 +205,7 @@ func TestExecuteC_AncestorBeforeDescendant(t *testing.T) {
 	}
 	root.AddCommand(child)
 
-	// Bind rootOpts on child too — flags are local per command.
+	// Bind rootOpts on child too; flags are local per command.
 	// The ancestor-before-descendant contract is about unmarshal order
 	// when both root and child have bound options.
 	require.NoError(t, Bind(root, rootOpts))
@@ -332,7 +332,7 @@ func TestExecuteC_Idempotent(t *testing.T) {
 	assert.Equal(t, 1111, opts.Port)
 	assert.Equal(t, 1, runCount)
 
-	// Second execution on same tree — wrappers should not stack
+	// Second execution on same tree; wrappers should not stack.
 	cmd.SetArgs([]string{"--port", "2222"})
 	_, err = ExecuteC(cmd)
 	require.NoError(t, err)
@@ -800,13 +800,13 @@ func TestExecuteC_TraverseChildrenWarning_OncePerTree(t *testing.T) {
 	var stderr bytes.Buffer
 	root.SetErr(&stderr)
 
-	// First execution — warning fires.
+	// First execution: warning fires.
 	root.SetArgs([]string{"sub"})
 	_, err := ExecuteC(root)
 	require.NoError(t, err)
 	assert.Contains(t, stderr.String(), "TraverseChildren is false")
 
-	// Second execution — warning should not repeat.
+	// Second execution: warning should not repeat.
 	stderr.Reset()
 	root.SetArgs([]string{"sub"})
 	_, err = ExecuteC(root)

--- a/exitcode/exitcode.go
+++ b/exitcode/exitcode.go
@@ -3,15 +3,15 @@
 // Exit codes are grouped into ranges that form a decision tree for AI agents:
 //
 //	exit_code == 0  → success
-//	exit_code 1–9   → runtime error → report to human
-//	exit_code 10–19 → input error → self-correct from error JSON → retry
-//	exit_code 20–29 → config/env error → fix environment → retry
+//	exit_code 1-9   → runtime error → report to human
+//	exit_code 10-19 → input error → self-correct from error JSON → retry
+//	exit_code 20-29 → config/env error → fix environment → retry
 //
 // These codes are returned by [structcli.HandleError] and included
 // in the structured JSON error output as the "exit_code" field.
 package exitcode
 
-// Runtime errors (1–9): not the agent's fault — report, don't retry.
+// Runtime errors (1-9): not the agent's fault. Report, don't retry.
 const (
 	// OK indicates successful execution.
 	OK = 0
@@ -29,7 +29,7 @@ const (
 	Interrupted = 4
 )
 
-// Input errors (10–19): the agent provided bad input — self-correct and retry.
+// Input errors (10-19): the agent provided bad input. Self-correct and retry.
 const (
 	// MissingRequiredFlag indicates a required input was missing at command
 	// execution time. Structured errors may include hints about env fallbacks,
@@ -56,7 +56,7 @@ const (
 	InvalidFlagEnum = 15
 )
 
-// Configuration and environment errors (20–29): the environment is wrong — fix it, then retry.
+// Configuration and environment errors (20-29): the environment is wrong. Fix it, then retry.
 const (
 	// ConfigParseError indicates the config file exists but is malformed
 	// (invalid YAML, JSON, or TOML syntax).
@@ -92,10 +92,10 @@ const (
 // Category returns the error category for a given exit code.
 //
 // Agents use this to decide their top-level strategy:
-//   - "ok": success — proceed
-//   - "input": bad input — self-correct from the error JSON and retry
-//   - "config": environment problem — fix config/env vars, then retry
-//   - "runtime": not the agent's fault — report to human
+//   - "ok": success, proceed
+//   - "input": bad input, self-correct from the error JSON and retry
+//   - "config": environment problem, fix config/env vars then retry
+//   - "runtime": not the agent's fault, report to human
 func Category(code int) string {
 	switch {
 	case code == OK:

--- a/exitcode/exitcode_test.go
+++ b/exitcode/exitcode_test.go
@@ -10,14 +10,14 @@ func TestConstants(t *testing.T) {
 		wantCat  string
 		wantName string
 	}{
-		// Runtime (0–9)
+		// Runtime (0-9)
 		{"OK", OK, CategoryOK, "OK"},
 		{"Error", Error, CategoryRuntime, "Error"},
 		{"PermissionDenied", PermissionDenied, CategoryRuntime, "PermissionDenied"},
 		{"Timeout", Timeout, CategoryRuntime, "Timeout"},
 		{"Interrupted", Interrupted, CategoryRuntime, "Interrupted"},
 
-		// Input (10–19)
+		// Input (10-19)
 		{"MissingRequiredFlag", MissingRequiredFlag, CategoryInput, "MissingRequiredFlag"},
 		{"InvalidFlagValue", InvalidFlagValue, CategoryInput, "InvalidFlagValue"},
 		{"UnknownFlag", UnknownFlag, CategoryInput, "UnknownFlag"},
@@ -25,7 +25,7 @@ func TestConstants(t *testing.T) {
 		{"UnknownCommand", UnknownCommand, CategoryInput, "UnknownCommand"},
 		{"InvalidFlagEnum", InvalidFlagEnum, CategoryInput, "InvalidFlagEnum"},
 
-		// Config/env (20–29)
+		// Config/env (20-29)
 		{"ConfigParseError", ConfigParseError, CategoryConfig, "ConfigParseError"},
 		{"ConfigUnknownKey", ConfigUnknownKey, CategoryConfig, "ConfigUnknownKey"},
 		{"ConfigInvalidValue", ConfigInvalidValue, CategoryConfig, "ConfigInvalidValue"},

--- a/flagenvonly_test.go
+++ b/flagenvonly_test.go
@@ -348,7 +348,7 @@ func TestUnmarshal_EnvOnly_RequiredMissing(t *testing.T) {
 	}
 	require.NoError(t, Define(cmd, opts))
 
-	// Execute without setting the env var — cobra's required flag check fires
+	// Execute without setting the env var; cobra's required flag check fires.
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	require.Error(t, err)

--- a/flagkit/doc.go
+++ b/flagkit/doc.go
@@ -3,7 +3,7 @@
 //
 // Each type encapsulates a single flag with an opinionated name, type, default,
 // and description matching industry conventions. This gives CLIs a consistent
-// declaration surface — agents and scripts can rely on --follow, --output,
+// declaration surface. Agents and scripts can rely on --follow, --output,
 // --timeout, etc. having predictable names and types across tools.
 //
 // flagkit standardizes flag declarations, not behavioral semantics. How a
@@ -13,7 +13,7 @@
 //
 // # Design Principles
 //
-//   - One struct per concern — maximum composability
+//   - One struct per concern for maximum composability
 //   - Sensible, agent-friendly defaults (e.g., no auto-tailing, finite timeouts)
 //   - Standard flag names matching industry conventions
 //   - Works with all structcli features: env vars, config files, JSON Schema,

--- a/flagkit/dryrun.go
+++ b/flagkit/dryrun.go
@@ -12,7 +12,7 @@ func init() {
 // DryRun provides a --dry-run flag for safe previewing of operations.
 //
 // The default is false. When true, commands should describe what they
-// would do without making changes. This is agent-friendly — AI agents
+// would do without making changes. This is agent-friendly: AI agents
 // can preview destructive operations before committing.
 //
 // Usage:

--- a/flagkit/follow.go
+++ b/flagkit/follow.go
@@ -50,7 +50,7 @@ func init() {
 //
 // When false (the default), commands should print current output and exit.
 // When true, commands should stream output continuously. This default is
-// agent-friendly — AI agents and scripts won't hang on indefinite tailing.
+// agent-friendly: AI agents and scripts won't hang on indefinite tailing.
 //
 // Usage:
 //

--- a/flagkit/loglevel_test.go
+++ b/flagkit/loglevel_test.go
@@ -178,7 +178,7 @@ func TestLogLevel_IsZapLogLevel(t *testing.T) {
 	var ll flagkit.LogLevel
 	var zll flagkit.ZapLogLevel
 
-	// LogLevel is a type alias for ZapLogLevel — assignment must compile.
+	// LogLevel is a type alias for ZapLogLevel; assignment must compile.
 	ll = zll
 	zll = ll
 	_ = zll

--- a/flagkit/output.go
+++ b/flagkit/output.go
@@ -62,7 +62,7 @@ func RegisterOutputFormats(formats ...OutputFormat) {
 //
 // For CLIs where different commands support different format subsets,
 // register the superset globally, then call [Output.RestrictFormats] after
-// Attach. RestrictFormats is the single source of truth — it narrows help,
+// Attach. RestrictFormats is the single source of truth: it narrows help,
 // JSON Schema, and runtime validation in one call:
 //
 //	func init() {
@@ -72,7 +72,7 @@ func RegisterOutputFormats(formats ...OutputFormat) {
 //	opts.Attach(cmd)
 //	opts.Output.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputYAML)
 //
-//	// In RunE — no args needed, uses the set from RestrictFormats:
+//	// In RunE (no args needed, uses the set from RestrictFormats):
 //	if err := opts.Output.ValidFormat(); err != nil {
 //	    return err
 //	}

--- a/flagkit/output_test.go
+++ b/flagkit/output_test.go
@@ -156,7 +156,7 @@ func TestOutput_ValidFormat_SingleAllowed(t *testing.T) {
 }
 
 func TestOutput_ValidFormat_NoRestriction(t *testing.T) {
-	// No RestrictFormats called, no explicit args — all formats accepted.
+	// No RestrictFormats called, no explicit args: all formats accepted.
 	opts := &flagkit.Output{Format: flagkit.OutputYAML}
 	assert.NoError(t, opts.ValidFormat())
 }
@@ -168,11 +168,11 @@ func TestOutput_ValidFormat_UsesRestrictFormats(t *testing.T) {
 
 	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
 
-	// Set format to an allowed value — should pass with no args.
+	// Set format to an allowed value; should pass with no args.
 	opts.Format = flagkit.OutputJSON
 	assert.NoError(t, opts.ValidFormat())
 
-	// Set format to a disallowed value — should fail with no args.
+	// Set format to a disallowed value; should fail with no args.
 	opts.Format = flagkit.OutputYAML
 	err := opts.ValidFormat()
 	assert.Error(t, err)
@@ -187,7 +187,7 @@ func TestOutput_ValidFormat_ExplicitOverridesStored(t *testing.T) {
 	// Restrict to json+text via RestrictFormats.
 	opts.RestrictFormats(cmd, flagkit.OutputJSON, flagkit.OutputText)
 
-	// Explicit args override the stored set — yaml is allowed here.
+	// Explicit args override the stored set; yaml is allowed here.
 	opts.Format = flagkit.OutputYAML
 	assert.NoError(t, opts.ValidFormat(flagkit.OutputYAML, flagkit.OutputJSON))
 
@@ -244,7 +244,7 @@ func TestOutput_RestrictFormats_JSONSchema(t *testing.T) {
 func TestOutput_RestrictFormats_NoFlag(t *testing.T) {
 	opts := &flagkit.Output{}
 	cmd := &cobra.Command{Use: "app"}
-	// Don't call Attach — no flag registered
+	// Don't call Attach; no flag registered.
 	opts.RestrictFormats(cmd, flagkit.OutputJSON) // should not panic
 }
 

--- a/flagkit/timeout.go
+++ b/flagkit/timeout.go
@@ -14,7 +14,7 @@ func init() {
 // Timeout provides a --timeout flag for operation deadlines.
 //
 // The default is 30s. Accepts any value parseable by [time.ParseDuration].
-// This is agent-friendly — operations won't hang indefinitely.
+// This is agent-friendly: operations won't hang indefinitely.
 //
 // Usage:
 //

--- a/generate/agents.go
+++ b/generate/agents.go
@@ -124,7 +124,7 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 		buf.WriteString("\n")
 	}
 
-	// Config File section — use annotation, not hardcoded flag name
+	// Config File section. Uses annotation, not hardcoded flag name.
 	configFlagName := findConfigFlagName(rootCmd)
 	if configFlagName != "" {
 		fmt.Fprintf(&buf, "### Config File\n\nSupports YAML/JSON/TOML config files. Use `--%s` to specify path.\n\n", configFlagName)
@@ -139,7 +139,7 @@ func Agents(rootCmd *cobra.Command, opts AgentsOptions) ([]byte, error) {
 	}
 	buf.WriteString("\n")
 
-	// Development Notes — emitted when flagkit types are detected
+	// Development Notes. Emitted when flagkit types are detected.
 	if hasFlagKitFlags(rootCmd) {
 		buf.WriteString("## Development Notes\n\n")
 		buf.WriteString("This CLI uses [structcli](https://github.com/leodido/structcli) with the `flagkit` package\n")

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -3,7 +3,7 @@
 // All generators consume [structcli.JSONSchema] with [jsonschema.WithFullTree]
 // and produce []byte output. The caller decides where to write the files.
 //
-// The generators produce mechanically correct scaffolds — every flag name, type,
+// The generators produce mechanically correct scaffolds. Every flag name, type,
 // default, env var, and required marker comes from the same struct definition that
 // powers --jsonschema. Humans should add on top:
 //   - Trigger phrases for skill discovery ("use when user asks to deploy")

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testServeOptions defines flags via structcli.Define() — the same path real users take.
+// testServeOptions defines flags via structcli.Define(), the same path real users take.
 // This ensures annotations (env vars, defaults, required) are set correctly.
 type testServeOptions struct {
 	Port int    `flagshort:"p" flagdescr:"Server port" flagenv:"true" flagrequired:"true" default:"3000"`

--- a/generate/llmstxt.go
+++ b/generate/llmstxt.go
@@ -12,7 +12,7 @@ import (
 
 // LLMsTxtOptions configures the llms.txt generator.
 type LLMsTxtOptions struct {
-	ModulePath string // Go module path (eg. "github.com/myorg/mycli") — used to derive project URL
+	ModulePath string // Go module path (eg. "github.com/myorg/mycli"), used to derive project URL
 	IncludeMCP bool   // Mention --mcp in the output
 }
 
@@ -63,7 +63,7 @@ func LLMsTxt(rootCmd *cobra.Command, opts LLMsTxtOptions) ([]byte, error) {
 		}
 	}
 
-	// Commands index section — use CommandPath for unique anchors
+	// Commands index section. Uses CommandPath for unique anchors.
 	if len(callables) > 0 {
 		fmt.Fprintf(&buf, "\n## Commands\n\n")
 		for _, callable := range callables {

--- a/generate/llmstxt_test.go
+++ b/generate/llmstxt_test.go
@@ -122,7 +122,7 @@ func TestLLMsTxt_RequiredFlagMarked(t *testing.T) {
 	require.NoError(t, err)
 
 	content := string(out)
-	// Port is required — should say so
+	// Port is required; should say so.
 	assert.Contains(t, content, "required")
 }
 

--- a/generate/skill_test.go
+++ b/generate/skill_test.go
@@ -25,7 +25,7 @@ func TestSkill_YAMLFrontmatter(t *testing.T) {
 }
 
 func TestSkill_NameKebabCase(t *testing.T) {
-	// Cobra's Name() returns the first word of Use — so Use should already be kebab-case
+	// Cobra's Name() returns the first word of Use, so Use should already be kebab-case.
 	root := &cobra.Command{
 		Use:  "my-cool-app",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -109,7 +109,7 @@ func resetFlags(root *cobra.Command) {
 // can suppress the bare usage line (avoiding a misleading "app" line that
 // implies the root is directly invocable).
 //
-// Safe to call multiple times — idempotent. Subsequent Setup* calls and
+// Safe to call multiple times (idempotent). Subsequent Setup* calls and
 // RecursivelyWrapExecution will wrap the synthetic RunE like any other.
 func EnsureRunnable(c *cobra.Command) {
 	if c.RunE == nil && c.Run == nil {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -268,7 +268,7 @@ func TestEnsureRunnable_InterceptsCommandWithoutRunE(t *testing.T) {
 	t.Cleanup(RestoreInterceptedExecutions)
 
 	intercepted := false
-	// Root has no RunE/Run — cobra would normally short-circuit to Help().
+	// Root has no RunE/Run; cobra would normally short-circuit to Help().
 	root := &cobra.Command{
 		Use:           "app",
 		SilenceErrors: true,

--- a/internal/config/viper.go
+++ b/internal/config/viper.go
@@ -148,7 +148,7 @@ func KeyRemappingHook(aliasToPathMap map[string]string, defaultsMap map[string]s
 					// When viper has already merged the flat key and the
 					// dotted path into a nested map (e.g. both "output"
 					// and "output.format" are set), the value is already
-					// a map — no restructuring needed.
+					// a map, so no restructuring is needed.
 					if _, alreadyNested := aliasValue.(map[string]any); alreadyNested {
 						continue
 					}
@@ -179,7 +179,7 @@ func KeyRemappingHook(aliasToPathMap map[string]string, defaultsMap map[string]s
 					finalKey := pathParts[len(pathParts)-1]
 					currentMap[finalKey] = aliasValue
 
-					// Delete the original flattened key — unless the alias
+					// Delete the original flattened key, unless the alias
 					// is the same as the first path segment, in which case
 					// the restructured map lives under that key.
 					if alias != pathParts[0] {

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -380,7 +380,7 @@ func (suite *structcliSuite) TestKeyRemappingHook_AlreadyNestedMap() {
 	hook := KeyRemappingHook(aliasToPathMap, defaultsMap)
 
 	// Simulate what viper.AllSettings() returns when both "output" and
-	// "output.format" defaults are set — a nested map, not a flat string.
+	// "output.format" defaults are set as a nested map, not a flat string.
 	input := map[string]any{
 		"output": map[string]any{"format": "text"},
 		"limit":  10,

--- a/internal/hooks/decode_fuzz_test.go
+++ b/internal/hooks/decode_fuzz_test.go
@@ -38,7 +38,7 @@ func FuzzStringToIntSlice(f *testing.F) {
 	f.Add("  1 , 2 , 3  ")
 	f.Add("999999999999999999999")
 	f.Add("-1,0,1")
-	f.Add("[1,2,3]") // error path — this hook doesn't strip brackets
+	f.Add("[1,2,3]") // error path: this hook doesn't strip brackets
 
 	hook := StringToIntSliceHookFunc(",").(decodeHookFuncType)
 	target := reflect.TypeOf([]int(nil))
@@ -48,7 +48,7 @@ func FuzzStringToIntSlice(f *testing.F) {
 	})
 }
 
-// FuzzStringToCSVStringSlice is not needed — the hook's string branch calls
+// FuzzStringToCSVStringSlice is not needed because the hook's string branch calls
 // readAsCSV(raw) with no preprocessing, so FuzzReadAsCSV covers it.
 
 func FuzzStringToBoolSlice(f *testing.F) {
@@ -147,7 +147,7 @@ func FuzzStringToInt64Map(f *testing.F) {
 	})
 }
 
-// StringToRawBytesHookFunc is not fuzzed — it is []byte(s) and cannot panic.
+// StringToRawBytesHookFunc is not fuzzed. It is []byte(s) and cannot panic.
 
 func FuzzStringToHexBytes(f *testing.F) {
 	f.Add("48656c6c6f")
@@ -195,7 +195,7 @@ func FuzzStringToIPMask(f *testing.F) {
 	})
 }
 
-// FuzzStringToIPSlice is not needed — the hook's string branch calls
+// FuzzStringToIPSlice is not needed because the hook's string branch calls
 // parseIPSlice(raw) with no preprocessing, so FuzzParseIPSlice covers it.
 
 func FuzzStringToZapcoreLevel(f *testing.F) {

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -37,7 +37,7 @@ func TestInferDecodeHooks(t *testing.T) {
 
 func TestInferDecodeHooks_PanicsOnUnknownFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
-	// Don't define a "durations" flag — SetAnnotation will panic on unknown flag
+	// Don't define a "durations" flag; SetAnnotation will panic on unknown flag.
 
 	assert.PanicsWithValue(t,
 		`structcli: SetAnnotation on just-registered flag "durations": no such flag -durations`,

--- a/internal/proptest/define/define_prop_test.go
+++ b/internal/proptest/define/define_prop_test.go
@@ -183,7 +183,7 @@ func TestProperty_Define_NeverPanics(t *testing.T) {
 }
 
 // P3.2: Every non-ignored field has a registered flag.
-// Deterministic — no randomization needed.
+// Deterministic; no randomization needed.
 func TestDefine_AllFieldsHaveFlags(t *testing.T) {
 	cmd := newCmd()
 	opts := &allTypesOpts{}
@@ -197,7 +197,7 @@ func TestDefine_AllFieldsHaveFlags(t *testing.T) {
 }
 
 // P3.3: Flag count matches field count (no presets).
-// Deterministic — no randomization needed.
+// Deterministic; no randomization needed.
 func TestDefine_FlagCountMatchesFieldCount(t *testing.T) {
 	cmd := newCmd()
 	opts := &allTypesOpts{}
@@ -235,7 +235,7 @@ func TestProperty_Define_HiddenFieldsAreHidden(t *testing.T) {
 		// Hidden uses pflag.Flag.Hidden bool, not annotations.
 		if hiddenFlag.Annotations != nil {
 			if _, exists := hiddenFlag.Annotations["hidden"]; exists {
-				t.Fatal("unexpected 'hidden' annotation — hidden uses the bool field")
+				t.Fatal("unexpected 'hidden' annotation; hidden uses the bool field")
 			}
 		}
 	})
@@ -266,7 +266,7 @@ func TestProperty_Define_RequiredFieldsAreRequired(t *testing.T) {
 }
 
 // P3.6: default tag sets the flag's DefValue.
-// Deterministic — no randomization needed.
+// Deterministic; no randomization needed.
 func TestDefine_DefaultTagSetsDefValue(t *testing.T) {
 	cmd := newCmd()
 	opts := &defaultOpts{}
@@ -380,7 +380,7 @@ func TestProperty_Define_PresetAliasesRegistered(t *testing.T) {
 }
 
 // P3.10: Preset alias count is additive to flag count.
-// Deterministic — no randomization needed.
+// Deterministic; no randomization needed.
 func TestDefine_PresetAliasCountIsAdditive(t *testing.T) {
 	cmd := newCmd()
 	opts := &presetOpts{}

--- a/internal/proptest/gen/generators.go
+++ b/internal/proptest/gen/generators.go
@@ -85,7 +85,7 @@ type TagSet struct {
 }
 
 // ToStructTag converts a TagSet to a reflect.StructTag string.
-// Values must not contain '"' or '\\' — these break struct tag encoding
+// Values must not contain '"' or '\\' because these break struct tag encoding
 // and cause Tag.Get to return truncated or empty results.
 func (ts TagSet) ToStructTag() reflect.StructTag {
 	var parts []string
@@ -157,7 +157,7 @@ type FieldSpec struct {
 	Tags TagSet
 }
 
-// UniqueFieldSpecs generates 1–maxFields field specs with unique valid flag names.
+// UniqueFieldSpecs generates 1-maxFields field specs with unique valid flag names.
 func UniqueFieldSpecs(maxFields int) *rapid.Generator[[]FieldSpec] {
 	return rapid.Custom(func(t *rapid.T) []FieldSpec {
 		n := rapid.IntRange(1, maxFields).Draw(t, "fieldCount")

--- a/internal/proptest/tag/tag_prop_test.go
+++ b/internal/proptest/tag/tag_prop_test.go
@@ -15,7 +15,7 @@ import (
 	"pgregory.net/rapid"
 )
 
-// Intentionally duplicated from internal/tag/tag.go — P1.1 cross-checks
+// Intentionally duplicated from internal/tag/tag.go. P1.1 cross-checks
 // IsValidFlagName against this independent copy. If the production regex
 // changes without updating this one, P1.1 will catch the drift.
 var validFlagNameRegex = regexp.MustCompile(`^[a-zA-Z0-9]+([.-][a-zA-Z0-9]+)*$`)
@@ -228,7 +228,7 @@ func TestProperty_ParseFlagPresets_SemicolonPrecedence(t *testing.T) {
 		if name1 == name2 {
 			name2 = name2 + "x"
 		}
-		// Value with comma inside — should NOT be treated as separator
+		// Value with comma inside: should NOT be treated as separator.
 		value1 := "a,b"
 		value2 := "c"
 		tag := name1 + "=" + value1 + ";" + name2 + "=" + value2

--- a/internal/proptest/validation/validation_prop_test.go
+++ b/internal/proptest/validation/validation_prop_test.go
@@ -424,7 +424,7 @@ func TestProperty_Validation_ErrorsAreWellTyped(t *testing.T) {
 		}
 
 		// Check against each known error type with concrete typed pointers.
-		// Using *any as the errors.As target would match everything — each
+		// Using *any as the errors.As target would match everything; each
 		// check must use a concretely-typed pointer variable.
 		var (
 			invalidBoolTag     *structclierrors.InvalidBooleanTagError

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -16,7 +16,7 @@ import (
 )
 
 // enumPattern matches the {val1,val2,...} pattern in flag usage strings.
-// Values must be simple identifiers (alphanumeric, hyphens, underscores) — this avoids
+// Values must be simple identifiers (alphanumeric, hyphens, underscores) to avoid
 // matching config search path patterns like {/etc/app,...} or similar non-enum braces.
 var enumPattern = regexp.MustCompile(`\{([\w-]+(?:,[\w-]+)+)\}`)
 

--- a/jsonschema/types.go
+++ b/jsonschema/types.go
@@ -38,7 +38,7 @@ func WithFullTree() Opt {
 // WithEnumInDescription preserves {val1,val2,...} patterns in description fields.
 //
 // By default, enum patterns are stripped from descriptions since the values
-// are already available in the enum array — this produces cleaner output for
+// are already available in the enum array. This produces cleaner output for
 // machine consumers. Use this option to keep the original description text intact.
 func WithEnumInDescription() Opt {
 	return func(c *Config) {

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -346,7 +346,7 @@ func TestJSONSchema_ManualFlagRegexFallback(t *testing.T) {
 	SetEnvPrefix("")
 
 	cmd := &cobra.Command{Use: "app"}
-	// Manually added flag (not via Define) — no enum annotation set
+	// Manually added flag (not via Define): no enum annotation set.
 	cmd.Flags().String("mode", "", "Output mode {json,yaml,text}")
 
 	schemas, err := JSONSchema(cmd)
@@ -1095,7 +1095,7 @@ func TestSetupJSONSchema_WorksWithoutRunE(t *testing.T) {
 	SetEnvPrefix("APP")
 	t.Cleanup(func() { SetEnvPrefix("") })
 
-	// Root command with no RunE/Run — the common case for CLI apps
+	// Root command with no RunE/Run, the common case for CLI apps.
 	// where the root just shows help.
 	root := &cobra.Command{
 		Use: "app", SilenceErrors: true, SilenceUsage: true,

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -18,7 +18,7 @@ const ProtocolVersion = "2024-11-05"
 // Parameters:
 //   - argv: the command path and flag arguments (excluding the root command
 //     name). Provided for informational use or conditional subtree building.
-//     The factory must not call SetArgs — the caller handles that.
+//     The factory must not call SetArgs; the caller handles that.
 //   - stdout, stderr: writers that must receive all command output. Wire these
 //     into any closures that capture output streams at construction time.
 //

--- a/setup.go
+++ b/setup.go
@@ -231,7 +231,7 @@ func applyAppName(cmd *cobra.Command, appName string) error {
 func patchTreeEnvPrefix(c *cobra.Command, oldPrefix, newPrefix string) {
 	internalenv.PatchEnvPrefix(c, oldPrefix, newPrefix)
 	// Re-bind env vars with the updated annotations.
-	// Errors here are non-fatal — flags without env annotations are simply skipped.
+	// Errors here are non-fatal. Flags without env annotations are simply skipped.
 	_ = internalenv.BindEnv(c)
 
 	for _, sub := range c.Commands() {

--- a/setup_test.go
+++ b/setup_test.go
@@ -123,7 +123,7 @@ func TestSetup_WithFlagErrors(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	err := Setup(cmd, WithFlagErrors())
 	require.NoError(t, err)
-	// SetupFlagErrors doesn't register flags — it intercepts errors.
+	// SetupFlagErrors doesn't register flags; it intercepts errors.
 }
 
 func TestSetup_AllOptions(t *testing.T) {
@@ -205,7 +205,7 @@ func TestSetup_WithAppName_PatchesExistingFlags(t *testing.T) {
 		Port int `flag:"port" default:"3000" flagenv:"true"`
 	}{}
 
-	// Bind first — no global prefix, but command name "test" is baked in
+	// Bind first. No global prefix, but command name "test" is baked in.
 	// by GetEnv as a pseudo-prefix, so annotation is "TEST_PORT".
 	require.NoError(t, Bind(cmd, opts))
 
@@ -215,7 +215,7 @@ func TestSetup_WithAppName_PatchesExistingFlags(t *testing.T) {
 	require.NotEmpty(t, envsBefore)
 	assert.Equal(t, "TEST_PORT", envsBefore[0], "before Setup, env uses command name as prefix")
 
-	// Setup with AppName — on root command, the command name pseudo-prefix
+	// Setup with AppName. On root command, the command name pseudo-prefix
 	// is replaced by the real app prefix: TEST_PORT → MYAPP_PORT.
 	require.NoError(t, Setup(cmd, WithAppName("myapp")))
 
@@ -239,7 +239,7 @@ func TestSetup_WithAppName_BindBeforeSetup_EnvWorks(t *testing.T) {
 		Port int `flag:"port" default:"3000" flagenv:"true"`
 	}{}
 
-	// Bind before Setup (ordering independence — AC3).
+	// Bind before Setup (ordering independence, AC3).
 	require.NoError(t, Bind(cmd, opts))
 	require.NoError(t, Setup(cmd, WithAppName("myapp")))
 
@@ -267,7 +267,7 @@ func TestSetup_WithAppName_SetupBeforeBind_EnvWorks(t *testing.T) {
 		Port int `flag:"port" default:"3000" flagenv:"true"`
 	}{}
 
-	// Setup before Bind (AC4) — prefix is set before Define runs.
+	// Setup before Bind (AC4). Prefix is set before Define runs.
 	require.NoError(t, Setup(cmd, WithAppName("myapp")))
 	require.NoError(t, Bind(cmd, opts))
 
@@ -499,7 +499,7 @@ func TestSetup_WithAppNameAndConfig_FullIntegration(t *testing.T) {
 	assert.Equal(t, "example.com", opts.Host, "config value should be loaded")
 	assert.Equal(t, "MYAPP", EnvPrefix(), "prefix should be set")
 
-	// Verify env annotation was patched — child commands include command name.
+	// Verify env annotation was patched; child commands include command name.
 	f := child.Flags().Lookup("host")
 	require.NotNil(t, f)
 	envs := f.Annotations[internalenv.FlagAnnotation]

--- a/structerr.go
+++ b/structerr.go
@@ -20,7 +20,7 @@ import (
 // These are ONLY used as fallbacks when SetupFlagErrors has not been called
 // (ie. the CLI author did not opt into typed flag error interception).
 // When SetupFlagErrors is active, flag errors are intercepted as typed FlagError
-// via errors.As — no regex needed for those paths.
+// via errors.As, so no regex is needed for those paths.
 var (
 	// "required flag(s) "port" not set" or "required flag(s) "port", "host" not set"
 	reRequiredFlags = regexp.MustCompile(`^required flag\(s\) (.+) not set$`)
@@ -51,7 +51,7 @@ var (
 //
 // When active, cobra's flag parsing errors (invalid values, unknown flags) are
 // wrapped in typed [structclierrors.FlagError] values. [HandleError] then uses
-// errors.As to classify them — no regex parsing at classification time.
+// errors.As to classify them, eliminating regex parsing at classification time.
 //
 // Call this on the root command before Execute():
 //
@@ -78,7 +78,7 @@ func SetupFlagErrors(rootC *cobra.Command) {
 			return structclierrors.NewFlagError(structclierrors.FlagErrorUnknown, m[1], "", err)
 		}
 
-		// Unrecognized flag error — wrap so it's still typed
+		// Unrecognized flag error. Wrap so it's still typed.
 		return structclierrors.NewFlagError(structclierrors.FlagErrorInvalidValue, "", "", err)
 	})
 }
@@ -122,13 +122,13 @@ type Violation struct {
 
 // HandleError classifies err, writes a JSON StructuredError to w, and returns a semantic exit code.
 //
-// The cmd parameter must be the command where the error originated — not the root command.
+// The cmd parameter must be the command where the error originated, not the root command.
 // This is because HandleError looks up flag metadata (type, enum values, env var bindings)
 // from cmd's flag annotations to produce accurate error details. If the root command is
 // passed for a subcommand error, the metadata lookup yields empty results and the output
 // is degraded (no expected type, no enum check, no env var attribution).
 //
-// Use [ExecuteOrExit] to get this right automatically — it uses cobra's ExecuteC to obtain
+// Use [ExecuteOrExit] to get this right automatically. It uses cobra's ExecuteC to obtain
 // the correct command. If calling HandleError directly, use [cobra.Command.ExecuteC]:
 //
 //	cmd, err := rootCmd.ExecuteC()
@@ -218,10 +218,10 @@ func classify(cmd *cobra.Command, err error) *StructuredError {
 		return se
 	}
 
-	// 2. Typed flag errors from SetupFlagErrors (errors.As — no regex needed)
+	// 2. Typed flag errors from SetupFlagErrors (errors.As, no regex needed).
 	// FlagError carries only the flag name, value, and kind. Metadata enrichment
 	// (expected type, enum values, env vars) happens here via the same code path
-	// as the regex fallback — using the correct command from ExecuteC().
+	// as the regex fallback, using the correct command from ExecuteC().
 	var flagErr *structclierrors.FlagError
 	if errors.As(err, &flagErr) {
 		switch flagErr.Kind {
@@ -261,7 +261,7 @@ func classify(cmd *cobra.Command, err error) *StructuredError {
 		}
 	}
 
-	// Unknown command (no typed error possible — cobra creates these inline)
+	// Unknown command (no typed error possible; cobra creates these inline)
 	if m := reUnknownCommand.FindStringSubmatch(errMsg); m != nil {
 		return classifyUnknownCommand(cmd, m[1], cmdPath, errMsg)
 	}
@@ -431,7 +431,7 @@ func classifyMissingRequired(cmd *cobra.Command, cmdPath, flagList, errMsg strin
 		return se
 	}
 
-	// Multiple missing flags — no per-flag enrichment
+	// Multiple missing flags. No per-flag enrichment.
 	return &StructuredError{
 		Error:    "missing_required_flag",
 		ExitCode: exitcode.MissingRequiredFlag,
@@ -443,11 +443,11 @@ func classifyMissingRequired(cmd *cobra.Command, cmdPath, flagList, errMsg strin
 // classifyInvalidArg handles the `invalid argument "val" for "flags" flag:` cobra error.
 // It does source attribution to determine if the bad value came from the CLI, an env var, or config.
 func classifyInvalidArg(cmd *cobra.Command, cmdPath, gotValue, flagSpec, errMsg string) *StructuredError {
-	// flagSpec is like "-p, --port" or "--port" — extract the long name
+	// flagSpec is like "-p, --port" or "--port"; extract the long name.
 	flagName := extractLongFlagName(flagSpec)
 	expected := flagType(cmd, flagName)
 
-	// Check if the flag has enum annotations — if so, this might be an enum violation
+	// Check if the flag has enum annotations. If so, this might be an enum violation.
 	if enumVals := flagEnumValues(cmd, flagName); len(enumVals) > 0 {
 		if !contains(enumVals, gotValue) {
 			return &StructuredError{
@@ -536,7 +536,7 @@ func classifyUnmarshalError(cmd *cobra.Command, cmdPath, errMsg string) *Structu
 	fieldName, gotValue, expectedType := parseDecodeError(errMsg)
 
 	if fieldName == "" {
-		// Can't parse the specific field — treat as a config-origin decode failure.
+		// Can't parse the specific field. Treat as a config-origin decode failure.
 		return &StructuredError{
 			Error:    "config_invalid_value",
 			ExitCode: exitcode.ConfigInvalidValue,
@@ -553,7 +553,7 @@ func classifyUnmarshalError(cmd *cobra.Command, cmdPath, errMsg string) *Structu
 		expectedType = flagType(cmd, flagName)
 	}
 
-	// Check if the flag has enum annotations — if so, this might be an enum violation
+	// Check if the flag has enum annotations. If so, this might be an enum violation.
 	if flagName != "" && gotValue != "" {
 		if enumVals := flagEnumValues(cmd, flagName); len(enumVals) > 0 {
 			if !contains(enumVals, gotValue) {
@@ -595,7 +595,7 @@ func classifyUnmarshalError(cmd *cobra.Command, cmdPath, errMsg string) *Structu
 			}
 	}
 
-	// Not from env — could be from config or default
+	// Not from env; could be from config or default.
 	return &StructuredError{
 		Error:    "config_invalid_value",
 		ExitCode: exitcode.ConfigInvalidValue,

--- a/structerr_test.go
+++ b/structerr_test.go
@@ -318,7 +318,7 @@ func TestHandleError_MissingRequiredFlagWithEnvVarSet(t *testing.T) {
 	_ = cmd.MarkFlagRequired("port")
 	_ = cmd.Flags().SetAnnotation("port", internalenv.FlagAnnotation, []string{"MYCLI_PORT"})
 
-	// Env var IS set with a valid value — cobra still complains because it doesn't check env vars
+	// Env var IS set with a valid value, but cobra still complains because it doesn't check env vars.
 	t.Setenv("MYCLI_PORT", "3000")
 
 	err := fmt.Errorf(`required flag(s) "port" not set`)
@@ -333,7 +333,7 @@ func TestHandleError_MissingRequiredFlagWithEnvVarSet(t *testing.T) {
 	assert.Equal(t, "port", se.Flag)
 	assert.Empty(t, se.EnvVar)
 	assert.Empty(t, se.Hint)
-	// NOT env_invalid_value — the env var value is fine
+	// NOT env_invalid_value; the env var value is fine.
 	assert.NotEqual(t, "env_invalid_value", se.Error)
 }
 
@@ -852,7 +852,7 @@ func TestHandleError_InvalidFlagEnum_ValidValue(t *testing.T) {
 	_ = cmd.Flags().SetAnnotation("priority", flagEnumAnnotation, []string{"1", "2", "3"})
 
 	// Cobra error for invalid argument where "abc" is NOT in enum set
-	// This tests: value not in enum AND type error — enum takes precedence
+	// This tests: value not in enum AND type error. Enum takes precedence.
 	err := fmt.Errorf(`invalid argument "abc" for "--priority" flag: strconv.ParseInt: parsing "abc": invalid syntax`)
 	code := HandleError(cmd, err, &buf)
 
@@ -1173,7 +1173,7 @@ func TestHandleError_InvalidFlagValue_FromEmptyEnvVarRegexFallback(t *testing.T)
 }
 
 func TestHandleError_FlagError_UsesCommandPath(t *testing.T) {
-	// FlagError no longer carries CommandPath — HandleError uses cmd.CommandPath()
+	// FlagError no longer carries CommandPath; HandleError uses cmd.CommandPath().
 	root := &cobra.Command{Use: "myapp"}
 	srv := &cobra.Command{Use: "srv", RunE: func(c *cobra.Command, args []string) error { return nil }}
 	root.AddCommand(srv)

--- a/viper.go
+++ b/viper.go
@@ -169,7 +169,7 @@ func unmarshal(c *cobra.Command, opts any, hooks ...mapstructure.DecodeHookFunc)
 	}
 
 	// Automatically set common options into the context of the cobra command.
-	// Prefer ContextInjector (standalone); fall back to deprecated ContextOptions.
+	// Prefer ContextInjector (standalone); fall back to ContextOptions.
 	if o, ok := opts.(ContextInjector); ok {
 		c.SetContext(o.Context(c.Context()))
 	} else if o, ok := opts.(ContextOptions); ok {
@@ -177,7 +177,7 @@ func unmarshal(c *cobra.Command, opts any, hooks ...mapstructure.DecodeHookFunc)
 	}
 
 	// Automatically transform options if feasible.
-	// Prefer Transformable (standalone); fall back to deprecated TransformableOptions.
+	// Prefer Transformable (standalone); fall back to TransformableOptions.
 	if o, ok := opts.(Transformable); ok {
 		if transformErr := o.Transform(c.Context()); transformErr != nil {
 			return fmt.Errorf("couldn't transform options: %w", transformErr)
@@ -189,7 +189,7 @@ func unmarshal(c *cobra.Command, opts any, hooks ...mapstructure.DecodeHookFunc)
 	}
 
 	// Automatically run options validation if feasible.
-	// Prefer Validatable (standalone); fall back to deprecated ValidatableOptions.
+	// Prefer Validatable (standalone); fall back to ValidatableOptions.
 	if o, ok := opts.(Validatable); ok {
 		if validationErrors := o.Validate(c.Context()); validationErrors != nil {
 			return &structclierrors.ValidationError{


### PR DESCRIPTION
## Description

Two related cleanups across 46 `.go` files:

**Em/en dash removal** — Replace all em dashes (`—`) and en dashes (`–`) with proper English punctuation (periods, semicolons, colons, commas, or rephrasing). En dashes in numeric ranges (e.g., `1–9`) become plain hyphens. Covers source, test, and example files.

**Undeprecate composite interfaces** — Remove `// Deprecated:` markers from `ValidatableOptions`, `TransformableOptions`, and `ContextOptions` in `contract.go`. These interfaces are valid for `Define`/`Unmarshal` workflows and when the type already implements `Options`. Godoc now guides `Bind` users toward the standalone alternatives (`Validatable`, `Transformable`, `ContextInjector`) without marking the composite interfaces as deprecated. The \"fall back to deprecated\" wording in `viper.go` and `define.go` is updated accordingly.

## How to test

```
go build ./...
go test ./...
grep -rn '—\|–' --include='*.go' .  # should return nothing
```