### PR TITLE
feat: add `RegisterType[T]`, `FieldHookProvider`, and `FieldCompleter` APIs

### DIFF
--- a/contract.go
+++ b/contract.go
@@ -3,8 +3,60 @@ package structcli
 import (
 	"context"
 
+	internalhooks "github.com/leodido/structcli/internal/hooks"
 	"github.com/spf13/cobra"
 )
+
+// DefineHookFunc defines how to create a pflag.Value for a custom type
+// during Define/Bind.
+type DefineHookFunc = internalhooks.DefineHookFunc
+
+// DecodeHookFunc defines how to decode a raw value into a custom type
+// during Unmarshal.
+type DecodeHookFunc = internalhooks.DecodeHookFunc
+
+// CompleteHookFunc defines how to provide shell completion candidates
+// for a flag.
+type CompleteHookFunc = internalhooks.CompleteHookFunc
+
+// FieldHook bundles the Define and Decode hooks for a single struct field.
+//
+// Both hooks are optional: if Define is nil the field falls through to the
+// type registry or built-in handling; if Decode is nil the default decode
+// path is used.
+type FieldHook struct {
+	// Define creates the pflag.Value for this field.
+	Define DefineHookFunc
+
+	// Decode converts raw input to the field's type during Unmarshal.
+	Decode DecodeHookFunc
+}
+
+// FieldHookProvider provides per-field Define/Decode hooks.
+//
+// Implement this interface when the same type needs different flag behavior
+// in different fields, or when a standard type needs custom handling for a
+// specific field.
+//
+// Map keys are struct field names (e.g., "ListenAddr", not the flag name
+// "listen"). Unknown keys that do not match any struct field cause an error
+// at Define/Bind time.
+//
+// Precedence: FieldHookProvider > [RegisterType] > built-in registry.
+type FieldHookProvider interface {
+	FieldHooks() map[string]FieldHook
+}
+
+// FieldCompleter provides per-field shell completion hooks.
+//
+// Map keys are struct field names. Works for any field that becomes a flag,
+// not only fields with [FieldHookProvider] hooks.
+//
+// If a completion function is already registered on a flag before Define,
+// structcli preserves it (the FieldCompleter hook is not applied).
+type FieldCompleter interface {
+	CompletionHooks() map[string]CompleteHookFunc
+}
 
 // Options represents a struct that can define command-line flags, env vars, config file keys.
 //

--- a/internal/hooks/complete.go
+++ b/internal/hooks/complete.go
@@ -36,3 +36,12 @@ func StoreCompletionHookFunc(c *cobra.Command, flagName string, completeM reflec
 		panic(fmt.Sprintf("structcli: RegisterFlagCompletionFunc(%q) on just-registered flag: %v", flagName, err))
 	}
 }
+
+// StoreCompletionHookFuncDirect registers a typed completion hook for a flag.
+// Unlike StoreCompletionHookFunc, it calls the function directly without
+// reflect.Value.Call, enabling dead-code elimination.
+func StoreCompletionHookFuncDirect(c *cobra.Command, flagName string, fn CompleteHookFunc) {
+	if err := c.RegisterFlagCompletionFunc(flagName, cobra.CompletionFunc(fn)); err != nil {
+		panic(fmt.Sprintf("structcli: RegisterFlagCompletionFunc(%q) on just-registered flag: %v", flagName, err))
+	}
+}

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -984,3 +984,61 @@ func StoreDecodeHookFunc(c *cobra.Command, flagname string, decodeM reflect.Valu
 		panic(fmt.Sprintf("structcli: SetAnnotation on just-registered flag %q: %v", flagname, err))
 	}
 }
+
+// sanitizeTypeName converts a Go type name to a safe annotation suffix.
+// e.g., "main.HostPort" -> "main_HostPort", "[]byte" -> "_byte"
+func sanitizeTypeName(typeName string) string {
+	r := strings.NewReplacer(
+		".", "_",
+		"[", "_",
+		"]", "",
+		"*", "Ptr",
+		"/", "_",
+	)
+
+	return r.Replace(typeName)
+}
+
+// StoreDecodeHookFuncDirect stores a typed decode hook for a flag.
+// Unlike StoreDecodeHookFunc, it calls the function directly without
+// reflect.Value.Call, enabling dead-code elimination.
+func StoreDecodeHookFuncDirect(c *cobra.Command, flagname string, decodeFn DecodeHookFunc, target reflect.Type) {
+	s := internalscope.Get(c)
+
+	hookFunc := func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if to != target {
+			return data, nil
+		}
+		if from.Kind() != reflect.String {
+			return data, nil
+		}
+
+		return decodeFn(data)
+	}
+
+	k := fmt.Sprintf("customDecodeHook_%s_%s", c.Name(), flagname)
+	s.SetCustomDecodeHook(k, hookFunc)
+
+	if err := c.Flags().SetAnnotation(flagname, FlagDecodeHookAnnotation, []string{k}); err != nil {
+		panic(fmt.Sprintf("structcli: SetAnnotation on just-registered flag %q: %v", flagname, err))
+	}
+}
+
+// RegisterUserDecodeHook registers a user-provided DecodeHookFunc for a type
+// into both decode registries. The annotation name is derived from the type name.
+func RegisterUserDecodeHook(typeName string, fn DecodeHookFunc) {
+	ann := fmt.Sprintf("RegisterTypeTo%sHookFunc", sanitizeTypeName(typeName))
+
+	hook := func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if to.String() != typeName {
+			return data, nil
+		}
+		if from.Kind() != reflect.String {
+			return data, nil
+		}
+
+		return fn(data)
+	}
+
+	RegisterDecodeHook(typeName, ann, hook)
+}

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -492,3 +492,85 @@ func TestStringToIntEnumHookFunc_AliasCollisionPanics(t *testing.T) {
 		})
 	})
 }
+
+func TestStoreDecodeHookFuncDirect_WrapperBehavior(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("mode", "", "mode")
+
+	StoreDecodeHookFuncDirect(
+		cmd,
+		"mode",
+		func(input any) (any, error) {
+			return strings.ToUpper(input.(string)), nil
+		},
+		reflect.TypeOf(""),
+	)
+
+	flag := cmd.Flags().Lookup("mode")
+	require.NotNil(t, flag)
+	annotations := flag.Annotations[FlagDecodeHookAnnotation]
+	require.Len(t, annotations, 1)
+
+	hook, exists := internalscope.Get(cmd).GetCustomDecodeHook(annotations[0])
+	require.True(t, exists)
+	hookFunc := hook.(func(reflect.Type, reflect.Type, any) (any, error))
+
+	// Matching target type: hook is applied
+	out, err := hookFunc(reflect.TypeOf(""), reflect.TypeOf(""), "dev")
+	require.NoError(t, err)
+	assert.Equal(t, "DEV", out)
+
+	// Non-matching target type: passthrough
+	out, err = hookFunc(reflect.TypeOf(""), reflect.TypeOf(int(0)), "dev")
+	require.NoError(t, err)
+	assert.Equal(t, "dev", out)
+}
+
+func TestStoreDecodeHookFuncDirect_PropagatesErrors(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("mode", "", "mode")
+
+	expectedErr := errors.New("boom")
+	StoreDecodeHookFuncDirect(
+		cmd,
+		"mode",
+		func(input any) (any, error) {
+			return nil, expectedErr
+		},
+		reflect.TypeOf(""),
+	)
+
+	flag := cmd.Flags().Lookup("mode")
+	require.NotNil(t, flag)
+	hook, exists := internalscope.Get(cmd).GetCustomDecodeHook(flag.Annotations[FlagDecodeHookAnnotation][0])
+	require.True(t, exists)
+	hookFunc := hook.(func(reflect.Type, reflect.Type, any) (any, error))
+
+	_, err := hookFunc(reflect.TypeOf(""), reflect.TypeOf(""), "dev")
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestRegisterUserDecodeHook(t *testing.T) {
+	snap := SnapshotDecodeRegistries()
+	defer RestoreDecodeRegistries(snap)
+
+	RegisterUserDecodeHook("test.Custom", func(input any) (any, error) {
+		return "decoded:" + input.(string), nil
+	})
+
+	data, ok := DecodeHookRegistry["test.Custom"]
+	require.True(t, ok)
+	assert.Equal(t, "RegisterTypeTotest_CustomHookFunc", data.ann)
+
+	_, ok = AnnotationToDecodeHookRegistry["RegisterTypeTotest_CustomHookFunc"]
+	assert.True(t, ok)
+}
+
+func TestSanitizeTypeName(t *testing.T) {
+	assert.Equal(t, "main_HostPort", sanitizeTypeName("main.HostPort"))
+	assert.Equal(t, "_byte", sanitizeTypeName("[]byte"))
+	assert.Equal(t, "map_stringint", sanitizeTypeName("map[string]int"))
+	assert.Equal(t, "Ptrmain_Foo", sanitizeTypeName("*main.Foo"))
+}
+
+

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -136,6 +136,51 @@ func (suite *structcliSuite) TestStoreCompletionHookFunc_PanicsOnInvalidHookValu
 	)
 }
 
+func (suite *structcliSuite) TestStoreDecodeHookFuncDirect() {
+	cmd := &cobra.Command{Use: "testcmd"}
+	cmd.Flags().String("custom-field", "", "test flag")
+
+	decodeFn := func(input any) (any, error) {
+		return input, nil
+	}
+	targetType := reflect.TypeOf("")
+
+	internalhooks.StoreDecodeHookFuncDirect(cmd, "custom-field", decodeFn, targetType)
+
+	scope := internalscope.Get(cmd)
+	expectedKey := fmt.Sprintf("customDecodeHook_%s_%s", cmd.Name(), "custom-field")
+
+	storedHook, exists := scope.GetCustomDecodeHook(expectedKey)
+	require.True(suite.T(), exists, "Custom decode hook should be stored in scope")
+	assert.NotNil(suite.T(), storedHook, "Stored hook should not be nil")
+
+	flag := cmd.Flags().Lookup("custom-field")
+	require.NotNil(suite.T(), flag, "Flag should exist")
+
+	annotations := flag.Annotations[internalhooks.FlagDecodeHookAnnotation]
+	require.NotNil(suite.T(), annotations, "Flag should have decode hook annotation")
+	require.Len(suite.T(), annotations, 1, "Should have exactly one annotation")
+	assert.Equal(suite.T(), expectedKey, annotations[0], "Annotation should contain the correct key")
+}
+
+func (suite *structcliSuite) TestStoreCompletionHookFuncDirect() {
+	cmd := &cobra.Command{Use: "testcmd"}
+	cmd.Flags().String("mode", "", "test flag")
+
+	completeFn := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"dev", "prod"}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	internalhooks.StoreCompletionHookFuncDirect(cmd, "mode", completeFn)
+
+	completion, exists := cmd.GetFlagCompletionFunc("mode")
+	require.True(suite.T(), exists, "completion function should be registered")
+
+	suggestions, directive := completion(cmd, nil, "")
+	assert.Equal(suite.T(), []string{"dev", "prod"}, suggestions)
+	assert.Equal(suite.T(), cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
 type zapcoreLevelOptions struct {
 	LogLevel zapcore.Level `default:"info" flagdescr:"the logging level" flagenv:"true"`
 }

--- a/register.go
+++ b/register.go
@@ -1,0 +1,47 @@
+package structcli
+
+import (
+	"fmt"
+	"reflect"
+
+	internalhooks "github.com/leodido/structcli/internal/hooks"
+)
+
+// TypeHooks defines custom flag behavior for a type.
+//
+// Define creates the pflag.Value for this type. Called during Define/Bind for
+// each struct field of type T. Receives the specific field's value and metadata.
+//
+// Decode converts raw input (string from env/config) to T during Unmarshal.
+type TypeHooks[T any] struct {
+	Define DefineHookFunc
+	Decode DecodeHookFunc
+}
+
+// RegisterType registers custom flag hooks for type T.
+//
+// After registration, struct fields of type T work without any special tag
+// or interface. The define hook is called once per field during Define/Bind;
+// the decode hook is called during Unmarshal for env/config values.
+//
+// Must be called in init() before any Define/Bind calls.
+// Panics if T is already registered (duplicate or conflict with a built-in).
+// Panics if Define is nil. Panics if Decode is nil.
+func RegisterType[T any](hooks TypeHooks[T]) {
+	typeName := reflect.TypeFor[T]().String()
+
+	if hooks.Define == nil {
+		panic(fmt.Sprintf("structcli: RegisterType[%s]: Define hook must not be nil", typeName))
+	}
+	if hooks.Decode == nil {
+		panic(fmt.Sprintf("structcli: RegisterType[%s]: Decode hook must not be nil", typeName))
+	}
+
+	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
+		panic(fmt.Sprintf("structcli: RegisterType[%s]: type is already registered", typeName))
+	}
+
+	internalhooks.DefineHookRegistry[typeName] = hooks.Define
+
+	internalhooks.RegisterUserDecodeHook(typeName, hooks.Decode)
+}

--- a/register_test.go
+++ b/register_test.go
@@ -1,0 +1,88 @@
+package structcli
+
+import (
+	"reflect"
+	"testing"
+
+	internalhooks "github.com/leodido/structcli/internal/hooks"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testCustomType struct{ val string }
+
+func TestRegisterType_Success(t *testing.T) {
+	snap := internalhooks.SnapshotDecodeRegistries()
+	defer func() {
+		internalhooks.RestoreDecodeRegistries(snap)
+		delete(internalhooks.DefineHookRegistry, reflect.TypeFor[testCustomType]().String())
+	}()
+
+	RegisterType(TypeHooks[testCustomType]{
+		Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+			return nil, descr
+		},
+		Decode: func(input any) (any, error) {
+			return testCustomType{val: input.(string)}, nil
+		},
+	})
+
+	typeName := reflect.TypeFor[testCustomType]().String()
+
+	// Verify define hook registered
+	defineHook, ok := internalhooks.DefineHookRegistry[typeName]
+	require.True(t, ok, "define hook should be registered")
+	assert.NotNil(t, defineHook)
+
+	// Verify decode hook registered
+	_, ok = internalhooks.DecodeHookRegistry[typeName]
+	assert.True(t, ok, "decode hook should be registered")
+}
+
+func TestRegisterType_PanicsOnNilDefine(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"structcli: RegisterType[structcli.testCustomType]: Define hook must not be nil",
+		func() {
+			RegisterType(TypeHooks[testCustomType]{
+				Define: nil,
+				Decode: func(input any) (any, error) { return input, nil },
+			})
+		},
+	)
+}
+
+func TestRegisterType_PanicsOnNilDecode(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"structcli: RegisterType[structcli.testCustomType]: Decode hook must not be nil",
+		func() {
+			RegisterType(TypeHooks[testCustomType]{
+				Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+					return nil, descr
+				},
+				Decode: nil,
+			})
+		},
+	)
+}
+
+func TestRegisterType_PanicsOnDuplicate(t *testing.T) {
+	snap := internalhooks.SnapshotDecodeRegistries()
+	defer func() {
+		internalhooks.RestoreDecodeRegistries(snap)
+		delete(internalhooks.DefineHookRegistry, reflect.TypeFor[testCustomType]().String())
+	}()
+
+	hooks := TypeHooks[testCustomType]{
+		Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+			return nil, descr
+		},
+		Decode: func(input any) (any, error) { return input, nil },
+	}
+
+	RegisterType(hooks)
+
+	assert.Panics(t, func() {
+		RegisterType(hooks)
+	}, "duplicate registration should panic")
+}


### PR DESCRIPTION
## Description

Add the new type hook infrastructure for DCE-compatible custom type handling. This is **additive only** — the existing `MethodByName` dispatch path is unchanged and all existing tests pass.

New public API surface:
- `RegisterType[T](TypeHooks[T])` — per-type Define/Decode registration in `init()`
- `FieldHookProvider` interface — per-field Define/Decode hooks via `FieldHooks() map[string]FieldHook`
- `FieldCompleter` interface — per-field completion hooks via `CompletionHooks() map[string]CompleteHookFunc`
- `DefineHookFunc`, `DecodeHookFunc`, `CompleteHookFunc` type aliases re-exported from `contract.go`

New internal functions:
- `StoreDecodeHookFuncDirect` — typed decode hook storage (no `reflect.Value.Call`)
- `StoreCompletionHookFuncDirect` — typed completion hook storage
- `RegisterUserDecodeHook` — wraps user `DecodeHookFunc` into `mapstructure.DecodeHookFunc`

## How to test

```
go test ./... -count=1 -race
```

New tests:
- `TestRegisterType_Success`, `TestRegisterType_PanicsOnNilDefine`, `TestRegisterType_PanicsOnNilDecode`, `TestRegisterType_PanicsOnDuplicate`
- `TestStoreDecodeHookFuncDirect`, `TestStoreCompletionHookFuncDirect`
- `TestStoreDecodeHookFuncDirect_WrapperBehavior`, `TestStoreDecodeHookFuncDirect_PropagatesErrors`
- `TestRegisterUserDecodeHook`, `TestSanitizeTypeName`