### PR TITLE
feat!: remove `MethodByName`, wire `FieldHookProvider`/`RegisterType` 

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -1,5 +1,11 @@
 package structcli
 
+import (
+	"reflect"
+
+	internalhooks "github.com/leodido/structcli/internal/hooks"
+)
+
 // Byte-related type contract:
 //   - []byte keeps raw textual bytes semantics.
 //   - Hex opts into hex-encoded textual input.
@@ -13,3 +19,15 @@ type Hex []byte
 
 // Base64 represents binary data provided as base64-encoded textual input.
 type Base64 []byte
+
+func init() {
+	hexType := reflect.TypeFor[Hex]()
+	internalhooks.DefineHookRegistry[hexType] = internalhooks.DefineHexBytesHookFunc()
+	internalhooks.RegisterDecodeHook(hexType, "StringToHexHookFunc",
+		internalhooks.StringToNamedBytesHookFunc(hexType, internalhooks.DecodeHexBytes))
+
+	b64Type := reflect.TypeFor[Base64]()
+	internalhooks.DefineHookRegistry[b64Type] = internalhooks.DefineBase64BytesHookFunc()
+	internalhooks.RegisterDecodeHook(b64Type, "StringToBase64HookFunc",
+		internalhooks.StringToNamedBytesHookFunc(b64Type, internalhooks.DecodeBase64Bytes))
+}

--- a/contract.go
+++ b/contract.go
@@ -21,9 +21,9 @@ type CompleteHookFunc = internalhooks.CompleteHookFunc
 
 // FieldHook bundles the Define and Decode hooks for a single struct field.
 //
-// Both hooks are optional: if Define is nil the field falls through to the
-// type registry or built-in handling; if Decode is nil the default decode
-// path is used.
+// If Define is nil, the field falls through to the type registry or built-in
+// handling. If Decode is nil, the default decode path is used.
+// Setting Decode without Define is an error (caught at Define/Bind time).
 type FieldHook struct {
 	// Define creates the pflag.Value for this field.
 	Define DefineHookFunc

--- a/define.go
+++ b/define.go
@@ -225,6 +225,14 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			continue
 		}
 
+		// Reject removed flagcustom tag with a migration message.
+		if f.Tag.Get("flagcustom") != "" {
+			return fmt.Errorf(
+				"field %q: flagcustom tag is no longer supported; use RegisterType[T] for per-type hooks or implement FieldHookProvider for per-field hooks",
+				f.Name,
+			)
+		}
+
 		short := f.Tag.Get("flagshort")
 		defval := f.Tag.Get("default")
 		descr := f.Tag.Get("flagdescr")
@@ -452,8 +460,8 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 
 		// Check registry for known custom types (RegisterType, RegisterEnum, built-ins).
 		if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
-			if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
-				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
+			if !internalhooks.InferDecodeHooks(c, name, f.Type) {
+				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type)
 			}
 
 			finalizeFieldDefinition()
@@ -572,8 +580,8 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				ref := field.Addr().Interface().(*[]int)
 				c.Flags().IntSliceVarP(ref, name, short, val, descr)
 			}
-			if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
-				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
+			if !internalhooks.InferDecodeHooks(c, name, f.Type) {
+				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type)
 			}
 
 		default:

--- a/define.go
+++ b/define.go
@@ -152,7 +152,36 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 	if !val.IsValid() {
 		val = internalreflect.GetValue(internalreflect.GetValuePtr(o).Interface())
 	}
-	structPtr := internalreflect.GetValuePtr(o)
+	// Resolve per-field hooks from interfaces (no MethodByName).
+	var fieldHooks map[string]FieldHook
+	if fhp, ok := o.(FieldHookProvider); ok {
+		fieldHooks = fhp.FieldHooks()
+	}
+	var completionHooks map[string]CompleteHookFunc
+	if fc, ok := o.(FieldCompleter); ok {
+		completionHooks = fc.CompletionHooks()
+	}
+
+	// Validate hook map keys against actual struct fields.
+	if len(fieldHooks) > 0 || len(completionHooks) > 0 {
+		fieldNames := make(map[string]bool, val.NumField())
+		for i := range val.NumField() {
+			fieldNames[val.Type().Field(i).Name] = true
+		}
+		for key, fh := range fieldHooks {
+			if !fieldNames[key] {
+				return fmt.Errorf("FieldHookProvider: key %q does not match any struct field in %s", key, val.Type().Name())
+			}
+			if fh.Define == nil && fh.Decode != nil {
+				return fmt.Errorf("FieldHookProvider: key %q has Decode without Define (Define is required when Decode is set)", key)
+			}
+		}
+		for key := range completionHooks {
+			if !fieldNames[key] {
+				return fmt.Errorf("FieldCompleter: key %q does not match any struct field in %s", key, val.Type().Name())
+			}
+		}
+	}
 
 	for i := range val.NumField() {
 		field := val.Field(i)
@@ -244,9 +273,10 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 		// Lint: suggest flagenv:"only" when flaghidden:"true" + flagenv:"true" is used
 		// without any flag-specific tags that would be incompatible with flagenv:"only".
 		if hidden && envMode == internalenv.EnvOn && kind != reflect.Struct {
-			custom, _ := strconv.ParseBool(f.Tag.Get("flagcustom"))
 			flagType := f.Tag.Get("flagtype")
-			if short == "" && len(presets) == 0 && flagType == "" && !custom {
+			fh, hasFieldHook := fieldHooks[f.Name]
+			hasDefineHook := hasFieldHook && fh.Define != nil
+			if short == "" && len(presets) == 0 && flagType == "" && !hasDefineHook {
 				fmt.Fprintf(c.ErrOrStderr(),
 					"structcli: field '%s': flaghidden:\"true\" + flagenv:\"true\" can be replaced with flagenv:\"only\" (which also rejects CLI input)\n",
 					f.Name,
@@ -380,14 +410,16 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 				mustSetAnnotation(fs, name, internalenv.FlagEnvOnlyAnnotation, []string{"true"})
 			}
 			applyPresetAliases()
-			completeHookName := fmt.Sprintf("Complete%s", f.Name)
-			completeHookFunc := structPtr.MethodByName(completeHookName)
-			if completeHookFunc.IsValid() {
-				if _, exists := c.GetFlagCompletionFunc(name); !exists {
-					internalhooks.StoreCompletionHookFunc(c, name, completeHookFunc)
+			// Register per-field completion hook from FieldCompleter interface.
+			// Skipped for envOnly fields: hidden flags have no CLI completion.
+			if !envOnly {
+				if completeHook, ok := completionHooks[f.Name]; ok {
+					if _, exists := c.GetFlagCompletionFunc(name); !exists {
+						internalhooks.StoreCompletionHookFuncDirect(c, name, completeHook)
+					}
 				}
 			}
-			// Auto-register enum completion when no explicit Complete hook exists
+			// Auto-register enum completion when no explicit completion hook exists.
 			if _, exists := c.GetFlagCompletionFunc(name); !exists {
 				if fl := c.Flags().Lookup(name); fl != nil {
 					if ev, ok := fl.Value.(EnumValuer); ok {
@@ -402,56 +434,23 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			}
 		}
 
-		// Flags with `flagcustom:"true"` tag (validation already done)
-		custom, _ := strconv.ParseBool(f.Tag.Get("flagcustom"))
-		if custom && kind != reflect.Struct {
-			defineHookName := fmt.Sprintf("Define%s", f.Name)
-			decodeHookName := fmt.Sprintf("Decode%s", f.Name)
+		// Per-field hooks from FieldHookProvider take highest precedence.
+		if fh, ok := fieldHooks[f.Name]; ok && kind != reflect.Struct {
+			if fh.Define != nil {
+				returnedValue, returnedUsage := fh.Define(name, short, descr, f, field)
+				c.Flags().VarP(returnedValue, name, short, returnedUsage)
 
-			if structPtr.IsValid() {
-				defineHookFunc := structPtr.MethodByName(defineHookName)
-				decodeHookFunc := structPtr.MethodByName(decodeHookName)
-
-				if defineHookFunc.IsValid() {
-					// Call user's define hook
-					results := defineHookFunc.Call([]reflect.Value{
-						reflect.ValueOf(name),
-						reflect.ValueOf(short),
-						reflect.ValueOf(descr),
-						reflect.ValueOf(f),
-						reflect.ValueOf(field),
-					})
-
-					returnedValue := results[0].Interface().(pflag.Value)
-					returnedUsage := results[1].Interface().(string)
-					c.Flags().VarP(returnedValue, name, short, returnedUsage)
-
-					// Register user's decode hook (`Unmarshal` will call it)
-					internalhooks.StoreDecodeHookFunc(c, name, decodeHookFunc, f.Type)
-
-					finalizeFieldDefinition()
-
-					continue
-				}
-				// The users set `flagcustom:"true"` but they didn't define a custom define hook
-				// We fallback to look up the hooks registries to avoid erroring out
-				if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
-				// Best-effort: attach a decode hook if one exists, but don't
-					// hard-error when missing. This is a fallback path, not a
-					// mandatory one like the other two call sites.
-					internalhooks.InferDecodeHooks(c, name, f.Type.String())
-
-					finalizeFieldDefinition()
-
-					continue
+				if fh.Decode != nil {
+					internalhooks.StoreDecodeHookFuncDirect(c, name, fh.Decode, f.Type)
 				}
 
-				// This should never happen since validation would have caught missing hooks
-				return fmt.Errorf("internal error: custom flag %s passed validation but no hooks found", f.Name)
+				finalizeFieldDefinition()
+
+				continue
 			}
 		}
 
-		// Check registry for known custom types
+		// Check registry for known custom types (RegisterType, RegisterEnum, built-ins).
 		if internalhooks.InferDefineHooks(c, name, short, descr, f, field) {
 			if !internalhooks.InferDecodeHooks(c, name, f.Type.String()) {
 				return fmt.Errorf("internal error: missing decode hook for built-in type %s", f.Type.String())
@@ -462,7 +461,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 			continue
 		}
 
-		// Skip custom types that aren't in registry
+		// Non-standard types without registry hooks or per-field hooks are skipped.
 		if !internaltag.IsStandardType(f.Type) && kind != reflect.Struct && kind != reflect.Slice {
 			continue
 		}

--- a/define_test.go
+++ b/define_test.go
@@ -3544,3 +3544,20 @@ func (suite *structcliSuite) TestDefine_FieldHookProvider_RejectsDecodeWithoutDe
 	assert.Contains(suite.T(), err.Error(), "Decode without Define")
 }
 
+// flagcustomOptions uses the removed flagcustom tag.
+type flagcustomOptions struct {
+	Token string `flag:"token" flagdescr:"API token" flagcustom:"true"`
+}
+
+func (o *flagcustomOptions) Attach(c *cobra.Command) error { return nil }
+
+func (suite *structcliSuite) TestDefine_RejectsFlagcustomTag() {
+	opts := &flagcustomOptions{}
+	cmd := &cobra.Command{Use: "test"}
+	err := Define(cmd, opts)
+	require.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "flagcustom tag is no longer supported")
+	assert.Contains(suite.T(), err.Error(), "RegisterType")
+	assert.Contains(suite.T(), err.Error(), "FieldHookProvider")
+}
+

--- a/define_test.go
+++ b/define_test.go
@@ -12,8 +12,6 @@ import (
 
 	structclierrors "github.com/leodido/structcli/errors"
 	internalenv "github.com/leodido/structcli/internal/env"
-	internalhooks "github.com/leodido/structcli/internal/hooks"
-	internalreflect "github.com/leodido/structcli/internal/reflect"
 	internalusage "github.com/leodido/structcli/internal/usage"
 	"github.com/leodido/structcli/values"
 	"github.com/spf13/cobra"
@@ -274,18 +272,23 @@ func (suite *structcliSuite) TestDefine_CountFlagSupport() {
 }
 
 type gotoCustomHookOptions struct {
-	Mode string `flagcustom:"true" flag:"mode" default:"dev" flagenv:"true" flaggroup:"Config" flagrequired:"true" flagdescr:"custom mode"`
+	Mode string `flag:"mode" default:"dev" flagenv:"true" flaggroup:"Config" flagrequired:"true" flagdescr:"custom mode"`
 }
 
-func (o *gotoCustomHookOptions) DefineMode(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "dev"
+func (o *gotoCustomHookOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"Mode": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = "dev"
 
-	return values.NewString(fieldPtr), descr + " (dev,staging,prod)"
-}
-
-func (o *gotoCustomHookOptions) DecodeMode(input any) (any, error) {
-	return input, nil
+				return values.NewString(fieldPtr), descr + " (dev,staging,prod)"
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+	}
 }
 
 func (o gotoCustomHookOptions) Attach(c *cobra.Command) error       { return nil }
@@ -437,44 +440,51 @@ const (
 
 type comprehensiveCustomOptions struct {
 	LogLevel   zapcore.Level `flagdescr:"log level"`
-	ServerMode serverMode    `flagcustom:"true" flag:"server-mode" flagshort:"m" flagdescr:"set server mode"`
-	SomeConfig string        `flagcustom:"true" flag:"some-config" flagshort:"c" flagdescr:"config file path"`
+	ServerMode serverMode    `flag:"server-mode" flagshort:"m" flagdescr:"set server mode"`
+	SomeConfig string        `flag:"some-config" flagshort:"c" flagdescr:"config file path"`
 	NormalFlag string        `flag:"normal-flag" flagdescr:"normal description"`
 }
 
-func (o *comprehensiveCustomOptions) DefineServerMode(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	enhancedDesc := descr + fmt.Sprintf(" (%s,%s,%s)", string(development), string(staging), string(production))
-	fieldPtr := fieldValue.Addr().Interface().(*serverMode)
-	*fieldPtr = development // Set default
+func (o *comprehensiveCustomOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"ServerMode": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				enhancedDesc := descr + fmt.Sprintf(" (%s,%s,%s)", string(development), string(staging), string(production))
+				fieldPtr := fieldValue.Addr().Interface().(*serverMode)
+				*fieldPtr = development // Set default
 
-	// Since serverMode is fundamentally a string, we can wrap it.
-	return values.NewString((*string)(fieldPtr)), enhancedDesc
+				return values.NewString((*string)(fieldPtr)), enhancedDesc
+			},
+			Decode: func(input any) (any, error) {
+				s := serverMode(input.(string))
+
+				return s, nil
+			},
+		},
+		"SomeConfig": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				enhancedDesc := descr + " (must be .yaml, .yml, or .json)"
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = "" // default
+
+				return values.NewString(fieldPtr), enhancedDesc
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+	}
 }
 
-func (o *comprehensiveCustomOptions) DecodeServerMode(input any) (any, error) {
-	s := serverMode(input.(string))
-
-	return s, nil
-}
-
-func (o *comprehensiveCustomOptions) CompleteServerMode(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{string(development), string(staging), string(production)}, cobra.ShellCompDirectiveDefault
-}
-
-func (o *comprehensiveCustomOptions) DefineSomeConfig(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	enhancedDesc := descr + " (must be .yaml, .yml, or .json)"
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "" // default
-
-	return values.NewString(fieldPtr), enhancedDesc
-}
-
-func (o *comprehensiveCustomOptions) DecodeSomeConfig(input any) (any, error) {
-	return input, nil
-}
-
-func (o *comprehensiveCustomOptions) CompleteSomeConfig(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"yaml", "yml", "json"}, cobra.ShellCompDirectiveFilterFileExt
+func (o *comprehensiveCustomOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"ServerMode": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{string(development), string(staging), string(production)}, cobra.ShellCompDirectiveDefault
+		},
+		"SomeConfig": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"yaml", "yml", "json"}, cobra.ShellCompDirectiveFilterFileExt
+		},
+	}
 }
 
 func (o *comprehensiveCustomOptions) Attach(c *cobra.Command) error {
@@ -533,8 +543,12 @@ type autoCompleteOptions struct {
 
 func (o *autoCompleteOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *autoCompleteOptions) CompleteRegion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"us-east-1", "us-west-2"}, cobra.ShellCompDirectiveNoFileComp
+func (o *autoCompleteOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"Region": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"us-east-1", "us-west-2"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_AutoRegistersCompletionForStandardFlags() {
@@ -557,8 +571,12 @@ type builtInCompletionOptions struct {
 
 func (o *builtInCompletionOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *builtInCompletionOptions) CompleteLogLevel(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"debug", "info", "warn", "error"}, cobra.ShellCompDirectiveNoFileComp
+func (o *builtInCompletionOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"LogLevel": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"debug", "info", "warn", "error"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_AutoRegistersCompletionForBuiltInHookFlags() {
@@ -579,8 +597,12 @@ type nestedCompletionChild struct {
 	Profile string `flag:"profile"`
 }
 
-func (o *nestedCompletionChild) CompleteProfile(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"default", "strict"}, cobra.ShellCompDirectiveNoFileComp
+func (o *nestedCompletionChild) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"Profile": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"default", "strict"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 type nestedCompletionOptions struct {
@@ -609,8 +631,12 @@ type manualCompletionPrecedenceOptions struct {
 
 func (o *manualCompletionPrecedenceOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *manualCompletionPrecedenceOptions) CompleteMode(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"hook"}, cobra.ShellCompDirectiveNoFileComp
+func (o *manualCompletionPrecedenceOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"Mode": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"hook"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_DoesNotOverrideExistingFlagCompletion() {
@@ -652,12 +678,15 @@ type ignoreCompletionOptions struct {
 
 func (o *ignoreCompletionOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *ignoreCompletionOptions) CompleteHidden(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"should-not-register"}, cobra.ShellCompDirectiveNoFileComp
-}
-
-func (o *ignoreCompletionOptions) CompleteVisible(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"register-me"}, cobra.ShellCompDirectiveNoFileComp
+func (o *ignoreCompletionOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"Hidden": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"should-not-register"}, cobra.ShellCompDirectiveNoFileComp
+		},
+		"Visible": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"register-me"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_DoesNotRegisterCompletionForIgnoredFlags() {
@@ -684,8 +713,12 @@ type presetCompletionOptions struct {
 
 func (o *presetCompletionOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *presetCompletionOptions) CompleteLevel(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"1", "5", "10"}, cobra.ShellCompDirectiveNoFileComp
+func (o *presetCompletionOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"Level": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"1", "5", "10"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_RegistersCompletionOnlyForCanonicalFlagWithPresets() {
@@ -716,12 +749,16 @@ type completionForwardingOptions struct {
 
 func (o *completionForwardingOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *completionForwardingOptions) CompleteTarget(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	o.seenCommandUse = cmd.Use
-	o.seenArgs = append([]string{}, args...)
-	o.seenToComplete = toComplete
+func (o *completionForwardingOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"Target": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			o.seenCommandUse = cmd.Use
+			o.seenArgs = append([]string{}, args...)
+			o.seenToComplete = toComplete
 
-	return []string{"ok"}, cobra.ShellCompDirectiveNoFileComp
+			return []string{"ok"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_ForwardsCompletionInvocationArguments() {
@@ -742,26 +779,6 @@ func (suite *structcliSuite) TestDefine_ForwardsCompletionInvocationArguments() 
 
 type nestedStruct struct {
 	Value string `flagdescr:"nested value"`
-}
-
-type structFieldOptions struct {
-	Nest         nestedStruct `flagcustom:"true"`
-	methodCalled bool
-}
-
-func (o *structFieldOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestFlagcustom_EdgeCases() {
-	// Test struct fields (should be ignored)
-	structOpts := &structFieldOptions{}
-	c1 := &cobra.Command{Use: "test1"}
-	err := Define(c1, structOpts)
-
-	require.Error(suite.T(), err, "custom methods should not be called for struct fields")
-	require.ErrorIs(suite.T(), err, structclierrors.ErrInvalidTagUsage)
-	require.Contains(suite.T(), err.Error(), "cannot be used on struct types")
-	assert.Contains(suite.T(), err.Error(), "Nest")
-	assert.False(suite.T(), structOpts.methodCalled, "custom methods should not be called for struct fields")
 }
 
 type envAnnotationsTestOptions struct {
@@ -1210,178 +1227,7 @@ func (suite *structcliSuite) TestDefine_CanAddrValidation() {
 	})
 }
 
-type flagCustomTestOptions struct {
-	ValidCustom   string `flagcustom:"true" flag:"valid-custom" flagdescr:"should use custom handler"`
-	InvalidCustom string `flagcustom:"invalid" flag:"invalid-custom" flagdescr:"has invalid flagcustom value"`
-	EmptyCustom   string `flagcustom:"" flag:"empty-custom" flagdescr:"has empty flagcustom value"`
-	FalseCustom   string `flagcustom:"false" flag:"false-custom" flagdescr:"explicitly false custom"`
-	NormalField   string `flag:"normal" flagdescr:"normal field without flagcustom"`
-}
 
-func (o *flagCustomTestOptions) DefineValidCustom(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_DEFAULT"
-
-	return values.NewString(fieldPtr), descr + " [CUSTOM]"
-}
-
-func (o *flagCustomTestOptions) DecodeValidCustom(input any) (any, error) {
-	return input, nil
-}
-
-func (o *flagCustomTestOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestFlagCustom_ShouldReturnError() {
-	opts := &flagCustomTestOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	err := Define(cmd, opts)
-
-	assert.Error(suite.T(), err, "Should return error for invalid flagcustom value")
-	assert.Contains(suite.T(), err.Error(), "flagcustom", "Error should mention flagcustom")
-	assert.Contains(suite.T(), err.Error(), "invalid", "Error should mention the invalid value")
-	assert.Contains(suite.T(), err.Error(), "InvalidCustom", "Error should mention the field name")
-}
-
-type validFlagCustomOptions struct {
-	TrueCustom  string `flagcustom:"true" flag:"true-custom" flagdescr:"should use custom"`
-	FalseCustom string `flagcustom:"false" flag:"false-custom" flagdescr:"should not use custom"`
-	EmptyCustom string `flagcustom:"" flag:"empty-custom" flagdescr:"should not use custom"`
-	NoCustom    string `flag:"no-custom" flagdescr:"should not use custom"`
-}
-
-func (o *validFlagCustomOptions) DefineTrueCustom(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_VALUE"
-	return values.NewString(fieldPtr), descr + " [CUSTOM]"
-}
-
-func (o *validFlagCustomOptions) DecodeTrueCustom(input any) (any, error) {
-	return input, nil
-}
-
-func (o *validFlagCustomOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestFlagCustom_ValidValues() {
-	opts := &validFlagCustomOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	err := Define(cmd, opts)
-
-	require.NoError(suite.T(), err, "Should not return error for valid flagcustom values")
-
-	// Check that flags are created correctly
-	trueFlag := cmd.Flags().Lookup("true-custom")
-	falseFlag := cmd.Flags().Lookup("false-custom")
-	emptyFlag := cmd.Flags().Lookup("empty-custom")
-	noFlag := cmd.Flags().Lookup("no-custom")
-
-	// Only the true custom should use custom handler
-	assert.Equal(suite.T(), "CUSTOM_VALUE", trueFlag.DefValue, "flagcustom='true' should use custom handler")
-	assert.NotEqual(suite.T(), "CUSTOM_VALUE", falseFlag.DefValue, "flagcustom='false' should not use custom handler")
-	assert.NotEqual(suite.T(), "CUSTOM_VALUE", emptyFlag.DefValue, "flagcustom='' should not use custom handler")
-	assert.NotEqual(suite.T(), "CUSTOM_VALUE", noFlag.DefValue, "no flagcustom should not use custom handler")
-}
-
-type flagCustomEdgeCasesOptions struct {
-	CaseTrue   string `flagcustom:"True" flag:"case-true" flagdescr:"capital True"`
-	CaseFalse  string `flagcustom:"FALSE" flag:"case-false" flagdescr:"capital FALSE"`
-	NumberOne  string `flagcustom:"1" flag:"number-one" flagdescr:"number 1"`
-	NumberZero string `flagcustom:"0" flag:"number-zero" flagdescr:"number 0"`
-	WithSpaces string `flagcustom:" true " flag:"with-spaces" flagdescr:"spaces around true"`
-}
-
-func (o *flagCustomEdgeCasesOptions) DefineCaseTrue(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_TRUE"
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *flagCustomEdgeCasesOptions) DecodeCaseTrue(input any) (any, error) {
-	return input, nil
-}
-
-func (o *flagCustomEdgeCasesOptions) DefineNumberOne(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_ONE"
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *flagCustomEdgeCasesOptions) DecodeNumberOne(input any) (any, error) {
-	return input, nil
-}
-
-func (o *flagCustomEdgeCasesOptions) Attach(c *cobra.Command) error { return nil }
-
-type validEdgeCasesOptions struct {
-	CaseTrue   string `flagcustom:"True" flag:"case-true" flagdescr:"capital True"`
-	CaseFalse  string `flagcustom:"FALSE" flag:"case-false" flagdescr:"capital FALSE"`
-	NumberOne  string `flagcustom:"1" flag:"number-one" flagdescr:"number 1"`
-	NumberZero string `flagcustom:"0" flag:"number-zero" flagdescr:"number 0"`
-}
-
-func (o *validEdgeCasesOptions) DefineCaseTrue(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_TRUE"
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *validEdgeCasesOptions) DecodeCaseTrue(input any) (any, error) {
-	return input, nil
-}
-
-func (o *validEdgeCasesOptions) DefineNumberOne(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_ONE"
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *validEdgeCasesOptions) DecodeNumberOne(input any) (any, error) {
-	return input, nil
-}
-
-func (o *validEdgeCasesOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestFlagCustom_EdgeCases_ValidValues() {
-	opts := &validEdgeCasesOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// These should all pass validation because strconv.ParseBool handles them.
-	err := Define(cmd, opts)
-	require.NoError(suite.T(), err, "Should not return error for valid edge case values")
-
-	// Check behavior
-	caseTrueFlag := cmd.Flags().Lookup("case-true")
-	caseFalseFlag := cmd.Flags().Lookup("case-false")
-	numberOneFlag := cmd.Flags().Lookup("number-one")
-	numberZeroFlag := cmd.Flags().Lookup("number-zero")
-
-	// The custom Define hook should be called for "True" and "1"
-	require.NotNil(suite.T(), caseTrueFlag)
-	assert.Equal(suite.T(), "CUSTOM_TRUE", caseTrueFlag.DefValue, "ParseBool should accept 'True'")
-	require.NotNil(suite.T(), numberOneFlag)
-	assert.Equal(suite.T(), "CUSTOM_ONE", numberOneFlag.DefValue, "ParseBool should accept '1' as true")
-
-	// No custom hook should be called for "FALSE" and "0", so regular flags are created.
-	require.NotNil(suite.T(), caseFalseFlag)
-	assert.NotEqual(suite.T(), "CUSTOM_TRUE", caseFalseFlag.DefValue, "ParseBool should accept 'FALSE' as false")
-	require.NotNil(suite.T(), numberZeroFlag)
-	assert.NotEqual(suite.T(), "CUSTOM_ONE", numberZeroFlag.DefValue, "ParseBool should accept '0' as false")
-}
-
-func (suite *structcliSuite) TestFlagCustom_EdgeCases_ShouldReturnError() {
-	opts := &flagCustomEdgeCasesOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// The " true " value with spaces should cause a validation error.
-	err := Define(cmd, opts)
-
-	// These assertions remain correct.
-	assert.Error(suite.T(), err, "Should return error for flagcustom value with spaces")
-	assert.Contains(suite.T(), err.Error(), "flagcustom", "Error should mention flagcustom")
-	assert.Contains(suite.T(), err.Error(), " true ", "Error should mention the invalid value with spaces")
-	assert.Contains(suite.T(), err.Error(), "WithSpaces", "Error should mention the field name")
-}
 
 type flagEnvTestOptions struct {
 	ValidEnv   string `flagenv:"true" flag:"valid-env" flagdescr:"should have env binding"`
@@ -1544,32 +1390,37 @@ func (suite *structcliSuite) TestFlagenv_MultipleInvalid_ReturnsFirstError() {
 }
 
 type flagEnvCombinedOptions struct {
-	EnvWithCustom   string `flagenv:"true" flagcustom:"true" flag:"env-custom" flagdescr:"env with custom"`
+	EnvWithCustom   string `flagenv:"true" flag:"env-custom" flagdescr:"env with custom"`
 	EnvWithRequired string `flagenv:"true" flagrequired:"true" flag:"env-required" flagdescr:"env with required"`
 	EnvWithGroup    string `flagenv:"true" flaggroup:"TestGroup" flag:"env-group" flagdescr:"env with group"`
-	InvalidEnvValid string `flagenv:"invalid" flagcustom:"true" flag:"invalid-env-valid" flagdescr:"invalid env with valid custom"`
+	InvalidEnvValid string `flagenv:"invalid" flag:"invalid-env-valid" flagdescr:"invalid env with valid custom"`
 }
 
-func (o *flagEnvCombinedOptions) DefineEnvWithCustom(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_DEFAULT"
+func (o *flagEnvCombinedOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"EnvWithCustom": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = "CUSTOM_DEFAULT"
 
-	return values.NewString(fieldPtr), descr + " [CUSTOM]"
-}
+				return values.NewString(fieldPtr), descr + " [CUSTOM]"
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+		"InvalidEnvValid": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = "INVALID"
 
-func (o *flagEnvCombinedOptions) DecodeEnvWithCustom(input any) (any, error) {
-	return input, nil
-}
-
-func (o *flagEnvCombinedOptions) DefineInvalidEnvValid(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "INVALID"
-
-	return values.NewString(fieldPtr), descr + " [INVALID]"
-}
-
-func (o *flagEnvCombinedOptions) DecodeInvalidEnvValid(input any) (any, error) {
-	return input, nil
+				return values.NewString(fieldPtr), descr + " [INVALID]"
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+	}
 }
 
 func (o *flagEnvCombinedOptions) Attach(c *cobra.Command) error { return nil }
@@ -1589,20 +1440,25 @@ func (suite *structcliSuite) TestFlagenv_CombinedWithOtherTags_FailureCase() {
 }
 
 type validFlagEnvInteractionOptions struct {
-	EnvWithCustom   string `flagenv:"true" flagcustom:"true" flag:"env-with-custom"`
+	EnvWithCustom   string `flagenv:"true" flag:"env-with-custom"`
 	EnvWithRequired string `flagenv:"true" flagrequired:"true" flag:"env-with-required"`
 	EnvWithGroup    string `flagenv:"true" flaggroup:"TestGroup" flag:"env-with-group"`
 }
 
-func (o *validFlagEnvInteractionOptions) DefineEnvWithCustom(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "custom"
+func (o *validFlagEnvInteractionOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"EnvWithCustom": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = "custom"
 
-	return values.NewString(fieldPtr), "custom usage"
-}
-
-func (o *validFlagEnvInteractionOptions) DecodeEnvWithCustom(input any) (any, error) {
-	return input, nil
+				return values.NewString(fieldPtr), "custom usage"
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+	}
 }
 
 func (o *validFlagEnvInteractionOptions) Attach(c *cobra.Command) error { return nil }
@@ -1615,7 +1471,7 @@ func (suite *structcliSuite) TestFlagenv_InteractionWithOtherTags_SuccessCase() 
 	err := Define(cmd, opts)
 	require.NoError(suite.T(), err)
 
-	// 1. Verify `flagenv:"true"` with `flagcustom:"true"`
+	// 1. Verify `flagenv:"true"` with FieldHookProvider
 	customFlag := cmd.Flags().Lookup("env-with-custom")
 	require.NotNil(suite.T(), customFlag)
 	customEnvAnnotation, ok := customFlag.Annotations[internalenv.FlagAnnotation]
@@ -1643,7 +1499,7 @@ func (suite *structcliSuite) TestFlagenv_InteractionWithOtherTags_SuccessCase() 
 }
 
 type bothInvalidOptions struct {
-	InvalidBoth string `flagenv:"invalid" flagcustom:"invalid" flag:"invalid-both" flagdescr:"both invalid"`
+	InvalidBoth string `flagenv:"invalid" flag:"invalid-both" flagdescr:"both invalid"`
 }
 
 func (o *bothInvalidOptions) Attach(c *cobra.Command) error { return nil }
@@ -1655,8 +1511,7 @@ func (suite *structcliSuite) TestFlagenv_BothInvalid_ReturnsFirstError() {
 	err := Define(cmd, opts)
 
 	assert.Error(suite.T(), err, "Should return error for invalid tag values")
-	// Should return the first error (flagcustom is validated first in the current implementation)
-	assert.Contains(suite.T(), err.Error(), "flagcustom", "Error should mention the first invalid tag")
+	assert.Contains(suite.T(), err.Error(), "flagenv", "Error should mention the invalid tag")
 }
 
 type errorMessageOptions struct {
@@ -1853,21 +1708,26 @@ func (suite *structcliSuite) TestFlagignore_MultipleInvalid_ReturnsFirstError() 
 }
 
 type flagIgnoreCombinedOptions struct {
-	IgnoreWithCustom   string `flagignore:"true" flagcustom:"true" flag:"ignore-custom" flagdescr:"ignore with custom"`
+	IgnoreWithCustom   string `flagignore:"true" flag:"ignore-custom" flagdescr:"ignore with custom"`
 	IgnoreWithRequired string `flagignore:"false" flagrequired:"true" flag:"ignore-required" flagdescr:"ignore with required"`
 	IgnoreWithGroup    string `flagignore:"false" flaggroup:"TestGroup" flag:"ignore-group" flagdescr:"ignore with group"`
 	InvalidIgnoreValid string `flagignore:"invalid" flagenv:"true" flag:"invalid-ignore-valid" flagdescr:"invalid ignore with valid env"`
 }
 
-func (o *flagIgnoreCombinedOptions) DefineIgnoreWithCustom(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "CUSTOM_DEFAULT"
+func (o *flagIgnoreCombinedOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"IgnoreWithCustom": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = "CUSTOM_DEFAULT"
 
-	return values.NewString(fieldPtr), descr + " [CUSTOM]"
-}
-
-func (o *flagIgnoreCombinedOptions) DecodeIgnoreWithCustom(input any) (any, error) {
-	return input, nil
+				return values.NewString(fieldPtr), descr + " [CUSTOM]"
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+	}
 }
 
 func (o *flagIgnoreCombinedOptions) Attach(c *cobra.Command) error { return nil }
@@ -1887,37 +1747,41 @@ func (suite *structcliSuite) TestFlagignore_CombinedWithOtherTags_FailureCase() 
 }
 
 type validFlagIgnoreInteractionOptions struct {
-	IgnoreWithCustom   string `flagignore:"true" flagcustom:"true" flag:"ignore-custom"`
+	IgnoreWithCustom   string `flagignore:"true" flag:"ignore-custom"`
 	IgnoreWithRequired string `flagignore:"false" flagrequired:"true" flag:"is-required"`
 	IgnoreWithGroup    string `flagignore:"false" flaggroup:"TestGroup" flag:"in-group"`
 }
 
-func (o *validFlagIgnoreInteractionOptions) DefineIgnoreWithCustom(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	// This method should NOT be called if flagignore:"true" is respected.
-	// We can test this by causing a panic if it's ever called.
-	panic("DefineIgnoreWithCustom should not have been called!")
-}
-
-func (o *validFlagIgnoreInteractionOptions) DecodeIgnoreWithCustom(input any) (any, error) {
-	panic("DecodeIgnoreWithCustom should not have been called!")
+func (o *validFlagIgnoreInteractionOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"IgnoreWithCustom": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				// This hook should NOT be called if flagignore:"true" is respected.
+				panic("FieldHooks[IgnoreWithCustom].Define should not have been called!")
+			},
+			Decode: func(input any) (any, error) {
+				panic("FieldHooks[IgnoreWithCustom].Decode should not have been called!")
+			},
+		},
+	}
 }
 
 func (o *validFlagIgnoreInteractionOptions) Attach(c *cobra.Command) error { return nil }
 
-// New test to verify the correct behavior of valid `flagignore` tags.
+// Test to verify the correct behavior of valid `flagignore` tags.
 func (suite *structcliSuite) TestFlagignore_InteractionWithOtherTags_SuccessCase() {
 	opts := &validFlagIgnoreInteractionOptions{}
 	cmd := &cobra.Command{Use: "test"}
 
 	// This should not panic or error out, as `flagignore:"true"` should prevent
-	// the `DefineIgnoreWithCustom` method from ever being called.
+	// the FieldHookProvider hook from ever being called.
 	var err error
 	require.NotPanics(suite.T(), func() {
 		err = Define(cmd, opts)
 	})
 	require.NoError(suite.T(), err)
 
-	// 1. Verify `flagignore:"true"` takes precedence over `flagcustom:"true"`
+	// 1. Verify `flagignore:"true"` takes precedence over FieldHookProvider
 	ignoredFlag := cmd.Flags().Lookup("ignore-custom")
 	assert.Nil(suite.T(), ignoredFlag, "Flag should be ignored and not created")
 
@@ -1935,7 +1799,7 @@ func (suite *structcliSuite) TestFlagignore_InteractionWithOtherTags_SuccessCase
 }
 
 type allThreeInvalidOptions struct {
-	InvalidAll string `flagignore:"invalid" flagenv:"invalid" flagcustom:"invalid" flag:"invalid-all" flagdescr:"all three invalid"`
+	InvalidAll string `flagignore:"invalid" flagenv:"invalid" flag:"invalid-all" flagdescr:"both invalid"`
 }
 
 func (o *allThreeInvalidOptions) Attach(c *cobra.Command) error { return nil }
@@ -1947,8 +1811,10 @@ func (suite *structcliSuite) TestFlagignore_AllThreeInvalid_ReturnsFirstError() 
 	err := Define(cmd, opts)
 
 	assert.Error(suite.T(), err, "Should return error for invalid tag values")
-	// Should return the first error (flagcustom is validated first in the current implementation)
-	assert.Contains(suite.T(), err.Error(), "flagcustom", "Error should mention the first invalid tag")
+	// Validation returns the first error encountered
+	assert.True(suite.T(),
+		strings.Contains(err.Error(), "flagignore") || strings.Contains(err.Error(), "flagenv"),
+		"Error should mention one of the invalid tags")
 }
 
 type errorIgnoreMessageOptions struct {
@@ -2156,7 +2022,7 @@ func (suite *structcliSuite) TestFlagrequired_MultipleInvalid_ReturnsFirstError(
 }
 
 type allFourInvalidOptions struct {
-	InvalidAll string `flagrequired:"invalid" flagignore:"invalid" flagenv:"invalid" flagcustom:"invalid" flag:"invalid-all" flagdescr:"all four invalid"`
+	InvalidAll string `flagrequired:"invalid" flagignore:"invalid" flagenv:"invalid" flag:"invalid-all" flagdescr:"all three invalid"`
 }
 
 func (o *allFourInvalidOptions) Attach(c *cobra.Command) error { return nil }
@@ -2168,8 +2034,10 @@ func (suite *structcliSuite) TestFlagrequired_AllFourInvalid_ReturnsFirstError()
 	err := Define(cmd, opts)
 
 	assert.Error(suite.T(), err, "Should return error for invalid tag values")
-	// Should return the first error (flagcustom is validated first in the current implementation)
-	assert.Contains(suite.T(), err.Error(), "flagcustom", "Error should mention the first invalid tag")
+	// Validation returns the first error encountered
+	assert.True(suite.T(),
+		strings.Contains(err.Error(), "flagignore") || strings.Contains(err.Error(), "flagenv") || strings.Contains(err.Error(), "flagrequired"),
+		"Error should mention one of the invalid tags")
 }
 
 type errorRequiredMessageOptions struct {
@@ -2832,361 +2700,6 @@ func (suite *structcliSuite) TestDefine_NilPointerHandling_Extended() {
 	})
 }
 
-type missingDecodeHookOptions struct {
-	CustomField string `flagcustom:"true" flag:"custom-field"`
-}
-
-func (o *missingDecodeHookOptions) DefineCustomField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default"
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *missingDecodeHookOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestValidateCustomFlag_MissingDecodeHook() {
-	opts := &missingDecodeHookOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// This should error because the decode hook is missing
-	err := Define(cmd, opts)
-
-	require.Error(suite.T(), err, "Should return error when decode hook is missing")
-	assert.Contains(suite.T(), err.Error(), "missing decode hook", "Error should mention missing decode hook")
-	assert.Contains(suite.T(), err.Error(), "DecodeCustomField", "Error should mention the expected decode hook name")
-	assert.Contains(suite.T(), err.Error(), "CustomField", "Error should mention the field name")
-}
-
-type missingDefineHookOptions struct {
-	CustomField string `flagcustom:"true" flag:"custom-field"`
-}
-
-// No DefineCustomField method - define hook missing
-func (o *missingDefineHookOptions) DecodeCustomField(input any) (any, error) {
-	return input, nil
-}
-
-func (o *missingDefineHookOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestValidateCustomFlag_MissingDefineHook() {
-	opts := &missingDefineHookOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// This should error because the define hook is missing
-	err := Define(cmd, opts)
-
-	require.Error(suite.T(), err, "Should return error when define hook is missing")
-	require.ErrorIs(suite.T(), err, structclierrors.ErrMissingDefineHook)
-	assert.Contains(suite.T(), err.Error(), "missing define hook", "Error should mention missing define hook")
-	assert.Contains(suite.T(), err.Error(), "DefineCustomField", "Error should mention the expected define hook name")
-	assert.Contains(suite.T(), err.Error(), "CustomField", "Error should mention the field name")
-}
-
-type wrongDefineSignatureOptions struct {
-	CustomField string `flagcustom:"true" flag:"custom-field"`
-}
-
-func (o *wrongDefineSignatureOptions) DefineCustomField(wrongParam string) {
-	// Wrong signature - should have (c *cobra.Command, name, short, descr string, structField reflect.StructField, fieldValue reflect.Value)
-}
-
-func (o *wrongDefineSignatureOptions) DecodeCustomField(input any) (any, error) {
-	return input, nil
-}
-
-func (o *wrongDefineSignatureOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestValidateCustomFlag_WrongDefineSignature() {
-	opts := &wrongDefineSignatureOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// This should error because define hook has wrong signature
-	err := Define(cmd, opts)
-
-	require.Error(suite.T(), err, "Should return error when define hook has wrong signature")
-	assert.Contains(suite.T(), err.Error(), "invalid", "Error should mention invalid signature")
-	assert.Contains(suite.T(), err.Error(), "DefineCustomField", "Error should mention the hook name")
-	assert.Contains(suite.T(), err.Error(), "define hook", "Error should identify it as a define hook error")
-
-	var fx internalhooks.DefineHookFunc
-	require.Contains(suite.T(), err.Error(), internalreflect.Signature(fx))
-}
-
-type wrongDecodeSignatureOptions struct {
-	CustomField string `flagcustom:"true" flag:"custom-field"`
-}
-
-func (o *wrongDecodeSignatureOptions) DefineCustomField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default"
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *wrongDecodeSignatureOptions) DecodeCustomField(wrongParam string, anotherParam int) {
-	// Wrong signature - should have (input any) (any, error)
-}
-
-func (o *wrongDecodeSignatureOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestValidateCustomFlag_WrongDecodeSignature() {
-	opts := &wrongDecodeSignatureOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// This should error because decode hook has wrong signature
-	err := Define(cmd, opts)
-
-	require.Error(suite.T(), err, "Should return error when decode hook has wrong signature")
-	assert.Contains(suite.T(), err.Error(), "invalid", "Error should mention invalid signature")
-	assert.Contains(suite.T(), err.Error(), "DecodeCustomField", "Error should mention the hook name")
-	assert.Contains(suite.T(), err.Error(), "decode hook", "Error should identify it as a decode hook error")
-
-	var fx internalhooks.DecodeHookFunc
-	require.Contains(suite.T(), err.Error(), internalreflect.Signature(fx))
-}
-
-type wrongDecodeReturnOptions struct {
-	CustomField string `flagcustom:"true" flag:"custom-field"`
-}
-
-func (o *wrongDecodeReturnOptions) DefineCustomField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default"
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *wrongDecodeReturnOptions) DecodeCustomField(input any) string {
-	// Wrong signature - should return (any, error), not just string
-	return "value"
-}
-
-func (o *wrongDecodeReturnOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestValidateCustomFlag_WrongDecodeReturnSignature() {
-	opts := &wrongDecodeReturnOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// This should error because decode hook returns wrong number of values
-	err := Define(cmd, opts)
-
-	require.Error(suite.T(), err, "Should return error when decode hook returns wrong number of values")
-	assert.Contains(suite.T(), err.Error(), "(interface {}, error)", "Error should mention correct return signature")
-	assert.Contains(suite.T(), err.Error(), "DecodeCustomField", "Error should mention the hook name")
-}
-
-type correctHooksOptions struct {
-	CustomField string `flagcustom:"true" flag:"custom-field"`
-}
-
-func (o *correctHooksOptions) DefineCustomField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default" // Set the default value on the struct
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *correctHooksOptions) DecodeCustomField(input any) (any, error) {
-	return input, nil
-}
-
-func (o *correctHooksOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestValidateCustomFlag_CorrectHooks() {
-	opts := &correctHooksOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// This should succeed because both hooks are correctly defined
-	err := Define(cmd, opts)
-
-	assert.NoError(suite.T(), err, "Should not return error when both hooks are correctly defined")
-
-	// Verify that the flag was actually created
-	flag := cmd.Flags().Lookup("custom-field")
-	assert.NotNil(suite.T(), flag, "Custom flag should be created")
-	assert.Equal(suite.T(), "default", flag.DefValue, "Flag should have default value from define hook")
-}
-
-func (suite *structcliSuite) TestValidateCustomFlag_ErrorTypes() {
-	suite.T().Run("missing_decode_hook_error_type", func(t *testing.T) {
-		opts := &missingDecodeHookOptions{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := Define(cmd, opts)
-
-		require.Error(t, err)
-
-		// Should be wrapped in a MissingDecodeHookError
-		var missingErr *structclierrors.MissingDecodeHookError
-		assert.True(t, errors.As(err, &missingErr), "Should be MissingDecodeHookError type")
-		if missingErr != nil {
-			assert.Equal(t, "CustomField", missingErr.FieldName)
-			assert.Equal(t, "DecodeCustomField", missingErr.ExpectedHook)
-		}
-	})
-
-	suite.T().Run("wrong_define_signature_error_type", func(t *testing.T) {
-		opts := &wrongDefineSignatureOptions{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := Define(cmd, opts)
-
-		require.Error(t, err)
-
-		// Should be wrapped in an InvalidDefineHookSignatureError
-		var defineErr *structclierrors.InvalidDefineHookSignatureError
-		assert.True(t, errors.As(err, &defineErr), "Should be InvalidDefineHookSignatureError type")
-		if defineErr != nil {
-			assert.Equal(t, "CustomField", defineErr.FieldName)
-			assert.Equal(t, "DefineCustomField", defineErr.HookName)
-		}
-	})
-
-	suite.T().Run("wrong_decode_signature_error_type", func(t *testing.T) {
-		opts := &wrongDecodeSignatureOptions{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := Define(cmd, opts)
-
-		require.Error(t, err)
-
-		// Should be wrapped in an InvalidDecodeHookSignatureError
-		var decodeErr *structclierrors.InvalidDecodeHookSignatureError
-		assert.True(t, errors.As(err, &decodeErr), "Should be InvalidDecodeHookSignatureError type")
-		if decodeErr != nil {
-			assert.Equal(t, "CustomField", decodeErr.FieldName)
-			assert.Equal(t, "DecodeCustomField", decodeErr.HookName)
-		}
-	})
-}
-
-type multipleCustomOptions struct {
-	GoodField string `flagcustom:"true" flag:"good-field"`
-	BadField  string `flagcustom:"true" flag:"bad-field"`
-}
-
-func (o *multipleCustomOptions) DefineGoodField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default"
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *multipleCustomOptions) DecodeGoodField(input any) (any, error) {
-	return input, nil
-}
-
-func (o *multipleCustomOptions) DefineBadField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default"
-
-	return values.NewString(fieldPtr), descr
-}
-
-// NOTE: DecodeBadField is intentionally missing to trigger the test's error condition.
-
-func (o *multipleCustomOptions) Attach(c *cobra.Command) error { return nil }
-
-type nestedCustomStruct struct {
-	CustomField string `flagcustom:"true" flag:"nested-custom"`
-}
-
-func (n *nestedCustomStruct) DefineCustomField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "nested-default"
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (n *nestedCustomStruct) DecodeCustomField(input any) (any, error) {
-	return input, nil
-}
-
-type parentOptions struct {
-	Nested nestedCustomStruct
-}
-
-func (o *parentOptions) Attach(c *cobra.Command) error { return nil }
-
-func (suite *structcliSuite) TestValidateCustomFlag_EdgeCases() {
-	suite.T().Run("multiple_custom_fields", func(t *testing.T) {
-		// Test struct with multiple custom fields where one is wrong
-
-		opts := &multipleCustomOptions{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := Define(cmd, opts)
-
-		require.Error(t, err, "Should fail when one custom field is missing decode hook")
-		assert.Contains(t, err.Error(), "BadField", "Should mention the problematic field")
-		assert.Contains(t, err.Error(), "DecodeBadField", "Should mention the missing decode hook")
-	})
-
-	suite.T().Run("nested_struct_with_custom_field", func(t *testing.T) {
-		// Test nested struct containing custom field
-
-		opts := &parentOptions{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := Define(cmd, opts)
-
-		assert.NoError(t, err, "Should handle nested struct with custom field correctly")
-
-		flag := cmd.Flags().Lookup("nested-custom")
-		assert.NotNil(t, flag, "Nested custom flag should be created")
-	})
-}
-
-type standardTypeOptions struct {
-	Field1 string `flagcustom:"true" flagdescr:"First string field"`
-	Field2 string `flagcustom:"true" flagdescr:"Second string field"`
-	Field3 int    `flagcustom:"true" flagdescr:"Int field"`
-	Level  string `flag:"level" flagdescr:"Normal field"`
-}
-
-func (s *standardTypeOptions) DefineField1(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default1"
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (s *standardTypeOptions) DecodeField1(input any) (any, error) {
-	return "field1_" + input.(string), nil
-}
-
-func (s *standardTypeOptions) DefineField2(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default2"
-
-	return values.NewString(fieldPtr), descr
-}
-
-func (s *standardTypeOptions) DecodeField2(input any) (any, error) {
-	return "field2_" + input.(string), nil
-}
-
-func (s *standardTypeOptions) DefineField3(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*int)
-	*fieldPtr = 0
-
-	return values.NewInt(fieldPtr), descr
-}
-
-func (s *standardTypeOptions) DecodeField3(input any) (any, error) { return 42, nil }
-
-func (s *standardTypeOptions) Attach(cmd *cobra.Command) error { return nil }
-
-func TestDefine_CustomTypeConflict_StandardTypesAllowed(t *testing.T) {
-	opts := &standardTypeOptions{}
-	cmd := &cobra.Command{Use: "test"}
-
-	// This should NOT error - standard types can have multiple custom fields
-	err := Define(cmd, opts)
-	require.NoError(t, err, "Multiple standard type fields with flagcustom should be allowed")
-}
-
 type duplOptsA struct {
 	Port int `flag:"port" flagdescr:"port number"`
 }
@@ -3537,7 +3050,7 @@ func (o *enumCustomHookOptions) Attach(c *cobra.Command) error { return nil }
 
 func (suite *structcliSuite) TestDefine_EnumAnnotation_BuiltInHook() {
 	// zapcore.Level is registered via RegisterEnum, so the built-in hook
-	// handles it without flagcustom:"true".
+	// handles it via the type registry.
 	opts := &enumCustomHookOptions{}
 	cmd := &cobra.Command{Use: "test"}
 
@@ -3547,26 +3060,31 @@ func (suite *structcliSuite) TestDefine_EnumAnnotation_BuiltInHook() {
 	require.NotNil(suite.T(), f)
 
 	enumVals, ok := f.Annotations[flagEnumAnnotation]
-	require.True(suite.T(), ok, "enum annotation should be set for built-in hook via flagcustom fallback")
+	require.True(suite.T(), ok, "enum annotation should be set for built-in hook via registry")
 	assert.Equal(suite.T(), []string{"debug", "info", "warn", "error", "dpanic", "panic", "fatal"}, enumVals)
 }
 
 type enumCustomDefineHookOptions struct {
-	ServerMode serverMode `flagcustom:"true" flag:"server-mode" flagshort:"m" flagdescr:"set server mode"`
+	ServerMode serverMode `flag:"server-mode" flagshort:"m" flagdescr:"set server mode"`
 }
 
 func (o *enumCustomDefineHookOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *enumCustomDefineHookOptions) DefineServerMode(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	enhancedDesc := descr + fmt.Sprintf(" {%s,%s,%s}", string(development), string(staging), string(production))
-	fieldPtr := fieldValue.Addr().Interface().(*serverMode)
-	*fieldPtr = development
+func (o *enumCustomDefineHookOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"ServerMode": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				enhancedDesc := descr + fmt.Sprintf(" {%s,%s,%s}", string(development), string(staging), string(production))
+				fieldPtr := fieldValue.Addr().Interface().(*serverMode)
+				*fieldPtr = development
 
-	return values.NewString((*string)(fieldPtr)), enhancedDesc
-}
-
-func (o *enumCustomDefineHookOptions) DecodeServerMode(input any) (any, error) {
-	return serverMode(input.(string)), nil
+				return values.NewString((*string)(fieldPtr)), enhancedDesc
+			},
+			Decode: func(input any) (any, error) {
+				return serverMode(input.(string)), nil
+			},
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_EnumAnnotation_CustomDefineHookWithEnumPattern() {
@@ -3579,7 +3097,7 @@ func (suite *structcliSuite) TestDefine_EnumAnnotation_CustomDefineHookWithEnumP
 	require.NotNil(suite.T(), f)
 
 	enumVals, ok := f.Annotations[flagEnumAnnotation]
-	require.True(suite.T(), ok, "enum annotation should be set when custom DefineFieldName hook uses enum pattern")
+	require.True(suite.T(), ok, "enum annotation should be set when FieldHookProvider uses enum pattern")
 	assert.Equal(suite.T(), []string{"dev", "staging", "prod"}, enumVals)
 }
 
@@ -3599,20 +3117,25 @@ func (f *enumValuerFlag) EnumValues() []string {
 }
 
 type enumValuerHookOptions struct {
-	Priority string `flagcustom:"true" flag:"priority" flagdescr:"Set priority {x,y,z}"`
+	Priority string `flag:"priority" flagdescr:"Set priority {x,y,z}"`
 }
 
 func (o enumValuerHookOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *enumValuerHookOptions) DefinePriority(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	ref := fieldValue.Addr().Interface().(*string)
-	// Return a pflag.Value that implements EnumValuer with [alpha, beta, gamma]
-	// but the description says {x,y,z}
-	return &enumValuerFlag{val: *ref}, descr
-}
-
-func (o *enumValuerHookOptions) DecodePriority(input any) (any, error) {
-	return input.(string), nil
+func (o *enumValuerHookOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"Priority": {
+			Define: func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				ref := fieldValue.Addr().Interface().(*string)
+				// Return a pflag.Value that implements EnumValuer with [alpha, beta, gamma]
+				// but the description says {x,y,z}
+				return &enumValuerFlag{val: *ref}, descr
+			},
+			Decode: func(input any) (any, error) {
+				return input.(string), nil
+			},
+		},
+	}
 }
 
 func (suite *structcliSuite) TestDefine_EnumAnnotation_EnumValuerTakesPrecedenceOverRegex() {
@@ -3787,18 +3310,23 @@ func (suite *structcliSuite) TestDefine_ValidateModAnnotations_NestedStructs() {
 }
 
 type flagCustomWithValidateOptions struct {
-	Token string `flagcustom:"true" flag:"token" flagdescr:"auth token" validate:"required"`
+	Token string `flag:"token" flagdescr:"auth token" validate:"required"`
 }
 
-func (o *flagCustomWithValidateOptions) DefineToken(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = ""
+func (o *flagCustomWithValidateOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"Token": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = ""
 
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *flagCustomWithValidateOptions) DecodeToken(input any) (any, error) {
-	return input, nil
+				return values.NewString(fieldPtr), descr
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+	}
 }
 
 func (o *flagCustomWithValidateOptions) Attach(c *cobra.Command) error { return nil }
@@ -3812,7 +3340,7 @@ func (suite *structcliSuite) TestDefine_ValidateAnnotation_FlagCustomWithValidat
 	tokenFlag := cmd.Flags().Lookup("token")
 	require.NotNil(suite.T(), tokenFlag)
 	valAnnotation := tokenFlag.Annotations[flagValidateAnnotation]
-	assert.Equal(suite.T(), []string{"required"}, valAnnotation, "flagcustom field with validate tag should have the validate annotation stored")
+	assert.Equal(suite.T(), []string{"required"}, valAnnotation, "FieldHookProvider field with validate tag should have the validate annotation stored")
 }
 
 // customTagOptions uses non-default struct tag names for validation and transformation.
@@ -3942,3 +3470,77 @@ func (suite *structcliSuite) TestDefine_UnexportedNonEmbeddedFieldStillSkipped()
 	assert.NotNil(suite.T(), cmd.Flags().Lookup("visible"), "exported field should be defined")
 	assert.Nil(suite.T(), cmd.Flags().Lookup("invisible"), "unexported non-embedded field should still be skipped")
 }
+
+// --- FieldHookProvider / FieldCompleter validation tests ---
+
+type unknownFieldHookOptions struct {
+	Name string `flag:"name" flagdescr:"name"`
+}
+
+func (o *unknownFieldHookOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"Bogus": {
+			Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+				return values.NewString(fv.Addr().Interface().(*string)), descr
+			},
+			Decode: func(input any) (any, error) { return input, nil },
+		},
+	}
+}
+
+func (o *unknownFieldHookOptions) Attach(c *cobra.Command) error { return nil }
+
+func (suite *structcliSuite) TestDefine_FieldHookProvider_RejectsUnknownKey() {
+	opts := &unknownFieldHookOptions{}
+	cmd := &cobra.Command{Use: "test"}
+	err := Define(cmd, opts)
+	require.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "Bogus")
+	assert.Contains(suite.T(), err.Error(), "does not match any struct field")
+}
+
+type unknownCompleterOptions struct {
+	Name string `flag:"name" flagdescr:"name"`
+}
+
+func (o *unknownCompleterOptions) CompletionHooks() map[string]CompleteHookFunc {
+	return map[string]CompleteHookFunc{
+		"Bogus": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveDefault
+		},
+	}
+}
+
+func (o *unknownCompleterOptions) Attach(c *cobra.Command) error { return nil }
+
+func (suite *structcliSuite) TestDefine_FieldCompleter_RejectsUnknownKey() {
+	opts := &unknownCompleterOptions{}
+	cmd := &cobra.Command{Use: "test"}
+	err := Define(cmd, opts)
+	require.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "Bogus")
+	assert.Contains(suite.T(), err.Error(), "does not match any struct field")
+}
+
+type decodeWithoutDefineOptions struct {
+	Name string `flag:"name" flagdescr:"name"`
+}
+
+func (o *decodeWithoutDefineOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"Name": {
+			Decode: func(input any) (any, error) { return input, nil },
+		},
+	}
+}
+
+func (o *decodeWithoutDefineOptions) Attach(c *cobra.Command) error { return nil }
+
+func (suite *structcliSuite) TestDefine_FieldHookProvider_RejectsDecodeWithoutDefine() {
+	opts := &decodeWithoutDefineOptions{}
+	cmd := &cobra.Command{Use: "test"}
+	err := Define(cmd, opts)
+	require.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "Decode without Define")
+}
+

--- a/enum.go
+++ b/enum.go
@@ -40,16 +40,17 @@ func RegisterEnum[E ~string](values map[E][]string) {
 		panic("structcli: RegisterEnum: values must not be empty")
 	}
 
-	typeName := reflect.TypeFor[E]().String()
+	typ := reflect.TypeFor[E]()
+	typeName := typ.String()
 
-	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
+	if _, exists := internalhooks.DefineHookRegistry[typ]; exists {
 		panic(fmt.Sprintf("structcli: RegisterEnum: type %q is already registered", typeName))
 	}
 
-	internalhooks.DefineHookRegistry[typeName] = internalhooks.DefineStringEnumHookFunc(values)
+	internalhooks.DefineHookRegistry[typ] = internalhooks.DefineStringEnumHookFunc(values)
 
 	annName := fmt.Sprintf("StringTo%sHookFunc", typeName)
-	internalhooks.RegisterDecodeHook(typeName, annName, internalhooks.StringToEnumHookFunc(values))
+	internalhooks.RegisterDecodeHook(typ, annName, internalhooks.StringToEnumHookFunc(values))
 }
 
 // RegisterIntEnum registers an integer-based enum type for automatic flag handling.
@@ -86,15 +87,16 @@ func RegisterIntEnum[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map[E][]s
 		panic("structcli: RegisterIntEnum: values must not be empty")
 	}
 
-	typeName := reflect.TypeFor[E]().String()
+	typ := reflect.TypeFor[E]()
+	typeName := typ.String()
 
-	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
+	if _, exists := internalhooks.DefineHookRegistry[typ]; exists {
 		panic(fmt.Sprintf("structcli: RegisterIntEnum: type %q is already registered", typeName))
 	}
 
-	internalhooks.DefineHookRegistry[typeName] = internalhooks.DefineIntEnumHookFunc(values)
+	internalhooks.DefineHookRegistry[typ] = internalhooks.DefineIntEnumHookFunc(values)
 
 	annName := fmt.Sprintf("StringTo%sHookFunc", typeName)
-	internalhooks.RegisterDecodeHook(typeName, annName, internalhooks.StringToIntEnumHookFunc(values))
+	internalhooks.RegisterDecodeHook(typ, annName, internalhooks.StringToIntEnumHookFunc(values))
 }
 

--- a/enum.go
+++ b/enum.go
@@ -8,8 +8,9 @@ import (
 )
 
 // RegisterEnum registers a string-based enum type for automatic flag handling.
-// After registration, struct fields of type E work without flagcustom:"true"
-// or manual Define/Decode/Complete hook methods.
+// After registration, struct fields of type E work without any special tag
+// or interface. This is a convenience wrapper over [RegisterType] for the
+// common case of string-based enums with named values and aliases.
 //
 // values maps each enum constant to its string representations. The first
 // string in each slice is the canonical name shown in help text and shell
@@ -59,7 +60,7 @@ func RegisterEnum[E ~string](values map[E][]string) {
 // Values appear in help text sorted by their integer value.
 //
 // Unsigned integer types (~uint, ~uint8, etc.) are not supported. For those,
-// use flagcustom:"true" with manual Define/Decode/Complete hooks.
+// use [RegisterType] with manual Define/Decode hooks.
 //
 // Must be called in init() before any Define() calls. Panics if the type
 // is already registered, or if values is empty.

--- a/enum_test.go
+++ b/enum_test.go
@@ -197,7 +197,7 @@ func TestRegisterEnum_NoFlagcustomNeeded(t *testing.T) {
 
 	opts := &enumOptions{}
 	cmd := &cobra.Command{Use: "app"}
-	// Define succeeds without flagcustom:"true"
+	// Define succeeds via the type registry
 	require.NoError(t, Define(cmd, opts))
 
 	// Flag exists and works

--- a/enum_test.go
+++ b/enum_test.go
@@ -2,6 +2,7 @@ package structcli
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	internalhooks "github.com/leodido/structcli/internal/hooks"
@@ -73,7 +74,7 @@ func resetEnumTestState() {
 func saveAndRestoreRegistries(t *testing.T) {
 	t.Helper()
 
-	origDefine := make(map[string]internalhooks.DefineHookFunc)
+	origDefine := make(map[reflect.Type]internalhooks.DefineHookFunc)
 	for k, v := range internalhooks.DefineHookRegistry {
 		origDefine[k] = v
 	}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -3,7 +3,6 @@ package errors
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 )
 
@@ -113,20 +112,14 @@ func (e *ValidationError) UnderlyingErrors() []error {
 
 // These are all DefinitionError
 var (
-	ErrInvalidBooleanTag            = errors.New("invalid boolean tag value")
-	ErrInvalidFlagEnvTag            = errors.New("invalid flagenv tag value")
-	ErrInvalidShorthand             = errors.New("invalid shorthand flag")
-	ErrMissingDefineHook            = errors.New("missing custom flag definition hook")
-	ErrMissingDecodeHook            = errors.New("missing custom flag decoding hook")
-	ErrInvalidDefineHookSignature   = errors.New("invalid define hook signature")
-	ErrInvalidDecodeHookSignature   = errors.New("invalid decode hook signature")
-	ErrInvalidCompleteHookSignature = errors.New("invalid complete hook signature")
-	ErrInvalidTagUsage              = errors.New("invalid tag usage")
-	ErrConflictingTags              = errors.New("conflicting struct tags")
-	ErrConflictingType              = errors.New("conflicting struct field types")
-	ErrUnsupportedType              = errors.New("unsupported field type")
-	ErrDuplicateFlag                = errors.New("duplicate flag name")
-	ErrInvalidFlagName              = errors.New("invalid flag name")
+	ErrInvalidBooleanTag = errors.New("invalid boolean tag value")
+	ErrInvalidFlagEnvTag = errors.New("invalid flagenv tag value")
+	ErrInvalidShorthand  = errors.New("invalid shorthand flag")
+	ErrInvalidTagUsage   = errors.New("invalid tag usage")
+	ErrConflictingTags   = errors.New("conflicting struct tags")
+	ErrUnsupportedType   = errors.New("unsupported field type")
+	ErrDuplicateFlag     = errors.New("duplicate flag name")
+	ErrInvalidFlagName   = errors.New("invalid flag name")
 )
 
 // DefinitionError represents an error that occurred while processing a struct field's tags at definition time.
@@ -216,102 +209,6 @@ func (e *InvalidShorthandError) Unwrap() error {
 	return ErrInvalidShorthand
 }
 
-// MissingDefineHookError represents a missing custom flag definition hook
-type MissingDefineHookError struct {
-	FieldName    string
-	ExpectedHook string
-}
-
-func (e *MissingDefineHookError) Error() string {
-	return fmt.Sprintf("field '%s': flagcustom='true' but missing define hook '%s'", e.FieldName, e.ExpectedHook)
-}
-
-func (e *MissingDefineHookError) Field() string {
-	return e.FieldName
-}
-
-func (e *MissingDefineHookError) Unwrap() error {
-	return ErrMissingDefineHook
-}
-
-// MissingDecodeHookError represents a missing custom flag decoding hook
-type MissingDecodeHookError struct {
-	FieldName    string
-	ExpectedHook string
-}
-
-func (e *MissingDecodeHookError) Error() string {
-	return fmt.Sprintf("field '%s': flagcustom='true' but missing decode hook '%s'", e.FieldName, e.ExpectedHook)
-}
-
-func (e *MissingDecodeHookError) Field() string {
-	return e.FieldName
-}
-
-func (e *MissingDecodeHookError) Unwrap() error {
-	return ErrMissingDecodeHook
-}
-
-// InvalidDecodeHookSignatureError represents an invalid custom flag definition hook
-type InvalidDecodeHookSignatureError struct {
-	FieldName string
-	HookName  string
-	Message   string
-}
-
-func (e *InvalidDecodeHookSignatureError) Error() string {
-	return fmt.Sprintf("field '%s': invalid '%s' decode hook: %s",
-		e.FieldName, e.HookName, e.Message)
-}
-
-func (e *InvalidDecodeHookSignatureError) Field() string {
-	return e.FieldName
-}
-
-func (e *InvalidDecodeHookSignatureError) Unwrap() error {
-	return ErrInvalidDecodeHookSignature
-}
-
-// InvalidDefineHookSignatureError represents an invalid custom flag definition hook
-type InvalidDefineHookSignatureError struct {
-	FieldName string
-	HookName  string
-	Message   string
-}
-
-func (e *InvalidDefineHookSignatureError) Error() string {
-	return fmt.Sprintf("field '%s': invalid '%s' define hook: %s",
-		e.FieldName, e.HookName, e.Message)
-}
-
-func (e *InvalidDefineHookSignatureError) Field() string {
-	return e.FieldName
-}
-
-func (e *InvalidDefineHookSignatureError) Unwrap() error {
-	return ErrInvalidDefineHookSignature
-}
-
-// InvalidCompleteHookSignatureError represents an invalid completion hook.
-type InvalidCompleteHookSignatureError struct {
-	FieldName string
-	HookName  string
-	Message   string
-}
-
-func (e *InvalidCompleteHookSignatureError) Error() string {
-	return fmt.Sprintf("field '%s': invalid '%s' completion hook: %s",
-		e.FieldName, e.HookName, e.Message)
-}
-
-func (e *InvalidCompleteHookSignatureError) Field() string {
-	return e.FieldName
-}
-
-func (e *InvalidCompleteHookSignatureError) Unwrap() error {
-	return ErrInvalidCompleteHookSignature
-}
-
 // InvalidTagUsageError represents invalid tag usages
 type InvalidTagUsageError struct {
 	FieldName string
@@ -352,30 +249,6 @@ func (e *ConflictingTagsError) Field() string {
 }
 func (e *ConflictingTagsError) Unwrap() error {
 	return ErrConflictingTags
-}
-
-// ConflictingTypeError represents conflicting struct fields having the same custom type
-type ConflictingTypeError struct {
-	Type     reflect.Type
-	TypeName string
-	Fields   []string
-	Message  string
-}
-
-func (e *ConflictingTypeError) Error() string {
-	return fmt.Sprintf(
-		"fields [%s]: conflicting type [%s]: %s",
-		strings.Join(e.Fields, ", "),
-		e.TypeName,
-		e.Message,
-	)
-}
-
-func (e *ConflictingTypeError) Field() string {
-	return strings.Join(e.Fields, ", ")
-}
-func (e *ConflictingTypeError) Unwrap() error {
-	return ErrConflictingType
 }
 
 // UnsupportedTypeError represents an unsupported field type
@@ -445,44 +318,6 @@ func NewInvalidShorthandError(fieldName, shorthand string) error {
 	}
 }
 
-func NewMissingDefineHookError(fieldName, hookName string) error {
-	return &MissingDefineHookError{
-		FieldName:    fieldName,
-		ExpectedHook: hookName,
-	}
-}
-
-func NewMissingDecodeHookError(fieldName, hookName string) error {
-	return &MissingDecodeHookError{
-		FieldName:    fieldName,
-		ExpectedHook: hookName,
-	}
-}
-
-func NewInvalidDecodeHookSignatureError(fieldName, hookName string, err error) error {
-	return &InvalidDecodeHookSignatureError{
-		FieldName: fieldName,
-		HookName:  hookName,
-		Message:   err.Error(),
-	}
-}
-
-func NewInvalidDefineHookSignatureError(fieldName, hookName string, err error) error {
-	return &InvalidDefineHookSignatureError{
-		FieldName: fieldName,
-		HookName:  hookName,
-		Message:   err.Error(),
-	}
-}
-
-func NewInvalidCompleteHookSignatureError(fieldName, hookName string, err error) error {
-	return &InvalidCompleteHookSignatureError{
-		FieldName: fieldName,
-		HookName:  hookName,
-		Message:   err.Error(),
-	}
-}
-
 func NewInvalidTagUsageError(fieldName, tagName, message string) error {
 	return &InvalidTagUsageError{
 		FieldName: fieldName,
@@ -496,15 +331,6 @@ func NewConflictingTagsError(fieldName string, tags []string, message string) er
 		FieldName:       fieldName,
 		ConflictingTags: tags,
 		Message:         message,
-	}
-}
-
-func NewConflictingTypeError(fieldType reflect.Type, fields []string, message string) error {
-	return &ConflictingTypeError{
-		Fields:   fields,
-		Type:     fieldType,
-		TypeName: fieldType.String(),
-		Message:  message,
 	}
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -3,7 +3,6 @@ package errors
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,26 +12,26 @@ import (
 func TestInvalidBooleanTagError_ErrorMessage(t *testing.T) {
 	err := &InvalidBooleanTagError{
 		FieldName: "InvalidCustom",
-		TagName:   "flagcustom",
+		TagName:   "flaghidden",
 		TagValue:  "invalid",
 	}
 
-	expected := "field 'InvalidCustom': tag 'flagcustom=invalid': invalid boolean value"
+	expected := "field 'InvalidCustom': tag 'flaghidden=invalid': invalid boolean value"
 	assert.Equal(t, expected, err.Error())
 }
 
 func TestInvalidBooleanTagError_ContainsExpectedStrings(t *testing.T) {
 	err := &InvalidBooleanTagError{
 		FieldName: "SomeField",
-		TagName:   "flagcustom",
+		TagName:   "flaghidden",
 		TagValue:  "bad_value",
 	}
 
 	errorMsg := err.Error()
 
-	// These are the strings our flagcustom test expects to find
+	// These are the strings our flaghidden test expects to find
 	assert.Contains(t, errorMsg, "SomeField")
-	assert.Contains(t, errorMsg, "flagcustom")
+	assert.Contains(t, errorMsg, "flaghidden")
 	assert.Contains(t, errorMsg, "bad_value")
 }
 
@@ -61,13 +60,13 @@ func TestInvalidBooleanTagError_ErrorsIs(t *testing.T) {
 }
 
 func TestInvalidBooleanTagError_ErrorsAs(t *testing.T) {
-	err := NewInvalidBooleanTagError("TestField", "flagcustom", "maybe")
+	err := NewInvalidBooleanTagError("TestField", "flaghidden", "maybe")
 
 	// Test errors.As() functionality
 	var boolErr *InvalidBooleanTagError
 	require.True(t, errors.As(err, &boolErr))
 	assert.Equal(t, "TestField", boolErr.FieldName)
-	assert.Equal(t, "flagcustom", boolErr.TagName)
+	assert.Equal(t, "flaghidden", boolErr.TagName)
 	assert.Equal(t, "maybe", boolErr.TagValue)
 
 	// Test DefinitionError interface extraction
@@ -162,46 +161,6 @@ func TestInvalidShorthandError_ErrorsIs(t *testing.T) {
 	}
 
 	assert.True(t, errors.Is(err, ErrInvalidShorthand))
-	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
-}
-
-func TestMissingDefineHookError_ErrorMessage(t *testing.T) {
-	err := &MissingDefineHookError{
-		FieldName:    "ServerMode",
-		ExpectedHook: "DefineServerMode",
-	}
-
-	expected := "field 'ServerMode': flagcustom='true' but missing define hook 'DefineServerMode'"
-	assert.Equal(t, expected, err.Error())
-}
-
-func TestMissingDefineHookError_ErrorsIs(t *testing.T) {
-	err := &MissingDefineHookError{
-		FieldName:    "TestField",
-		ExpectedHook: "DefineTestField",
-	}
-
-	assert.True(t, errors.Is(err, ErrMissingDefineHook))
-	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
-}
-
-func TestMissingDecodeHookError_ErrorMessage(t *testing.T) {
-	err := &MissingDecodeHookError{
-		FieldName:    "ServerMode",
-		ExpectedHook: "DecodeServerMode",
-	}
-
-	expected := "field 'ServerMode': flagcustom='true' but missing decode hook 'DecodeServerMode'"
-	assert.Equal(t, expected, err.Error())
-}
-
-func TestMissingDecodeHookError_ErrorsIs(t *testing.T) {
-	err := &MissingDecodeHookError{
-		FieldName:    "TestField",
-		ExpectedHook: "DecodeTestField",
-	}
-
-	assert.True(t, errors.Is(err, ErrMissingDecodeHook))
 	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
 }
 
@@ -394,24 +353,6 @@ func TestNewInvalidShorthandError_Constructor(t *testing.T) {
 	assert.Equal(t, "verb", shortErr.Shorthand)
 }
 
-func TestNewMissingDefineHookError_Constructor(t *testing.T) {
-	err := NewMissingDefineHookError("ServerMode", "DefineServerMode")
-
-	var hookErr *MissingDefineHookError
-	require.True(t, errors.As(err, &hookErr))
-	assert.Equal(t, "ServerMode", hookErr.FieldName)
-	assert.Equal(t, "DefineServerMode", hookErr.ExpectedHook)
-}
-
-func TestNewMissingDecodeHookError_Constructor(t *testing.T) {
-	err := NewMissingDecodeHookError("ServerMode", "DecodeServerMode")
-
-	var hookErr *MissingDecodeHookError
-	require.True(t, errors.As(err, &hookErr))
-	assert.Equal(t, "ServerMode", hookErr.FieldName)
-	assert.Equal(t, "DecodeServerMode", hookErr.ExpectedHook)
-}
-
 func TestNewInvalidTagUsageError_Constructor(t *testing.T) {
 	err := NewInvalidTagUsageError("TestField", "flagrequired", "cannot ignore required field")
 
@@ -465,22 +406,6 @@ func TestDefinitionError_Interface_MultipleTypes(t *testing.T) {
 			field: "ShortField",
 		},
 		{
-			name: "MissingDefineHookError",
-			err: &MissingDefineHookError{
-				FieldName:    "CustomField",
-				ExpectedHook: "DefineCustomField",
-			},
-			field: "CustomField",
-		},
-		{
-			name: "MissingDecodeHookError",
-			err: &MissingDecodeHookError{
-				FieldName:    "CustomField",
-				ExpectedHook: "DecodeCustomField",
-			},
-			field: "CustomField",
-		},
-		{
 			name: "InvalidTagUsage",
 			err: &InvalidTagUsageError{
 				FieldName: "InvalidTagField",
@@ -497,16 +422,6 @@ func TestDefinitionError_Interface_MultipleTypes(t *testing.T) {
 				Message:         "conflict",
 			},
 			field: "ConflictField",
-		},
-		{
-			name: "ConflictingTypeError",
-			err: &ConflictingTypeError{
-				Type:     reflect.TypeOf(""),
-				TypeName: "string",
-				Fields:   []string{"ConflictField1", "ConflictField2"},
-				Message:  "conflict",
-			},
-			field: "ConflictField1, ConflictField2",
 		},
 		{
 			name: "UnsupportedTypeError",
@@ -544,7 +459,7 @@ func TestDefinitionError_Interface_MultipleTypes(t *testing.T) {
 }
 
 func TestErrorChaining_WithWrapping(t *testing.T) {
-	originalErr := NewInvalidBooleanTagError("TestField", "flagcustom", "invalid")
+	originalErr := NewInvalidBooleanTagError("TestField", "flaghidden", "invalid")
 
 	// Test wrapping with additional context
 	wrappedErr := fmt.Errorf("failed to process field: %w", originalErr)
@@ -629,7 +544,7 @@ func TestValidationError_ErrorMessage_WithoutContextName_NilErrors(t *testing.T)
 }
 
 func TestValidationError_UnderlyingErrors_ReturnsCorrectSlice(t *testing.T) {
-	err1 := NewInvalidBooleanTagError("Field1", "flagcustom", "invalid")
+	err1 := NewInvalidBooleanTagError("Field1", "flaghidden", "invalid")
 	err2 := fmt.Errorf("errorf")
 	err3 := errors.New("custom error")
 
@@ -704,7 +619,7 @@ func TestValidationError_Unwrap_ErrorsIs(t *testing.T) {
 func TestValidationError_Unwrap_ErrorsAs(t *testing.T) {
 	inner := &InvalidBooleanTagError{
 		FieldName: "Field1",
-		TagName:   "flagcustom",
+		TagName:   "flaghidden",
 		TagValue:  "bad",
 	}
 	ve := &ValidationError{
@@ -760,345 +675,6 @@ func TestValidationError_Unwrap_ErrorsAsStillMatchesSelf(t *testing.T) {
 	assert.Equal(t, "test", target.ContextName)
 }
 
-func TestInvalidDecodeHookSignatureError_ErrorMessage(t *testing.T) {
-	err := &InvalidDecodeHookSignatureError{
-		FieldName: "ServerMode",
-		HookName:  "DecodeServerMode",
-		Message:   "decode hook must have signature: func(input interface{}) (interface{}, error)",
-	}
-
-	expected := "field 'ServerMode': invalid 'DecodeServerMode' decode hook: decode hook must have signature: func(input interface{}) (interface{}, error)"
-	assert.Equal(t, expected, err.Error())
-}
-
-func TestInvalidDecodeHookSignatureError_ContainsExpectedStrings(t *testing.T) {
-	err := &InvalidDecodeHookSignatureError{
-		FieldName: "CustomField",
-		HookName:  "DecodeCustomField",
-		Message:   "wrong signature",
-	}
-
-	errorMsg := err.Error()
-	assert.Contains(t, errorMsg, "CustomField")
-	assert.Contains(t, errorMsg, "DecodeCustomField")
-	assert.Contains(t, errorMsg, "wrong signature")
-	assert.Contains(t, errorMsg, "decode hook")
-}
-
-func TestInvalidDecodeHookSignatureError_FieldInterface(t *testing.T) {
-	err := &InvalidDecodeHookSignatureError{
-		FieldName: "TestField",
-		HookName:  "DecodeTestField",
-		Message:   "invalid signature",
-	}
-
-	// Test that it implements DefinitionError interface
-	var fieldErr DefinitionError = err
-	assert.Equal(t, "TestField", fieldErr.Field())
-}
-
-func TestInvalidDecodeHookSignatureError_ErrorsIs(t *testing.T) {
-	err := &InvalidDecodeHookSignatureError{
-		FieldName: "TestField",
-		HookName:  "DecodeTestField",
-		Message:   "invalid signature",
-	}
-
-	// Test errors.Is() functionality
-	assert.True(t, errors.Is(err, ErrInvalidDecodeHookSignature))
-	assert.False(t, errors.Is(err, ErrInvalidDefineHookSignature))
-	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
-}
-
-func TestInvalidDecodeHookSignatureError_ErrorsAs(t *testing.T) {
-	originalErr := errors.New("parameter 0 has wrong type")
-	err := NewInvalidDecodeHookSignatureError("TestField", "DecodeTestField", originalErr)
-
-	// Test errors.As() functionality
-	var decodeErr *InvalidDecodeHookSignatureError
-	require.True(t, errors.As(err, &decodeErr))
-	assert.Equal(t, "TestField", decodeErr.FieldName)
-	assert.Equal(t, "DecodeTestField", decodeErr.HookName)
-	assert.Equal(t, "parameter 0 has wrong type", decodeErr.Message)
-
-	// Test DefinitionError interface extraction
-	var fieldErr DefinitionError
-	require.True(t, errors.As(err, &fieldErr))
-	assert.Equal(t, "TestField", fieldErr.Field())
-}
-
-func TestInvalidDefineHookSignatureError_ErrorMessage(t *testing.T) {
-	err := &InvalidDefineHookSignatureError{
-		FieldName: "ServerMode",
-		HookName:  "DefineServerMode",
-		Message:   "define hook must have signature: func(c *cobra.Command, name, short, descr string, structField reflect.StructField, fieldValue reflect.Value)",
-	}
-
-	expected := "field 'ServerMode': invalid 'DefineServerMode' define hook: define hook must have signature: func(c *cobra.Command, name, short, descr string, structField reflect.StructField, fieldValue reflect.Value)"
-	assert.Equal(t, expected, err.Error())
-}
-
-func TestInvalidDefineHookSignatureError_ContainsExpectedStrings(t *testing.T) {
-	err := &InvalidDefineHookSignatureError{
-		FieldName: "CustomField",
-		HookName:  "DefineCustomField",
-		Message:   "wrong number of parameters",
-	}
-
-	errorMsg := err.Error()
-	assert.Contains(t, errorMsg, "CustomField")
-	assert.Contains(t, errorMsg, "DefineCustomField")
-	assert.Contains(t, errorMsg, "wrong number of parameters")
-	assert.Contains(t, errorMsg, "define hook")
-}
-
-func TestInvalidDefineHookSignatureError_FieldInterface(t *testing.T) {
-	err := &InvalidDefineHookSignatureError{
-		FieldName: "TestField",
-		HookName:  "DefineTestField",
-		Message:   "invalid signature",
-	}
-
-	// Test that it implements DefinitionError interface
-	var fieldErr DefinitionError = err
-	assert.Equal(t, "TestField", fieldErr.Field())
-}
-
-func TestInvalidDefineHookSignatureError_ErrorsIs(t *testing.T) {
-	err := &InvalidDefineHookSignatureError{
-		FieldName: "TestField",
-		HookName:  "DefineTestField",
-		Message:   "invalid signature",
-	}
-
-	// Test errors.Is() functionality
-	assert.True(t, errors.Is(err, ErrInvalidDefineHookSignature))
-	assert.False(t, errors.Is(err, ErrInvalidDecodeHookSignature))
-	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
-}
-
-func TestInvalidDefineHookSignatureError_ErrorsAs(t *testing.T) {
-	originalErr := errors.New("parameter 1 has wrong type")
-	err := NewInvalidDefineHookSignatureError("TestField", "DefineTestField", originalErr)
-
-	// Test errors.As() functionality
-	var defineErr *InvalidDefineHookSignatureError
-	require.True(t, errors.As(err, &defineErr))
-	assert.Equal(t, "TestField", defineErr.FieldName)
-	assert.Equal(t, "DefineTestField", defineErr.HookName)
-	assert.Equal(t, "parameter 1 has wrong type", defineErr.Message)
-
-	// Test DefinitionError interface extraction
-	var fieldErr DefinitionError
-	require.True(t, errors.As(err, &fieldErr))
-	assert.Equal(t, "TestField", fieldErr.Field())
-}
-
-func TestInvalidCompleteHookSignatureError_ErrorMessage(t *testing.T) {
-	err := &InvalidCompleteHookSignatureError{
-		FieldName: "ServerMode",
-		HookName:  "CompleteServerMode",
-		Message:   "complete hook must have signature: func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)",
-	}
-
-	expected := "field 'ServerMode': invalid 'CompleteServerMode' completion hook: complete hook must have signature: func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)"
-	assert.Equal(t, expected, err.Error())
-}
-
-func TestInvalidCompleteHookSignatureError_ContainsExpectedStrings(t *testing.T) {
-	err := &InvalidCompleteHookSignatureError{
-		FieldName: "CustomField",
-		HookName:  "CompleteCustomField",
-		Message:   "wrong return type",
-	}
-
-	errorMsg := err.Error()
-	assert.Contains(t, errorMsg, "CustomField")
-	assert.Contains(t, errorMsg, "CompleteCustomField")
-	assert.Contains(t, errorMsg, "wrong return type")
-	assert.Contains(t, errorMsg, "completion hook")
-}
-
-func TestInvalidCompleteHookSignatureError_FieldInterface(t *testing.T) {
-	err := &InvalidCompleteHookSignatureError{
-		FieldName: "TestField",
-		HookName:  "CompleteTestField",
-		Message:   "invalid signature",
-	}
-
-	var fieldErr DefinitionError = err
-	assert.Equal(t, "TestField", fieldErr.Field())
-}
-
-func TestInvalidCompleteHookSignatureError_ErrorsIs(t *testing.T) {
-	err := &InvalidCompleteHookSignatureError{
-		FieldName: "TestField",
-		HookName:  "CompleteTestField",
-		Message:   "invalid signature",
-	}
-
-	assert.True(t, errors.Is(err, ErrInvalidCompleteHookSignature))
-	assert.False(t, errors.Is(err, ErrInvalidDefineHookSignature))
-	assert.False(t, errors.Is(err, ErrInvalidDecodeHookSignature))
-}
-
-func TestInvalidCompleteHookSignatureError_ErrorsAs(t *testing.T) {
-	originalErr := errors.New("parameter 2 has wrong type")
-	err := NewInvalidCompleteHookSignatureError("TestField", "CompleteTestField", originalErr)
-
-	var completeErr *InvalidCompleteHookSignatureError
-	require.True(t, errors.As(err, &completeErr))
-	assert.Equal(t, "TestField", completeErr.FieldName)
-	assert.Equal(t, "CompleteTestField", completeErr.HookName)
-	assert.Equal(t, "parameter 2 has wrong type", completeErr.Message)
-
-	var fieldErr DefinitionError
-	require.True(t, errors.As(err, &fieldErr))
-	assert.Equal(t, "TestField", fieldErr.Field())
-}
-
-func TestConflictingTagsError_ErrorMessage(t *testing.T) {
-	err := &ConflictingTagsError{
-		FieldName:       "TestField",
-		ConflictingTags: []string{"flagignore", "flagrequired"},
-		Message:         "cannot ignore a required field",
-	}
-	expected := "field 'TestField': conflicting tags [flagignore, flagrequired]: cannot ignore a required field"
-	assert.Equal(t, expected, err.Error())
-}
-
-func TestConflictingTagsError_ErrorsIs(t *testing.T) {
-	err := &ConflictingTagsError{
-		FieldName:       "TestField",
-		ConflictingTags: []string{"tag1", "tag2"},
-		Message:         "conflict message",
-	}
-	assert.True(t, errors.Is(err, ErrConflictingTags))
-	assert.False(t, errors.Is(err, ErrUnsupportedType))
-}
-
-func TestNewConflictingTagsError_Constructor(t *testing.T) {
-	tags := []string{"flagignore", "flagrequired"}
-	err := NewConflictingTagsError("TestField", tags, "cannot ignore required field")
-	var conflictErr *ConflictingTagsError
-	require.True(t, errors.As(err, &conflictErr))
-	assert.Equal(t, "TestField", conflictErr.FieldName)
-	assert.Equal(t, tags, conflictErr.ConflictingTags)
-	assert.Equal(t, "cannot ignore required field", conflictErr.Message)
-}
-
-func TestConflictingTypeError_ErrorMessage(t *testing.T) {
-	// Create a test type for the error
-	var testValue int
-	testType := reflect.TypeOf(testValue)
-
-	err := &ConflictingTypeError{
-		Type:     testType,
-		TypeName: testType.String(),
-		Fields:   []string{"Field1", "Field2", "Field3"},
-		Message:  "create distinct custom types for each field",
-	}
-
-	expected := "fields [Field1, Field2, Field3]: conflicting type [int]: create distinct custom types for each field"
-	assert.Equal(t, expected, err.Error())
-}
-
-func TestConflictingTypeError_ContainsExpectedStrings(t *testing.T) {
-	// Create a test type for the error
-	type CustomStruct struct {
-		Name string
-	}
-	testType := reflect.TypeOf(CustomStruct{})
-
-	err := &ConflictingTypeError{
-		Type:     testType,
-		TypeName: testType.String(),
-		Fields:   []string{"FieldA", "FieldB"},
-		Message:  "multiple fields cannot use the same custom type",
-	}
-
-	errorMsg := err.Error()
-	assert.Contains(t, errorMsg, "FieldA")
-	assert.Contains(t, errorMsg, "FieldB")
-	assert.Contains(t, errorMsg, testType.String())
-	assert.Contains(t, errorMsg, "multiple fields cannot use the same custom type")
-	assert.Contains(t, errorMsg, "conflicting type")
-}
-
-func TestConflictingTypeError_FieldInterface(t *testing.T) {
-	var testValue string
-	testType := reflect.TypeOf(testValue)
-
-	err := &ConflictingTypeError{
-		Type:     testType,
-		TypeName: testType.String(),
-		Fields:   []string{"FirstField", "SecondField"},
-		Message:  "test message",
-	}
-
-	// Test that it implements DefinitionError interface
-	var fieldErr DefinitionError = err
-	assert.Equal(t, "FirstField, SecondField", fieldErr.Field())
-}
-
-func TestConflictingTypeError_ErrorsIs(t *testing.T) {
-	var testValue bool
-	testType := reflect.TypeOf(testValue)
-
-	err := &ConflictingTypeError{
-		Type:     testType,
-		TypeName: testType.String(),
-		Fields:   []string{"BoolField1", "BoolField2"},
-		Message:  "conflicting boolean fields",
-	}
-
-	// Test errors.Is() functionality
-	assert.True(t, errors.Is(err, ErrConflictingType))
-	assert.False(t, errors.Is(err, ErrConflictingTags))
-	assert.False(t, errors.Is(err, ErrUnsupportedType))
-	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
-}
-
-func TestConflictingTypeError_ErrorsAs(t *testing.T) {
-	type TestType struct {
-		Value int
-	}
-	testType := reflect.TypeOf(TestType{})
-	fields := []string{"TestField1", "TestField2"}
-
-	err := NewConflictingTypeError(testType, fields, "test conflict message")
-
-	// Test errors.As() functionality
-	var conflictErr *ConflictingTypeError
-	require.True(t, errors.As(err, &conflictErr))
-	assert.Equal(t, testType, conflictErr.Type)
-	assert.Equal(t, testType.String(), conflictErr.TypeName)
-	assert.Equal(t, fields, conflictErr.Fields)
-	assert.Equal(t, "test conflict message", conflictErr.Message)
-
-	// Test DefinitionError interface extraction
-	var fieldErr DefinitionError
-	require.True(t, errors.As(err, &fieldErr))
-	assert.Equal(t, "TestField1, TestField2", fieldErr.Field())
-}
-
-func TestNewConflictingTypeError_Constructor(t *testing.T) {
-	type CustomType struct {
-		Data string
-	}
-	testType := reflect.TypeOf(CustomType{})
-	fields := []string{"CustomField1", "CustomField2", "CustomField3"}
-	message := "create distinct custom types for each field"
-
-	err := NewConflictingTypeError(testType, fields, message)
-
-	var conflictErr *ConflictingTypeError
-	require.True(t, errors.As(err, &conflictErr))
-	assert.Equal(t, testType, conflictErr.Type)
-	assert.Equal(t, testType.String(), conflictErr.TypeName)
-	assert.Equal(t, fields, conflictErr.Fields)
-	assert.Equal(t, message, conflictErr.Message)
-}
 
 func TestInputError_ErrorMessage(t *testing.T) {
 	err := &InputError{
@@ -1132,7 +708,7 @@ func TestInputError_ErrorsIs(t *testing.T) {
 	require.True(t, errors.Is(err, ErrInputValue))
 	assert.False(t, errors.Is(err, ErrInvalidBooleanTag))
 	assert.False(t, errors.Is(err, ErrInvalidShorthand))
-	assert.False(t, errors.Is(err, ErrMissingDefineHook))
+	assert.False(t, errors.Is(err, ErrInvalidTagUsage))
 }
 
 func TestInputError_ErrorsAs(t *testing.T) {
@@ -1266,7 +842,7 @@ func TestInputError_Vs_DefinitionError_Distinction(t *testing.T) {
 	inputErr := NewInputError("nil", "cannot define flags from nil value")
 
 	// Create a DefinitionError
-	fieldErr := NewInvalidBooleanTagError("TestField", "flagcustom", "invalid")
+	fieldErr := NewInvalidBooleanTagError("TestField", "flaghidden", "invalid")
 
 	// InputError should NOT implement DefinitionError interface
 	var defErr DefinitionError

--- a/flagenvonly_test.go
+++ b/flagenvonly_test.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"reflect"
 	"testing"
 
 	structclierrors "github.com/leodido/structcli/errors"
 	internalenv "github.com/leodido/structcli/internal/env"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,19 +66,6 @@ type envOnlyWithTypeOptions struct {
 }
 
 func (o *envOnlyWithTypeOptions) Attach(c *cobra.Command) error { return nil }
-
-type envOnlyWithCustomOptions struct {
-	Bad string `flagenv:"only" flag:"bad" flagcustom:"true"`
-}
-
-func (o *envOnlyWithCustomOptions) Attach(c *cobra.Command) error { return nil }
-
-func (o *envOnlyWithCustomOptions) DefineBad(name, alias, group string, f reflect.StructField, v reflect.Value) (pflag.Value, string) {
-	return nil, ""
-}
-func (o *envOnlyWithCustomOptions) DecodeBad(name, alias, group string, f reflect.StructField, v reflect.Value) error {
-	return nil
-}
 
 type envOnlyWithIgnoreOptions struct {
 	Bad string `flagenv:"only" flagignore:"true"`
@@ -213,17 +198,6 @@ func TestDefine_EnvOnly_RejectsType(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, structclierrors.ErrConflictingTags)
 	assert.Contains(t, err.Error(), "flagtype cannot be used with flagenv='only'")
-}
-
-func TestDefine_EnvOnly_RejectsCustom(t *testing.T) {
-	resetEnvOnlyTestState()
-
-	cmd := &cobra.Command{Use: "app"}
-	opts := &envOnlyWithCustomOptions{}
-	err := Define(cmd, opts)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, structclierrors.ErrConflictingTags)
-	assert.Contains(t, err.Error(), "flagcustom cannot be used with flagenv='only'")
 }
 
 func TestDefine_EnvOnly_RejectsIgnore(t *testing.T) {

--- a/flaghidden_test.go
+++ b/flaghidden_test.go
@@ -89,18 +89,23 @@ type hiddenGroupOptions struct {
 func (o *hiddenGroupOptions) Attach(c *cobra.Command) error { return nil }
 
 type hiddenCustomOptions struct {
-	Mode string `flagcustom:"true" flag:"mode" flaghidden:"true" flagdescr:"hidden custom"`
+	Mode string `flag:"mode" flaghidden:"true" flagdescr:"hidden custom"`
 }
 
-func (o *hiddenCustomOptions) DefineMode(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	*fieldPtr = "default"
+func (o *hiddenCustomOptions) FieldHooks() map[string]FieldHook {
+	return map[string]FieldHook{
+		"Mode": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*string)
+				*fieldPtr = "default"
 
-	return values.NewString(fieldPtr), descr
-}
-
-func (o *hiddenCustomOptions) DecodeMode(input any) (any, error) {
-	return input, nil
+				return values.NewString(fieldPtr), descr
+			},
+			Decode: func(input any) (any, error) {
+				return input, nil
+			},
+		},
+	}
 }
 
 func (o *hiddenCustomOptions) Attach(c *cobra.Command) error { return nil }

--- a/go.work.sum
+++ b/go.work.sum
@@ -35,6 +35,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/structcli v0.15.0/go.mod h1:Tn8D3VE3eupE7H23HF92TMX+sMwBD04pNQAIu7PRl+I=
 github.com/leodido/structcli v0.16.0/go.mod h1:aCyyEWjghVqS7s7Ju8+aC8zSo5Y83W8Y5KlxN2X7ftI=
 github.com/leodido/structcli v0.16.1/go.mod h1:aCyyEWjghVqS7s7Ju8+aC8zSo5Y83W8Y5KlxN2X7ftI=
+github.com/leodido/structcli v0.17.0/go.mod h1:aCyyEWjghVqS7s7Ju8+aC8zSo5Y83W8Y5KlxN2X7ftI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/sftp v1.13.7/go.mod h1:KMKI0t3T6hfA+lTR/ssZdunHo+uwq7ghoN09/FSu3DY=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=

--- a/integration_test.go
+++ b/integration_test.go
@@ -315,20 +315,24 @@ type completionIntegrationOptions struct {
 
 func (o *completionIntegrationOptions) Attach(c *cobra.Command) error { return nil }
 
-func (o *completionIntegrationOptions) CompleteRegion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	candidates := []string{"us-east-1", "us-west-2", "eu-west-1"}
-	if toComplete == "" {
-		return candidates, cobra.ShellCompDirectiveNoFileComp
-	}
+func (o *completionIntegrationOptions) CompletionHooks() map[string]structcli.CompleteHookFunc {
+	return map[string]structcli.CompleteHookFunc{
+		"Region": func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			candidates := []string{"us-east-1", "us-west-2", "eu-west-1"}
+			if toComplete == "" {
+				return candidates, cobra.ShellCompDirectiveNoFileComp
+			}
 
-	filtered := make([]string, 0, len(candidates))
-	for _, candidate := range candidates {
-		if strings.HasPrefix(candidate, toComplete) {
-			filtered = append(filtered, candidate)
-		}
-	}
+			filtered := make([]string, 0, len(candidates))
+			for _, candidate := range candidates {
+				if strings.HasPrefix(candidate, toComplete) {
+					filtered = append(filtered, candidate)
+				}
+			}
 
-	return filtered, cobra.ShellCompDirectiveNoFileComp
+			return filtered, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
 }
 
 func TestDefine_CompletionShellRequest_Integration(t *testing.T) {
@@ -406,7 +410,7 @@ func TestDefine_Integration(t *testing.T) {
 			assert.Contains(t, u, "Configuration Flags:", "The help output should contain the 'Configuration' group")
 			assert.Contains(t, u, "Deep Flags:", "The help output should contain the 'Deep' group")
 
-			// Ignore custom types (no flagcustom tag, not in the registry)
+			// Ignore custom types (not in the registry, no FieldHookProvider)
 			ignorecustomstringtypeFlag := f.Lookup("ignorecustomstringtype")
 			require.Nil(t, ignorecustomstringtypeFlag, "Pflag 'ignorecustomstringtype' should not be defined")
 
@@ -2222,120 +2226,131 @@ const (
 )
 
 type customDecodeHookOptions struct {
-	ServerMode ServerMode1 `flagcustom:"true" flag:"server-mode" flagdescr:"Server deployment mode" flagenv:"true"`
+	ServerMode ServerMode1 `flag:"server-mode" flagdescr:"Server deployment mode" flagenv:"true"`
 	LogLevel   string      `flag:"log-level" flagdescr:"Logging level"`
 }
 
-func (o *customDecodeHookOptions) DefineServerMode(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	enhancedDesc := descr + " (development, staging, production)"
-	fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
-	*fieldPtr = DevMode1
+func (o *customDecodeHookOptions) FieldHooks() map[string]structcli.FieldHook {
+	return map[string]structcli.FieldHook{
+		"ServerMode": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				enhancedDesc := descr + " (development, staging, production)"
+				fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
+				*fieldPtr = DevMode1
 
-	// Since ServerMode1 is a string type, we can cast its pointer to *string and use our existing stringValue helper.
-	return values.NewString((*string)(fieldPtr)), enhancedDesc
-}
-
-func (o *customDecodeHookOptions) DecodeServerMode(input any) (any, error) {
-	str, ok := input.(string)
-	if !ok {
-		return input, nil // Not a string, pass through
-	}
-	switch strings.ToLower(strings.TrimSpace(str)) {
-	case "dev", "develop", "development":
-		return ServerMode1("development"), nil
-	case "stage", "staging":
-		return ServerMode1("staging"), nil
-	case "prod", "production":
-		return ServerMode1("production"), nil
-	case "test_custom_decode": // Special test value to verify hook was called
-		return ServerMode1("CUSTOM_DECODE_CALLED"), nil
-	default:
-		return nil, fmt.Errorf("invalid server mode: %s (must be development, staging, or production)", str)
+				return values.NewString((*string)(fieldPtr)), enhancedDesc
+			},
+			Decode: func(input any) (any, error) {
+				str, ok := input.(string)
+				if !ok {
+					return input, nil // Not a string, pass through
+				}
+				switch strings.ToLower(strings.TrimSpace(str)) {
+				case "dev", "develop", "development":
+					return ServerMode1("development"), nil
+				case "stage", "staging":
+					return ServerMode1("staging"), nil
+				case "prod", "production":
+					return ServerMode1("production"), nil
+				case "test_custom_decode": // Special test value to verify hook was called
+					return ServerMode1("CUSTOM_DECODE_CALLED"), nil
+				default:
+					return nil, fmt.Errorf("invalid server mode: %s (must be development, staging, or production)", str)
+				}
+			},
+		},
 	}
 }
 
 func (o *customDecodeHookOptions) Attach(c *cobra.Command) error { return structcli.Define(c, o) }
 
 type mixedHooksOptions struct {
-	ServerMode ServerMode1   `flagcustom:"true" flag:"server-mode" flagdescr:"Server mode"`
+	ServerMode ServerMode1   `flag:"server-mode" flagdescr:"Server mode"`
 	Timeout    time.Duration `flag:"timeout" flagdescr:"Request timeout"`
 	LogLevel   zapcore.Level `flag:"log-level" flagdescr:"Log level"`
 }
 
-// Implement the custom methods for ServerMode
-func (m *mixedHooksOptions) DefineServerMode(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
-	*fieldPtr = DevMode1
+func (m *mixedHooksOptions) FieldHooks() map[string]structcli.FieldHook {
+	return map[string]structcli.FieldHook{
+		"ServerMode": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
+				*fieldPtr = DevMode1
 
-	return values.NewString((*string)(fieldPtr)), descr
-}
-
-func (m *mixedHooksOptions) DecodeServerMode(input any) (any, error) {
-	str, ok := input.(string)
-	if !ok {
-		return input, nil
+				return values.NewString((*string)(fieldPtr)), descr
+			},
+			Decode: func(input any) (any, error) {
+				str, ok := input.(string)
+				if !ok {
+					return input, nil
+				}
+				if strings.ToLower(str) == "test" {
+					return ServerMode1("TEST_MODE"), nil
+				}
+				return ServerMode1(str), nil
+			},
+		},
 	}
-	if strings.ToLower(str) == "test" {
-		return ServerMode1("TEST_MODE"), nil
-	}
-	return ServerMode1(str), nil
 }
 
 func (o *mixedHooksOptions) Attach(c *cobra.Command) error { return structcli.Define(c, o) }
 
 type multiCustomOptions struct {
-	Mode1 ServerMode1 `flagcustom:"true" flagdescr:"First mode"`
-	Mode2 ServerMode2 `flagcustom:"true" flagdescr:"Second mode"`
+	Mode1 ServerMode1 `flagdescr:"First mode"`
+	Mode2 ServerMode2 `flagdescr:"Second mode"`
 	Level string      `flag:"level" flagdescr:"Normal field"`
 }
 
-func (m *multiCustomOptions) DefineMode1(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	enhancedDesc := descr + " (first custom mode)"
-	fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
-	*fieldPtr = DevMode1
+func (m *multiCustomOptions) FieldHooks() map[string]structcli.FieldHook {
+	return map[string]structcli.FieldHook{
+		"Mode1": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				enhancedDesc := descr + " (first custom mode)"
+				fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
+				*fieldPtr = DevMode1
 
-	return values.NewString((*string)(fieldPtr)), enhancedDesc
-}
+				return values.NewString((*string)(fieldPtr)), enhancedDesc
+			},
+			Decode: func(input any) (any, error) {
+				str, ok := input.(string)
+				if !ok {
+					return input, nil
+				}
 
-func (m *multiCustomOptions) DecodeMode1(input any) (any, error) {
-	str, ok := input.(string)
-	if !ok {
-		return input, nil
-	}
+				switch strings.ToLower(strings.TrimSpace(str)) {
+				case "test1":
+					return ServerMode1("MODE1_CUSTOM_CALLED"), nil
+				case "dev", "development":
+					return ServerMode1("development"), nil
+				default:
+					return ServerMode1("mode1_" + str), nil
+				}
+			},
+		},
+		"Mode2": {
+			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+				enhancedDesc := descr + " (second custom mode)"
+				fieldPtr := fieldValue.Addr().Interface().(*ServerMode2)
+				*fieldPtr = StagingMode2
 
-	// Add prefix to distinguish from Mode2
-	switch strings.ToLower(strings.TrimSpace(str)) {
-	case "test1":
-		return ServerMode1("MODE1_CUSTOM_CALLED"), nil
-	case "dev", "development":
-		return ServerMode1("development"), nil
-	default:
-		return ServerMode1("mode1_" + str), nil
-	}
-}
+				return values.NewString((*string)(fieldPtr)), enhancedDesc
+			},
+			Decode: func(input any) (any, error) {
+				str, ok := input.(string)
+				if !ok {
+					return input, nil
+				}
 
-func (m *multiCustomOptions) DefineMode2(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	enhancedDesc := descr + " (second custom mode)"
-	fieldPtr := fieldValue.Addr().Interface().(*ServerMode2)
-	*fieldPtr = StagingMode2
-
-	return values.NewString((*string)(fieldPtr)), enhancedDesc
-}
-
-func (m *multiCustomOptions) DecodeMode2(input any) (any, error) {
-	str, ok := input.(string)
-	if !ok {
-		return input, nil
-	}
-
-	// Add different prefix to distinguish from Mode1
-	switch strings.ToLower(strings.TrimSpace(str)) {
-	case "test2":
-		return ServerMode2("MODE2_CUSTOM_CALLED"), nil
-	case "stage", "staging":
-		return ServerMode2("staging"), nil
-	default:
-		return ServerMode2("mode2_" + str), nil
+				switch strings.ToLower(strings.TrimSpace(str)) {
+				case "test2":
+					return ServerMode2("MODE2_CUSTOM_CALLED"), nil
+				case "stage", "staging":
+					return ServerMode2("staging"), nil
+				default:
+					return ServerMode2("mode2_" + str), nil
+				}
+			},
+		},
 	}
 }
 
@@ -2615,68 +2630,6 @@ func TestUnmarshal_CustomDecodeHook_ScopeRetrieval(t *testing.T) {
 		assert.Equal(t, ServerMode2("mode2_flag2"), opts.Mode2, "Mode2 flag should override config and be processed by custom hook")
 	})
 }
-
-type nestedSameCustomType struct {
-	ModeAgain ServerMode1 `flagcustom:"true" flagdescr:"First mode"`
-}
-
-func (m *nestedSameCustomType) DefineModeAgain(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	return nil, ""
-}
-
-func (m *nestedSameCustomType) DecodeModeAgain(input any) (any, error) {
-	return input, nil
-}
-
-type conflictingCustomType struct {
-	Mode  ServerMode1 `flagcustom:"true" flagdescr:"First mode"`
-	Level string      `flag:"level" flagdescr:"Normal field"`
-	Nest  nestedSameCustomType
-}
-
-func (m *conflictingCustomType) DefineMode(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	return nil, ""
-}
-
-func (m *conflictingCustomType) DecodeMode(input any) (any, error) {
-	return input, nil
-}
-
-func (m *conflictingCustomType) Attach(c *cobra.Command) error { return nil }
-
-type wrongDefineParamOptions struct {
-	CustomField string `flagcustom:"true"`
-}
-
-// Wrong signature: first parameter should be `name string`.
-func (o *wrongDefineParamOptions) DefineCustomField(p1 int, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
-	return nil, ""
-}
-func (o *wrongDefineParamOptions) DecodeCustomField(i any) (any, error) { return i, nil }
-func (o *wrongDefineParamOptions) Attach(c *cobra.Command) error        { return structcli.Define(c, o) }
-
-type wrongDefineReturn1Options struct {
-	CustomField string `flagcustom:"true"`
-}
-
-// Wrong signature: first return value should be `pflag.Value`.
-func (o *wrongDefineReturn1Options) DefineCustomField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (string, string) {
-	return "", ""
-}
-func (o *wrongDefineReturn1Options) DecodeCustomField(i any) (any, error) { return i, nil }
-func (o *wrongDefineReturn1Options) Attach(c *cobra.Command) error        { return structcli.Define(c, o) }
-
-type wrongDefineReturn2Options struct {
-	CustomField string `flagcustom:"true"`
-}
-
-// Wrong signature: second return value should be `string`.
-func (o *wrongDefineReturn2Options) DefineCustomField(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, int) {
-	fieldPtr := fieldValue.Addr().Interface().(*string)
-	return values.NewString(fieldPtr), 0
-}
-func (o *wrongDefineReturn2Options) DecodeCustomField(i any) (any, error) { return i, nil }
-func (o *wrongDefineReturn2Options) Attach(c *cobra.Command) error        { return structcli.Define(c, o) }
 
 type remappingDatabaseOptions struct {
 	URL string `flag:"db-url" default:"postgres://default" flagdescr:"database URL"`
@@ -3158,67 +3111,6 @@ func TestUnmarshal_KeyRemapping_Characterization(t *testing.T) {
 
 		require.NoError(t, structcli.Unmarshal(srvCmd, opts))
 		assert.Equal(t, 9090, opts.Port)
-	})
-}
-
-func TestFlagCustom_Integration(t *testing.T) {
-	setupTest := func() {
-		viper.Reset()
-		structcli.Reset()
-	}
-
-	t.Run("MultipleFieldsWithSameCustomType", func(t *testing.T) {
-		setupTest()
-
-		opts := &conflictingCustomType{}
-		c := &cobra.Command{Use: "testcmd-custom-type"}
-
-		err := structcli.Define(c, opts)
-		require.Error(t, err)
-		require.ErrorIs(t, err, structclierrors.ErrConflictingType)
-		assert.Contains(t, err.Error(), "create distinct custom types for each field")
-		assert.Contains(t, err.Error(), "Mode")
-		assert.Contains(t, err.Error(), "Nest.ModeAgain")
-	})
-
-	t.Run("DefineHook_WrongParameterType", func(t *testing.T) {
-		setupTest()
-		opts := &wrongDefineParamOptions{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := opts.Attach(cmd)
-		require.Error(t, err)
-		var e *structclierrors.InvalidDefineHookSignatureError
-		require.ErrorAs(t, err, &e, "error should be of type InvalidDefineHookSignatureError")
-
-		assert.Contains(t, e.Error(), "define hook parameter 0 has wrong type", "Error should complain about the first parameter")
-		assert.Contains(t, e.Error(), "expected string, got int", "Error should specify the expected and actual types")
-	})
-
-	t.Run("DefineHook_WrongFirstReturnValue", func(t *testing.T) {
-		setupTest()
-		opts := &wrongDefineReturn1Options{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := opts.Attach(cmd)
-		require.Error(t, err)
-		var e *structclierrors.InvalidDefineHookSignatureError
-		require.ErrorAs(t, err, &e, "error should be of type InvalidDefineHookSignatureError")
-
-		assert.Contains(t, e.Error(), "define hook first return value must be a pflag.Value")
-	})
-
-	t.Run("DefineHook_WrongSecondReturnValue", func(t *testing.T) {
-		setupTest()
-		opts := &wrongDefineReturn2Options{}
-		cmd := &cobra.Command{Use: "test"}
-
-		err := opts.Attach(cmd)
-		require.Error(t, err)
-		var e *structclierrors.InvalidDefineHookSignatureError
-		require.ErrorAs(t, err, &e, "error should be of type InvalidDefineHookSignatureError")
-
-		assert.Contains(t, e.Error(), "define hook second return value must be a string")
 	})
 }
 

--- a/internal/hooks/complete.go
+++ b/internal/hooks/complete.go
@@ -2,46 +2,16 @@ package internalhooks
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/spf13/cobra"
 )
 
-// CompleteHookFunc defines the optional completion hook for a struct field flag.
-//
-// Methods matching the signature and naming convention `Complete<FieldName>`
-// are discovered during Define() and automatically registered on the command.
+// CompleteHookFunc defines the completion hook for a struct field flag.
 type CompleteHookFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 
-// StoreCompletionHookFunc registers a validated completion hook method for a flag.
-// Panics if the flag does not exist (structurally impossible when called after
-// flag registration) or if completeM is invalid.
-func StoreCompletionHookFunc(c *cobra.Command, flagName string, completeM reflect.Value) {
-	if !completeM.IsValid() {
-		panic(fmt.Sprintf("structcli: invalid completion hook for flag %q", flagName))
-	}
-
-	if err := c.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		results := completeM.Call([]reflect.Value{
-			reflect.ValueOf(cmd),
-			reflect.ValueOf(args),
-			reflect.ValueOf(toComplete),
-		})
-
-		suggestions, _ := results[0].Interface().([]string)
-		directive, _ := results[1].Interface().(cobra.ShellCompDirective)
-
-		return suggestions, directive
-	}); err != nil {
-		panic(fmt.Sprintf("structcli: RegisterFlagCompletionFunc(%q) on just-registered flag: %v", flagName, err))
-	}
-}
-
 // StoreCompletionHookFuncDirect registers a typed completion hook for a flag.
-// Unlike StoreCompletionHookFunc, it calls the function directly without
-// reflect.Value.Call, enabling dead-code elimination.
-func StoreCompletionHookFuncDirect(c *cobra.Command, flagName string, fn CompleteHookFunc) {
-	if err := c.RegisterFlagCompletionFunc(flagName, cobra.CompletionFunc(fn)); err != nil {
+func StoreCompletionHookFuncDirect(c *cobra.Command, flagName string, complete CompleteHookFunc) {
+	if err := c.RegisterFlagCompletionFunc(flagName, cobra.CompletionFunc(complete)); err != nil {
 		panic(fmt.Sprintf("structcli: RegisterFlagCompletionFunc(%q) on just-registered flag: %v", flagName, err))
 	}
 }

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -30,74 +30,68 @@ type decodingAnnotation struct {
 	fx  mapstructure.DecodeHookFunc
 }
 
-var DecodeHookRegistry = map[string]decodingAnnotation{
-	"time.Duration": {
+// DecodeHookRegistry maps reflect.Type to decode hook metadata.
+// Keyed by reflect.Type for collision-safe lookups.
+var DecodeHookRegistry = map[reflect.Type]decodingAnnotation{
+	reflect.TypeFor[time.Duration](): {
 		"StringToTimeDurationHookFunc",
 		mapstructure.StringToTimeDurationHookFunc(),
 	},
-	"[]time.Duration": {
+	reflect.TypeFor[[]time.Duration](): {
 		"StringToDurationSliceHookFunc",
 		StringToDurationSliceHookFunc(),
 	},
-	"[]bool": {
+	reflect.TypeFor[[]bool](): {
 		"StringToBoolSliceHookFunc",
 		StringToBoolSliceHookFunc(),
 	},
-	"[]uint": {
+	reflect.TypeFor[[]uint](): {
 		"StringToUintSliceHookFunc",
 		StringToUintSliceHookFunc(),
 	},
-	"map[string]string": {
+	reflect.TypeFor[map[string]string](): {
 		"StringToStringMapHookFunc",
 		StringToStringMapHookFunc(),
 	},
-	"map[string]int": {
+	reflect.TypeFor[map[string]int](): {
 		"StringToIntMapHookFunc",
 		StringToIntMapHookFunc(),
 	},
-	"map[string]int64": {
+	reflect.TypeFor[map[string]int64](): {
 		"StringToInt64MapHookFunc",
 		StringToInt64MapHookFunc(),
 	},
-	"net.IP": {
+	reflect.TypeFor[net.IP](): {
 		"StringToIPHookFunc",
 		mapstructure.StringToIPHookFunc(),
 	},
-	"net.IPMask": {
+	reflect.TypeFor[net.IPMask](): {
 		"StringToIPMaskHookFunc",
 		StringToIPMaskHookFunc(),
 	},
-	"net.IPNet": {
+	reflect.TypeFor[net.IPNet](): {
 		"StringToIPNetHookFunc",
 		mapstructure.StringToIPNetHookFunc(),
 	},
-	"[]net.IP": {
+	reflect.TypeFor[[]net.IP](): {
 		"StringToIPSliceHookFunc",
 		StringToIPSliceHookFunc(),
 	},
-	"slog.Level": {
+	reflect.TypeFor[slog.Level](): {
 		"StringToSlogLevelHookFunc",
 		StringToSlogLevelHookFunc(),
 	},
-	"[]string": {
+	reflect.TypeFor[[]string](): {
 		"StringToCSVStringSliceHookFunc",
 		StringToCSVStringSliceHookFunc(),
 	},
-	"[]int": {
+	reflect.TypeFor[[]int](): {
 		"StringToIntSliceHookFunc",
 		StringToIntSliceHookFunc(","),
 	},
-	"[]uint8": {
+	reflect.TypeFor[[]uint8](): {
 		"StringToRawBytesHookFunc",
 		StringToRawBytesHookFunc(),
-	},
-	"structcli.Hex": {
-		"StringToHexHookFunc",
-		StringToNamedBytesHookFunc("structcli.Hex", decodeHexBytes),
-	},
-	"structcli.Base64": {
-		"StringToBase64HookFunc",
-		StringToNamedBytesHookFunc("structcli.Base64", decodeBase64Bytes),
 	},
 }
 
@@ -107,17 +101,17 @@ var AnnotationToDecodeHookRegistry map[string]mapstructure.DecodeHookFunc
 func init() {
 	// Map annotations to decoding hook
 	AnnotationToDecodeHookRegistry = make(map[string]mapstructure.DecodeHookFunc)
-	for typename, data := range DecodeHookRegistry {
+	for typ, data := range DecodeHookRegistry {
 		if _, exists := AnnotationToDecodeHookRegistry[data.ann]; exists {
-			panic(fmt.Sprintf("duplicate annotation name '%s' found in decode hook registry (type: %s)", data.ann, typename))
+			panic(fmt.Sprintf("duplicate annotation name '%s' found in decode hook registry (type: %s)", data.ann, typ))
 		}
 
 		AnnotationToDecodeHookRegistry[data.ann] = data.fx
 	}
 }
 
-func InferDecodeHooks(c *cobra.Command, name, typename string) bool {
-	if data, ok := DecodeHookRegistry[typename]; ok {
+func InferDecodeHooks(c *cobra.Command, name string, typ reflect.Type) bool {
+	if data, ok := DecodeHookRegistry[typ]; ok {
 		if err := c.Flags().SetAnnotation(name, FlagDecodeHookAnnotation, []string{data.ann}); err != nil {
 			panic(fmt.Sprintf("structcli: SetAnnotation on just-registered flag %q: %v", name, err))
 		}
@@ -131,13 +125,13 @@ func InferDecodeHooks(c *cobra.Command, name, typename string) bool {
 // DecodeRegistrySnapshot holds opaque copies of both decode registries for
 // test isolation.
 type DecodeRegistrySnapshot struct {
-	registry    map[string]decodingAnnotation
+	registry    map[reflect.Type]decodingAnnotation
 	annotations map[string]mapstructure.DecodeHookFunc
 }
 
 // SnapshotDecodeRegistries returns a deep copy of both decode registries.
 func SnapshotDecodeRegistries() DecodeRegistrySnapshot {
-	dr := make(map[string]decodingAnnotation, len(DecodeHookRegistry))
+	dr := make(map[reflect.Type]decodingAnnotation, len(DecodeHookRegistry))
 	for k, v := range DecodeHookRegistry {
 		dr[k] = v
 	}
@@ -158,23 +152,23 @@ func RestoreDecodeRegistries(snap DecodeRegistrySnapshot) {
 // RegisterDecodeHook registers a decode hook for a custom type. It updates both
 // DecodeHookRegistry and AnnotationToDecodeHookRegistry. Panics on duplicate
 // annotation name (consistent with init() behavior).
-func RegisterDecodeHook(typeName, annotationName string, hook mapstructure.DecodeHookFunc) {
+func RegisterDecodeHook(typ reflect.Type, annotationName string, hook mapstructure.DecodeHookFunc) {
 	if _, exists := AnnotationToDecodeHookRegistry[annotationName]; exists {
-		panic(fmt.Sprintf("duplicate annotation name '%s' in decode hook registry (type: %s)", annotationName, typeName))
+		panic(fmt.Sprintf("duplicate annotation name '%s' in decode hook registry (type: %s)", annotationName, typ))
 	}
 
-	DecodeHookRegistry[typeName] = decodingAnnotation{ann: annotationName, fx: hook}
+	DecodeHookRegistry[typ] = decodingAnnotation{ann: annotationName, fx: hook}
 	AnnotationToDecodeHookRegistry[annotationName] = hook
 }
 
 // RegisterUserDecodeHook wraps a user-provided DecodeHookFunc into a
-// mapstructure.DecodeHookFunc and registers it for the given type name.
-// The wrapper filters by target type (exact match) and source kind (string).
-func RegisterUserDecodeHook(typeName string, decode DecodeHookFunc) {
-	annName := fmt.Sprintf("RegisterTypeTo%sHookFunc", sanitizeTypeName(typeName))
+// mapstructure.DecodeHookFunc and registers it for the given type.
+// The wrapper filters by target type (reflect.Type equality) and source kind (string).
+func RegisterUserDecodeHook(typ reflect.Type, decode DecodeHookFunc) {
+	annName := fmt.Sprintf("RegisterTypeTo%sHookFunc", sanitizeTypeName(typ.String()))
 
 	hook := func(from reflect.Type, to reflect.Type, data any) (any, error) {
-		if to.String() != typeName {
+		if to != typ {
 			return data, nil
 		}
 		if from.Kind() != reflect.String {
@@ -184,7 +178,7 @@ func RegisterUserDecodeHook(typeName string, decode DecodeHookFunc) {
 		return decode(data)
 	}
 
-	RegisterDecodeHook(typeName, annName, mapstructure.DecodeHookFunc(hook))
+	RegisterDecodeHook(typ, annName, mapstructure.DecodeHookFunc(hook))
 }
 
 func sanitizeTypeName(typeName string) string {
@@ -782,7 +776,8 @@ func StringToRawBytesHookFunc() mapstructure.DecodeHookFunc {
 }
 
 // StringToNamedBytesHookFunc converts encoded textual input into a named []byte type.
-func StringToNamedBytesHookFunc(typeName string, decode func(string) ([]byte, error)) mapstructure.DecodeHookFunc {
+// Matches by reflect.Type equality for collision safety.
+func StringToNamedBytesHookFunc(targetType reflect.Type, decode func(string) ([]byte, error)) mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
@@ -791,25 +786,27 @@ func StringToNamedBytesHookFunc(typeName string, decode func(string) ([]byte, er
 		if f.Kind() != reflect.String {
 			return data, nil
 		}
-		if t.String() != typeName {
+		if t != targetType {
 			return data, nil
 		}
 
 		raw := data.(string)
 		decoded, err := decode(raw)
 		if err != nil {
-			return nil, fmt.Errorf("invalid string for %s '%s': %w", typeName, raw, err)
+			return nil, fmt.Errorf("invalid string for %s '%s': %w", targetType, raw, err)
 		}
 
 		return reflect.ValueOf(decoded).Convert(t).Interface(), nil
 	}
 }
 
-func decodeHexBytes(raw string) ([]byte, error) {
+// DecodeHexBytes decodes a hex-encoded string into bytes.
+func DecodeHexBytes(raw string) ([]byte, error) {
 	return hex.DecodeString(strings.TrimSpace(raw))
 }
 
-func decodeBase64Bytes(raw string) ([]byte, error) {
+// DecodeBase64Bytes decodes a base64-encoded string into bytes.
+func DecodeBase64Bytes(raw string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(strings.TrimSpace(raw))
 }
 

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -167,6 +167,38 @@ func RegisterDecodeHook(typeName, annotationName string, hook mapstructure.Decod
 	AnnotationToDecodeHookRegistry[annotationName] = hook
 }
 
+// RegisterUserDecodeHook wraps a user-provided DecodeHookFunc into a
+// mapstructure.DecodeHookFunc and registers it for the given type name.
+// The wrapper filters by target type (exact match) and source kind (string).
+func RegisterUserDecodeHook(typeName string, decode DecodeHookFunc) {
+	annName := fmt.Sprintf("RegisterTypeTo%sHookFunc", sanitizeTypeName(typeName))
+
+	hook := func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if to.String() != typeName {
+			return data, nil
+		}
+		if from.Kind() != reflect.String {
+			return data, nil
+		}
+
+		return decode(data)
+	}
+
+	RegisterDecodeHook(typeName, annName, mapstructure.DecodeHookFunc(hook))
+}
+
+func sanitizeTypeName(typeName string) string {
+	r := strings.NewReplacer(
+		".", "_",
+		"[", "_",
+		"]", "",
+		"*", "Ptr",
+		"/", "_",
+	)
+
+	return r.Replace(typeName)
+}
+
 // StringToEnumHookFunc creates a decode hook that converts string values to a
 // ~string enum type during configuration unmarshaling. It supports
 // case-insensitive matching and aliases.
@@ -946,63 +978,8 @@ func parseIPv4Mask(s string) net.IPMask {
 	return net.IPv4Mask(mask[12], mask[13], mask[14], mask[15])
 }
 
-func StoreDecodeHookFunc(c *cobra.Command, flagname string, decodeM reflect.Value, target reflect.Type) {
-	s := internalscope.Get(c)
-
-	// Wrap that adapts user method to mapstructure.DecodeHookFuncType signature
-	hookFunc := func(from reflect.Type, to reflect.Type, data any) (any, error) {
-		// Only apply this hook to the specific target type
-		if to != target {
-			return data, nil
-		}
-
-		// Only convert from string env var and config file values
-		// They always come as strings
-		if from.Kind() != reflect.String {
-			return data, nil
-		}
-
-		// Call user's decode hook: DecodeX(input interface{}) (target, error)
-		results := decodeM.Call([]reflect.Value{reflect.ValueOf(data)})
-
-		if len(results) != 2 {
-			return nil, fmt.Errorf("user decode method must return (value, error)")
-		}
-
-		// Check if error is not nil
-		if !results[1].IsNil() {
-			return nil, results[1].Interface().(error)
-		}
-
-		return results[0].Interface(), nil
-	}
-
-	k := fmt.Sprintf("customDecodeHook_%s_%s", c.Name(), flagname)
-	s.SetCustomDecodeHook(k, hookFunc)
-
-	if err := c.Flags().SetAnnotation(flagname, FlagDecodeHookAnnotation, []string{k}); err != nil {
-		panic(fmt.Sprintf("structcli: SetAnnotation on just-registered flag %q: %v", flagname, err))
-	}
-}
-
-// sanitizeTypeName converts a Go type name to a safe annotation suffix.
-// e.g., "main.HostPort" -> "main_HostPort", "[]byte" -> "_byte"
-func sanitizeTypeName(typeName string) string {
-	r := strings.NewReplacer(
-		".", "_",
-		"[", "_",
-		"]", "",
-		"*", "Ptr",
-		"/", "_",
-	)
-
-	return r.Replace(typeName)
-}
-
-// StoreDecodeHookFuncDirect stores a typed decode hook for a flag.
-// Unlike StoreDecodeHookFunc, it calls the function directly without
-// reflect.Value.Call, enabling dead-code elimination.
-func StoreDecodeHookFuncDirect(c *cobra.Command, flagname string, decodeFn DecodeHookFunc, target reflect.Type) {
+// StoreDecodeHookFuncDirect registers a typed decode hook for a flag.
+func StoreDecodeHookFuncDirect(c *cobra.Command, flagname string, decode DecodeHookFunc, target reflect.Type) {
 	s := internalscope.Get(c)
 
 	hookFunc := func(from reflect.Type, to reflect.Type, data any) (any, error) {
@@ -1013,7 +990,7 @@ func StoreDecodeHookFuncDirect(c *cobra.Command, flagname string, decodeFn Decod
 			return data, nil
 		}
 
-		return decodeFn(data)
+		return decode(data)
 	}
 
 	k := fmt.Sprintf("customDecodeHook_%s_%s", c.Name(), flagname)
@@ -1022,23 +999,4 @@ func StoreDecodeHookFuncDirect(c *cobra.Command, flagname string, decodeFn Decod
 	if err := c.Flags().SetAnnotation(flagname, FlagDecodeHookAnnotation, []string{k}); err != nil {
 		panic(fmt.Sprintf("structcli: SetAnnotation on just-registered flag %q: %v", flagname, err))
 	}
-}
-
-// RegisterUserDecodeHook registers a user-provided DecodeHookFunc for a type
-// into both decode registries. The annotation name is derived from the type name.
-func RegisterUserDecodeHook(typeName string, fn DecodeHookFunc) {
-	ann := fmt.Sprintf("RegisterTypeTo%sHookFunc", sanitizeTypeName(typeName))
-
-	hook := func(from reflect.Type, to reflect.Type, data any) (any, error) {
-		if to.String() != typeName {
-			return data, nil
-		}
-		if from.Kind() != reflect.String {
-			return data, nil
-		}
-
-		return fn(data)
-	}
-
-	RegisterDecodeHook(typeName, ann, hook)
 }

--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -151,8 +151,11 @@ func RestoreDecodeRegistries(snap DecodeRegistrySnapshot) {
 
 // RegisterDecodeHook registers a decode hook for a custom type. It updates both
 // DecodeHookRegistry and AnnotationToDecodeHookRegistry. Panics on duplicate
-// annotation name (consistent with init() behavior).
+// type or annotation name.
 func RegisterDecodeHook(typ reflect.Type, annotationName string, hook mapstructure.DecodeHookFunc) {
+	if _, exists := DecodeHookRegistry[typ]; exists {
+		panic(fmt.Sprintf("duplicate decode hook registration for type %s", typ))
+	}
 	if _, exists := AnnotationToDecodeHookRegistry[annotationName]; exists {
 		panic(fmt.Sprintf("duplicate annotation name '%s' in decode hook registry (type: %s)", annotationName, typ))
 	}
@@ -161,11 +164,15 @@ func RegisterDecodeHook(typ reflect.Type, annotationName string, hook mapstructu
 	AnnotationToDecodeHookRegistry[annotationName] = hook
 }
 
+// decodeHookSeq is an incrementing counter for generating opaque annotation IDs.
+var decodeHookSeq uint64
+
 // RegisterUserDecodeHook wraps a user-provided DecodeHookFunc into a
 // mapstructure.DecodeHookFunc and registers it for the given type.
 // The wrapper filters by target type (reflect.Type equality) and source kind (string).
 func RegisterUserDecodeHook(typ reflect.Type, decode DecodeHookFunc) {
-	annName := fmt.Sprintf("RegisterTypeTo%sHookFunc", sanitizeTypeName(typ.String()))
+	decodeHookSeq++
+	annName := fmt.Sprintf("userDecodeHook_%d", decodeHookSeq)
 
 	hook := func(from reflect.Type, to reflect.Type, data any) (any, error) {
 		if to != typ {
@@ -179,18 +186,6 @@ func RegisterUserDecodeHook(typ reflect.Type, decode DecodeHookFunc) {
 	}
 
 	RegisterDecodeHook(typ, annName, mapstructure.DecodeHookFunc(hook))
-}
-
-func sanitizeTypeName(typeName string) string {
-	r := strings.NewReplacer(
-		".", "_",
-		"[", "_",
-		"]", "",
-		"*", "Ptr",
-		"/", "_",
-	)
-
-	return r.Replace(typeName)
 }
 
 // StringToEnumHookFunc creates a decode hook that converts string values to a

--- a/internal/hooks/decode_fuzz_test.go
+++ b/internal/hooks/decode_fuzz_test.go
@@ -161,7 +161,7 @@ func FuzzStringToHexBytes(f *testing.F) {
 	// Can't target structcli.Hex from internal package, so fuzz the
 	// underlying decode function directly.
 	f.Fuzz(func(t *testing.T, input string) {
-		decodeHexBytes(input)
+		DecodeHexBytes(input)
 	})
 }
 
@@ -174,7 +174,7 @@ func FuzzStringToBase64Bytes(f *testing.F) {
 	f.Add("SGVsbG8==") // wrong padding
 
 	f.Fuzz(func(t *testing.T, input string) {
-		decodeBase64Bytes(input)
+		DecodeBase64Bytes(input)
 	})
 }
 

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -271,16 +271,16 @@ func TestStringToInt64MapHookFunc_InvalidMapValue(t *testing.T) {
 	assert.Contains(t, err.Error(), `invalid map value for key "ok"`)
 }
 
-func TestStoreDecodeHookFunc_WrapperBehavior(t *testing.T) {
+func TestStoreDecodeHookFuncDirect_WrapperBehavior(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("mode", "", "mode")
 
-	StoreDecodeHookFunc(
+	StoreDecodeHookFuncDirect(
 		cmd,
 		"mode",
-		reflect.ValueOf(func(input any) (any, error) {
+		func(input any) (any, error) {
 			return strings.ToUpper(input.(string)), nil
-		}),
+		},
 		reflect.TypeOf(""),
 	)
 
@@ -302,17 +302,17 @@ func TestStoreDecodeHookFunc_WrapperBehavior(t *testing.T) {
 	assert.Equal(t, "dev", out)
 }
 
-func TestStoreDecodeHookFunc_WrapperPropagatesErrors(t *testing.T) {
+func TestStoreDecodeHookFuncDirect_WrapperPropagatesErrors(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("mode", "", "mode")
 
 	expectedErr := errors.New("boom")
-	StoreDecodeHookFunc(
+	StoreDecodeHookFuncDirect(
 		cmd,
 		"mode",
-		reflect.ValueOf(func(input any) (any, error) {
+		func(input any) (any, error) {
 			return nil, expectedErr
-		}),
+		},
 		reflect.TypeOf(""),
 	)
 
@@ -492,85 +492,3 @@ func TestStringToIntEnumHookFunc_AliasCollisionPanics(t *testing.T) {
 		})
 	})
 }
-
-func TestStoreDecodeHookFuncDirect_WrapperBehavior(t *testing.T) {
-	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().String("mode", "", "mode")
-
-	StoreDecodeHookFuncDirect(
-		cmd,
-		"mode",
-		func(input any) (any, error) {
-			return strings.ToUpper(input.(string)), nil
-		},
-		reflect.TypeOf(""),
-	)
-
-	flag := cmd.Flags().Lookup("mode")
-	require.NotNil(t, flag)
-	annotations := flag.Annotations[FlagDecodeHookAnnotation]
-	require.Len(t, annotations, 1)
-
-	hook, exists := internalscope.Get(cmd).GetCustomDecodeHook(annotations[0])
-	require.True(t, exists)
-	hookFunc := hook.(func(reflect.Type, reflect.Type, any) (any, error))
-
-	// Matching target type: hook is applied
-	out, err := hookFunc(reflect.TypeOf(""), reflect.TypeOf(""), "dev")
-	require.NoError(t, err)
-	assert.Equal(t, "DEV", out)
-
-	// Non-matching target type: passthrough
-	out, err = hookFunc(reflect.TypeOf(""), reflect.TypeOf(int(0)), "dev")
-	require.NoError(t, err)
-	assert.Equal(t, "dev", out)
-}
-
-func TestStoreDecodeHookFuncDirect_PropagatesErrors(t *testing.T) {
-	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().String("mode", "", "mode")
-
-	expectedErr := errors.New("boom")
-	StoreDecodeHookFuncDirect(
-		cmd,
-		"mode",
-		func(input any) (any, error) {
-			return nil, expectedErr
-		},
-		reflect.TypeOf(""),
-	)
-
-	flag := cmd.Flags().Lookup("mode")
-	require.NotNil(t, flag)
-	hook, exists := internalscope.Get(cmd).GetCustomDecodeHook(flag.Annotations[FlagDecodeHookAnnotation][0])
-	require.True(t, exists)
-	hookFunc := hook.(func(reflect.Type, reflect.Type, any) (any, error))
-
-	_, err := hookFunc(reflect.TypeOf(""), reflect.TypeOf(""), "dev")
-	require.ErrorIs(t, err, expectedErr)
-}
-
-func TestRegisterUserDecodeHook(t *testing.T) {
-	snap := SnapshotDecodeRegistries()
-	defer RestoreDecodeRegistries(snap)
-
-	RegisterUserDecodeHook("test.Custom", func(input any) (any, error) {
-		return "decoded:" + input.(string), nil
-	})
-
-	data, ok := DecodeHookRegistry["test.Custom"]
-	require.True(t, ok)
-	assert.Equal(t, "RegisterTypeTotest_CustomHookFunc", data.ann)
-
-	_, ok = AnnotationToDecodeHookRegistry["RegisterTypeTotest_CustomHookFunc"]
-	assert.True(t, ok)
-}
-
-func TestSanitizeTypeName(t *testing.T) {
-	assert.Equal(t, "main_HostPort", sanitizeTypeName("main.HostPort"))
-	assert.Equal(t, "_byte", sanitizeTypeName("[]byte"))
-	assert.Equal(t, "map_stringint", sanitizeTypeName("map[string]int"))
-	assert.Equal(t, "Ptrmain_Foo", sanitizeTypeName("*main.Foo"))
-}
-
-

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -419,16 +419,34 @@ func TestRegisterDecodeHook(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func TestRegisterDecodeHook_DuplicatePanics(t *testing.T) {
+func TestRegisterDecodeHook_DuplicateAnnotationPanics(t *testing.T) {
 	snap := SnapshotDecodeRegistries()
 	defer RestoreDecodeRegistries(snap)
 
 	hook := StringToEnumHookFunc(testEnvValues())
 	RegisterDecodeHook(reflect.TypeFor[testEnv](), "StringToTestEnvHookFunc", hook)
 
-	assert.Panics(t, func() {
-		RegisterDecodeHook(reflect.TypeFor[testPriority](), "StringToTestEnvHookFunc", hook)
-	})
+	assert.PanicsWithValue(t,
+		"duplicate annotation name 'StringToTestEnvHookFunc' in decode hook registry (type: internalhooks.testPriority)",
+		func() {
+			RegisterDecodeHook(reflect.TypeFor[testPriority](), "StringToTestEnvHookFunc", hook)
+		},
+	)
+}
+
+func TestRegisterDecodeHook_DuplicateTypePanics(t *testing.T) {
+	snap := SnapshotDecodeRegistries()
+	defer RestoreDecodeRegistries(snap)
+
+	hook := StringToEnumHookFunc(testEnvValues())
+	RegisterDecodeHook(reflect.TypeFor[testEnv](), "FirstAnnotation", hook)
+
+	assert.PanicsWithValue(t,
+		"duplicate decode hook registration for type internalhooks.testEnv",
+		func() {
+			RegisterDecodeHook(reflect.TypeFor[testEnv](), "SecondAnnotation", hook)
+		},
+	)
 }
 
 type testPriority int

--- a/internal/hooks/decode_internal_test.go
+++ b/internal/hooks/decode_internal_test.go
@@ -24,14 +24,16 @@ func TestInferDecodeHooks(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("durations", "", "durations")
 
-	ok := InferDecodeHooks(cmd, "durations", "[]time.Duration")
+	ok := InferDecodeHooks(cmd, "durations", reflect.TypeFor[[]time.Duration]())
 	require.True(t, ok)
 
 	flag := cmd.Flags().Lookup("durations")
 	require.NotNil(t, flag)
 	assert.Equal(t, []string{"StringToDurationSliceHookFunc"}, flag.Annotations[FlagDecodeHookAnnotation])
 
-	found := InferDecodeHooks(cmd, "durations", "missing.Type")
+	// Unregistered type returns false.
+	type missingType struct{}
+	found := InferDecodeHooks(cmd, "durations", reflect.TypeFor[missingType]())
 	assert.False(t, found)
 }
 
@@ -41,7 +43,7 @@ func TestInferDecodeHooks_PanicsOnUnknownFlag(t *testing.T) {
 
 	assert.PanicsWithValue(t,
 		`structcli: SetAnnotation on just-registered flag "durations": no such flag -durations`,
-		func() { InferDecodeHooks(cmd, "durations", "[]time.Duration") },
+		func() { InferDecodeHooks(cmd, "durations", reflect.TypeFor[[]time.Duration]()) },
 	)
 }
 
@@ -405,10 +407,11 @@ func TestRegisterDecodeHook(t *testing.T) {
 	snap := SnapshotDecodeRegistries()
 	defer RestoreDecodeRegistries(snap)
 
+	typ := reflect.TypeFor[testEnv]()
 	hook := StringToEnumHookFunc(testEnvValues())
-	RegisterDecodeHook("test.Env", "StringToTestEnvHookFunc", hook)
+	RegisterDecodeHook(typ, "StringToTestEnvHookFunc", hook)
 
-	data, ok := DecodeHookRegistry["test.Env"]
+	data, ok := DecodeHookRegistry[typ]
 	require.True(t, ok)
 	assert.Equal(t, "StringToTestEnvHookFunc", data.ann)
 
@@ -421,10 +424,10 @@ func TestRegisterDecodeHook_DuplicatePanics(t *testing.T) {
 	defer RestoreDecodeRegistries(snap)
 
 	hook := StringToEnumHookFunc(testEnvValues())
-	RegisterDecodeHook("test.Env", "StringToTestEnvHookFunc", hook)
+	RegisterDecodeHook(reflect.TypeFor[testEnv](), "StringToTestEnvHookFunc", hook)
 
 	assert.Panics(t, func() {
-		RegisterDecodeHook("test.Env2", "StringToTestEnvHookFunc", hook)
+		RegisterDecodeHook(reflect.TypeFor[testPriority](), "StringToTestEnvHookFunc", hook)
 	})
 }
 

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -24,24 +24,29 @@ import (
 // description for the flag's usage message.
 type DefineHookFunc func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string)
 
-// DefineHookRegistry keeps track of the built-in flag definition functions
-var DefineHookRegistry = map[string]DefineHookFunc{
-	"time.Duration":     DefineTimeDurationHookFunc(),
-	"[]time.Duration":   DefineDurationSliceHookFunc(),
-	"[]bool":            DefineBoolSliceHookFunc(),
-	"[]uint":            DefineUintSliceHookFunc(),
-	"map[string]string": DefineStringMapHookFunc(),
-	"map[string]int":    DefineIntMapHookFunc(),
-	"map[string]int64":  DefineInt64MapHookFunc(),
-	"net.IP":            DefineIPHookFunc(),
-	"net.IPMask":        DefineIPMaskHookFunc(),
-	"net.IPNet":         DefineIPNetHookFunc(),
-	"[]net.IP":          DefineIPSliceHookFunc(),
-	"slog.Level":        DefineSlogLevelHookFunc(),
-	"[]uint8":           DefineRawBytesHookFunc(),
-	"structcli.Hex":     DefineHexBytesHookFunc(),
-	"structcli.Base64":  DefineBase64BytesHookFunc(),
+// DefineHookRegistry keeps track of the built-in flag definition functions.
+// Keyed by reflect.Type for collision-safe lookups.
+var DefineHookRegistry = map[reflect.Type]DefineHookFunc{
+	reflect.TypeFor[time.Duration]():     DefineTimeDurationHookFunc(),
+	reflect.TypeFor[[]time.Duration]():   DefineDurationSliceHookFunc(),
+	reflect.TypeFor[[]bool]():            DefineBoolSliceHookFunc(),
+	reflect.TypeFor[[]uint]():            DefineUintSliceHookFunc(),
+	reflect.TypeFor[map[string]string](): DefineStringMapHookFunc(),
+	reflect.TypeFor[map[string]int]():    DefineIntMapHookFunc(),
+	reflect.TypeFor[map[string]int64]():  DefineInt64MapHookFunc(),
+	reflect.TypeFor[net.IP]():            DefineIPHookFunc(),
+	reflect.TypeFor[net.IPMask]():        DefineIPMaskHookFunc(),
+	reflect.TypeFor[net.IPNet]():         DefineIPNetHookFunc(),
+	reflect.TypeFor[[]net.IP]():          DefineIPSliceHookFunc(),
+	reflect.TypeFor[slog.Level]():        DefineSlogLevelHookFunc(),
+	reflect.TypeFor[[]uint8]():           DefineRawBytesHookFunc(),
 }
+
+// defineHookRegistryByName holds entries registered by type name string.
+// Used only for types that cannot use reflect.TypeFor at init time from
+// this package (e.g., types from the parent structcli package).
+// InferDefineHooks checks DefineHookRegistry first, then falls back here.
+var defineHookRegistryByName = map[string]DefineHookFunc{}
 
 var byteSliceType = reflect.TypeOf([]byte(nil))
 
@@ -231,9 +236,18 @@ func DefineStringEnumHookFunc[E ~string](values map[E][]string) DefineHookFunc {
 	}
 }
 
-// InferDefineHooks checks if there's a predefined flag definition function for the given type
+// InferDefineHooks checks if there's a predefined flag definition function for the given type.
+// Checks the reflect.Type-keyed registry first, then falls back to the string-keyed
+// registry for types that cannot be referenced by reflect.TypeFor from this package.
 func InferDefineHooks(c *cobra.Command, name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) bool {
-	if defineFunc, ok := DefineHookRegistry[structField.Type.String()]; ok {
+	if defineFunc, ok := DefineHookRegistry[structField.Type]; ok {
+		value, usage := defineFunc(name, short, descr, structField, fieldValue)
+		c.Flags().VarP(value, name, short, usage)
+
+		return true
+	}
+
+	if defineFunc, ok := defineHookRegistryByName[structField.Type.String()]; ok {
 		value, usage := defineFunc(name, short, descr, structField, fieldValue)
 		c.Flags().VarP(value, name, short, usage)
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -84,11 +84,10 @@ func (suite *structcliSuite) TestStoreDecodeHookFunc() {
 	decodeMethod := func(input any) (any, error) {
 		return input, nil
 	}
-	decodeValue := reflect.ValueOf(decodeMethod)
 	targetType := reflect.TypeOf("")
 
-	// Call StoreDecodeHookFunc
-	internalhooks.StoreDecodeHookFunc(cmd, "custom-field", decodeValue, targetType)
+	// Call StoreDecodeHookFuncDirect
+	internalhooks.StoreDecodeHookFuncDirect(cmd, "custom-field", decodeMethod, targetType)
 
 	// Assert the scope contains the custom decode hook with correct key
 	scope := internalscope.Get(cmd)
@@ -108,7 +107,7 @@ func (suite *structcliSuite) TestStoreDecodeHookFunc() {
 	assert.Equal(suite.T(), expectedKey, annotations[0], "Annotation should contain the correct key")
 }
 
-func (suite *structcliSuite) TestStoreCompletionHookFunc() {
+func (suite *structcliSuite) TestStoreCompletionHookFuncDirect() {
 	cmd := &cobra.Command{Use: "testcmd"}
 	cmd.Flags().String("mode", "", "test flag")
 
@@ -116,62 +115,7 @@ func (suite *structcliSuite) TestStoreCompletionHookFunc() {
 		return []string{"dev", "prod"}, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	internalhooks.StoreCompletionHookFunc(cmd, "mode", reflect.ValueOf(completeMethod))
-
-	completion, exists := cmd.GetFlagCompletionFunc("mode")
-	require.True(suite.T(), exists, "completion function should be registered")
-
-	suggestions, directive := completion(cmd, nil, "")
-	assert.Equal(suite.T(), []string{"dev", "prod"}, suggestions)
-	assert.Equal(suite.T(), cobra.ShellCompDirectiveNoFileComp, directive)
-}
-
-func (suite *structcliSuite) TestStoreCompletionHookFunc_PanicsOnInvalidHookValue() {
-	cmd := &cobra.Command{Use: "testcmd"}
-	cmd.Flags().String("mode", "", "test flag")
-
-	assert.PanicsWithValue(suite.T(),
-		`structcli: invalid completion hook for flag "mode"`,
-		func() { internalhooks.StoreCompletionHookFunc(cmd, "mode", reflect.Value{}) },
-	)
-}
-
-func (suite *structcliSuite) TestStoreDecodeHookFuncDirect() {
-	cmd := &cobra.Command{Use: "testcmd"}
-	cmd.Flags().String("custom-field", "", "test flag")
-
-	decodeFn := func(input any) (any, error) {
-		return input, nil
-	}
-	targetType := reflect.TypeOf("")
-
-	internalhooks.StoreDecodeHookFuncDirect(cmd, "custom-field", decodeFn, targetType)
-
-	scope := internalscope.Get(cmd)
-	expectedKey := fmt.Sprintf("customDecodeHook_%s_%s", cmd.Name(), "custom-field")
-
-	storedHook, exists := scope.GetCustomDecodeHook(expectedKey)
-	require.True(suite.T(), exists, "Custom decode hook should be stored in scope")
-	assert.NotNil(suite.T(), storedHook, "Stored hook should not be nil")
-
-	flag := cmd.Flags().Lookup("custom-field")
-	require.NotNil(suite.T(), flag, "Flag should exist")
-
-	annotations := flag.Annotations[internalhooks.FlagDecodeHookAnnotation]
-	require.NotNil(suite.T(), annotations, "Flag should have decode hook annotation")
-	require.Len(suite.T(), annotations, 1, "Should have exactly one annotation")
-	assert.Equal(suite.T(), expectedKey, annotations[0], "Annotation should contain the correct key")
-}
-
-func (suite *structcliSuite) TestStoreCompletionHookFuncDirect() {
-	cmd := &cobra.Command{Use: "testcmd"}
-	cmd.Flags().String("mode", "", "test flag")
-
-	completeFn := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"dev", "prod"}, cobra.ShellCompDirectiveNoFileComp
-	}
-
-	internalhooks.StoreCompletionHookFuncDirect(cmd, "mode", completeFn)
+	internalhooks.StoreCompletionHookFuncDirect(cmd, "mode", completeMethod)
 
 	completion, exists := cmd.GetFlagCompletionFunc("mode")
 	require.True(suite.T(), exists, "completion function should be registered")

--- a/internal/proptest/gen/generators.go
+++ b/internal/proptest/gen/generators.go
@@ -78,8 +78,7 @@ type TagSet struct {
 	FlagHidden   string // "true" or "false" or ""
 	FlagRequired string // "true" or "false" or ""
 	FlagIgnore   string // "true" or "false" or ""
-	FlagCustom   string // "true" or "false" or ""
-	FlagEnv      string // "true", "false", "only", or ""
+	FlagEnv string // "true", "false", "only", or ""
 	FlagPreset   string
 	Default      string
 }
@@ -101,7 +100,6 @@ func (ts TagSet) ToStructTag() reflect.StructTag {
 	add("flaghidden", ts.FlagHidden)
 	add("flagrequired", ts.FlagRequired)
 	add("flagignore", ts.FlagIgnore)
-	add("flagcustom", ts.FlagCustom)
 	add("flagenv", ts.FlagEnv)
 	add("flagpreset", ts.FlagPreset)
 	add("default", ts.Default)

--- a/internal/proptest/validation/validation_prop_test.go
+++ b/internal/proptest/validation/validation_prop_test.go
@@ -28,7 +28,7 @@ func newCmd() *cobra.Command {
 func TestProperty_IsValidBoolTag_NoPanicAndTypedErrors(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		input := rapid.String().Draw(t, "input")
-		result, err := internalvalidation.IsValidBoolTag("Field", "flagcustom", input)
+		result, err := internalvalidation.IsValidBoolTag("Field", "flaghidden", input)
 		if err != nil {
 			var target *structclierrors.InvalidBooleanTagError
 			if !errors.As(err, &target) {
@@ -123,14 +123,13 @@ func TestProperty_Validation_AllowsHiddenAndRequired(t *testing.T) {
 // --- P2.5: Validation rejects leaf-only tags on struct-typed fields ---
 
 func TestProperty_Validation_RejectsLeafOnlyTagsOnStructFields(t *testing.T) {
-	// Tags like flagshort, flagcustom, flagignore, flagrequired, flaghidden
+	// Tags like flagshort, flagignore, flagrequired, flaghidden
 	// are valid only on leaf (non-struct) fields and rejected on struct fields.
 	tags := []struct {
 		name string
 		tag  string
 	}{
 		{"flagshort", `flagshort:"x"`},
-		{"flagcustom", `flagcustom:"true"`},
 		{"flagignore", `flagignore:"true"`},
 		{"flagrequired", `flagrequired:"true"`},
 		{"flaghidden", `flaghidden:"true"`},
@@ -266,7 +265,7 @@ func TestProperty_Validation_RejectsInvalidFlagNames(t *testing.T) {
 
 func TestProperty_Validation_RejectsInvalidBooleanTagValues(t *testing.T) {
 	// flagenv is excluded: it accepts "only" in addition to booleans and uses InvalidFlagEnvTagError.
-	boolTags := []string{"flagcustom", "flagignore", "flagrequired", "flaghidden"}
+	boolTags := []string{"flagignore", "flagrequired", "flaghidden"}
 
 	for _, tagName := range boolTags {
 		tagName := tagName
@@ -342,8 +341,6 @@ func TestProperty_Validation_AcceptsWellFormedStructs(t *testing.T) {
 // --- P2.9b: flagenv:"only" rejects incompatible flag-specific tags ---
 
 func TestProperty_Validation_EnvOnlyRejectsIncompatibleTags(t *testing.T) {
-	// flagcustom is omitted: it requires matching Define/Decode hook methods
-	// on the struct, which cannot be generated via reflect.StructOf.
 	incompatibleTags := []struct {
 		tagName string
 		tagVal  string
@@ -427,19 +424,13 @@ func TestProperty_Validation_ErrorsAreWellTyped(t *testing.T) {
 		// Using *any as the errors.As target would match everything; each
 		// check must use a concretely-typed pointer variable.
 		var (
-			invalidBoolTag     *structclierrors.InvalidBooleanTagError
-			invalidShorthand   *structclierrors.InvalidShorthandError
-			invalidTagUsage    *structclierrors.InvalidTagUsageError
-			conflictingTags    *structclierrors.ConflictingTagsError
-			duplicateFlag      *structclierrors.DuplicateFlagError
-			invalidFlagName    *structclierrors.InvalidFlagNameError
-			conflictingType    *structclierrors.ConflictingTypeError
-			inputErr           *structclierrors.InputError
-			missingDefineHook  *structclierrors.MissingDefineHookError
-			missingDecodeHook  *structclierrors.MissingDecodeHookError
-			invalidDefineSig   *structclierrors.InvalidDefineHookSignatureError
-			invalidDecodeSig   *structclierrors.InvalidDecodeHookSignatureError
-			invalidCompleteSig *structclierrors.InvalidCompleteHookSignatureError
+			invalidBoolTag   *structclierrors.InvalidBooleanTagError
+			invalidShorthand *structclierrors.InvalidShorthandError
+			invalidTagUsage  *structclierrors.InvalidTagUsageError
+			conflictingTags  *structclierrors.ConflictingTagsError
+			duplicateFlag    *structclierrors.DuplicateFlagError
+			invalidFlagName  *structclierrors.InvalidFlagNameError
+			inputErr         *structclierrors.InputError
 		)
 
 		switch {
@@ -449,13 +440,7 @@ func TestProperty_Validation_ErrorsAreWellTyped(t *testing.T) {
 		case errors.As(inner, &conflictingTags):
 		case errors.As(inner, &duplicateFlag):
 		case errors.As(inner, &invalidFlagName):
-		case errors.As(inner, &conflictingType):
 		case errors.As(inner, &inputErr):
-		case errors.As(inner, &missingDefineHook):
-		case errors.As(inner, &missingDecodeHook):
-		case errors.As(inner, &invalidDefineSig):
-		case errors.As(inner, &invalidDecodeSig):
-		case errors.As(inner, &invalidCompleteSig):
 		default:
 			t.Fatalf("validation returned unrecognized error type %T: %v", inner, inner)
 		}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -55,7 +55,7 @@ func Fields(val reflect.Value, prefix string, s *internalscope.Scope) error {
 		// because their exported fields are promoted and accessible.
 		if !field.CanInterface() {
 			if structF.Anonymous && structF.Type.Kind() == reflect.Struct {
-				_, hasDefineHook := internalhooks.DefineHookRegistry[structF.Type.String()]
+				_, hasDefineHook := internalhooks.DefineHookRegistry[structF.Type]
 				if !hasDefineHook {
 					if err := Fields(field, internalpath.GetFieldName(prefix, structF), s); err != nil {
 						return err
@@ -68,7 +68,7 @@ func Fields(val reflect.Value, prefix string, s *internalscope.Scope) error {
 		fieldName := internalpath.GetFieldName(prefix, structF)
 		// Some Go structs are handled as scalar/leaf values by built-in hooks
 		// (e.g. net.IPNet), so validation must not recurse into their exported fields.
-		_, hasDefineHook := internalhooks.DefineHookRegistry[structF.Type.String()]
+		_, hasDefineHook := internalhooks.DefineHookRegistry[structF.Type]
 		isStructKind := structF.Type.Kind() == reflect.Struct && !hasDefineHook
 
 		// Validate flagpreset tag syntax

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -14,7 +14,6 @@ import (
 	internalscope "github.com/leodido/structcli/internal/scope"
 	internaltag "github.com/leodido/structcli/internal/tag"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // IsValidBoolTag validates that a struct tag contains a valid boolean value
@@ -30,7 +29,7 @@ func IsValidBoolTag(fieldName, tagName, tagValue string) (*bool, error) {
 	return &val, nil
 }
 
-// Struct checks the coherence of definitions in the given struct
+// Struct checks the coherence of definitions in the given struct.
 func Struct(c *cobra.Command, o any) error {
 	val, err := internalreflect.GetValidValue(o)
 	if err != nil {
@@ -38,22 +37,16 @@ func Struct(c *cobra.Command, o any) error {
 	}
 	s := internalscope.Get(c)
 
-	typeToFields := make(map[reflect.Type][]string)
 	typeName := val.Type().Name()
-	if err := Fields(val, typeName, typeToFields, s); err != nil {
+	if err := Fields(val, typeName, s); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
-	}
-	for fieldType, fieldNames := range typeToFields {
-		if len(fieldNames) > 1 {
-			return structclierrors.NewConflictingTypeError(fieldType, fieldNames, "create distinct custom types for each field")
-		}
 	}
 
 	return nil
 }
 
-// Fields recursively validates the struct fields
-func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]string, s *internalscope.Scope) error {
+// Fields recursively validates the struct fields.
+func Fields(val reflect.Value, prefix string, s *internalscope.Scope) error {
 	for i := range val.NumField() {
 		field := val.Field(i)
 		structF := val.Type().Field(i)
@@ -64,7 +57,7 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 			if structF.Anonymous && structF.Type.Kind() == reflect.Struct {
 				_, hasDefineHook := internalhooks.DefineHookRegistry[structF.Type.String()]
 				if !hasDefineHook {
-					if err := Fields(field, internalpath.GetFieldName(prefix, structF), typeToFields, s); err != nil {
+					if err := Fields(field, internalpath.GetFieldName(prefix, structF), s); err != nil {
 						return err
 					}
 				}
@@ -77,8 +70,6 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 		// (e.g. net.IPNet), so validation must not recurse into their exported fields.
 		_, hasDefineHook := internalhooks.DefineHookRegistry[structF.Type.String()]
 		isStructKind := structF.Type.Kind() == reflect.Struct && !hasDefineHook
-		parts := strings.Split(fieldName, ".")
-		methodFieldName := parts[len(parts)-1]
 
 		// Validate flagpreset tag syntax
 		presets, presetErr := internaltag.ParseFlagPresets(structF.Tag.Get("flagpreset"))
@@ -100,33 +91,6 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 			return structclierrors.NewInvalidTagUsageError(fieldName, "flagshort", "flagshort cannot be used on struct types")
 		}
 
-		// Validate flagcustom tag
-		flagCustomValue, flagCustomErr := IsValidBoolTag(fieldName, "flagcustom", structF.Tag.Get("flagcustom"))
-		if flagCustomErr != nil {
-			return flagCustomErr
-		}
-
-		// Ensure that flagcustom is given to non-struct types
-		if flagCustomValue != nil && *flagCustomValue && isStructKind {
-			return structclierrors.NewInvalidTagUsageError(fieldName, "flagcustom", "flagcustom cannot be used on struct types")
-		}
-
-		// Reject flagcustom + flagenv:"only" before validating hooks (avoids confusing hook errors)
-		if flagCustomValue != nil && *flagCustomValue && internalenv.IsEnvOnly(structF) && !isStructKind {
-			return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagcustom"}, "flagcustom cannot be used with flagenv='only'")
-		}
-
-		// Validate the define and decode hooks when flagcustom is true
-		if flagCustomValue != nil && *flagCustomValue && !isStructKind {
-			// Map current field name to its custom type
-			if !internaltag.IsStandardType(structF.Type) {
-				typeToFields[structF.Type] = append(typeToFields[structF.Type], fieldName)
-			}
-			if err := validateCustomFlag(val, methodFieldName, structF.Type.String()); err != nil {
-				return err
-			}
-		}
-
 		// Validate flagenv tag (can be on struct fields for inheritance)
 		flagEnvValue := structF.Tag.Get("flagenv")
 		flagEnvOnly := internalenv.IsEnvOnly(structF)
@@ -145,9 +109,6 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 			if structF.Tag.Get("flagtype") != "" {
 				return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagtype"}, "flagtype cannot be used with flagenv='only'")
 			}
-			if flagCustomValue != nil && *flagCustomValue {
-				return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagcustom"}, "flagcustom cannot be used with flagenv='only'")
-			}
 		}
 
 		// Validate flagignore tag
@@ -165,11 +126,6 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 		}
 		if flagEnvOnly && flagIgnoreValue != nil && *flagIgnoreValue {
 			return structclierrors.NewConflictingTagsError(fieldName, []string{"flagenv", "flagignore"}, "mutually exclusive tags")
-		}
-		if !isStructKind && !(flagIgnoreValue != nil && *flagIgnoreValue) {
-			if err := validateCompletionHook(val, methodFieldName); err != nil {
-				return err
-			}
 		}
 
 		// Validate flagrequired tag
@@ -236,7 +192,7 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 
 		// Recursively validate children structs
 		if isStructKind {
-			if err := Fields(field, fieldName, typeToFields, s); err != nil {
+			if err := Fields(field, fieldName, s); err != nil {
 				return err
 			}
 		}
@@ -245,148 +201,4 @@ func Fields(val reflect.Value, prefix string, typeToFields map[reflect.Type][]st
 	return nil
 }
 
-func validateDefineHookSignature(m reflect.Value) error {
-	expectedType := reflect.TypeOf((*internalhooks.DefineHookFunc)(nil)).Elem()
-	actualType := m.Type()
 
-	if actualType.NumIn() != expectedType.NumIn() || actualType.NumOut() != expectedType.NumOut() {
-		var fx internalhooks.DefineHookFunc
-
-		return fmt.Errorf("define hook must have signature: %s", internalreflect.Signature(fx))
-	}
-
-	// Check input types
-	for i := range actualType.NumIn() {
-		if actualType.In(i) != expectedType.In(i) {
-			return fmt.Errorf("define hook parameter %d has wrong type: expected %v, got %v", i, expectedType.In(i), actualType.In(i))
-		}
-	}
-
-	// Check return types
-	pflagValueType := reflect.TypeOf((*pflag.Value)(nil)).Elem()
-	if !actualType.Out(0).Implements(pflagValueType) {
-		return fmt.Errorf("define hook first return value must be a pflag.Value")
-	}
-	if actualType.Out(1).Kind() != reflect.String {
-		return fmt.Errorf("define hook second return value must be a string")
-	}
-
-	return nil
-}
-
-func validateDecodeHookSignature(m reflect.Value) error {
-	expectedType := reflect.TypeOf((*internalhooks.DecodeHookFunc)(nil)).Elem()
-	actualType := m.Type()
-
-	if actualType.NumIn() != expectedType.NumIn() || actualType.NumOut() != expectedType.NumOut() {
-		var fx internalhooks.DecodeHookFunc
-
-		return fmt.Errorf("decode hook must have signature: %s", internalreflect.Signature(fx))
-	}
-
-	if actualType.In(0) != expectedType.In(0) {
-		return fmt.Errorf("decode hook input parameter has wrong type: expected %v, got %v", expectedType.In(0), actualType.In(0))
-	}
-
-	if actualType.Out(0) != expectedType.Out(0) ||
-		actualType.Out(1) != expectedType.Out(1) {
-		return fmt.Errorf("decode hook must return (any, error)")
-	}
-
-	return nil
-}
-
-func validateCompleteHookSignature(m reflect.Value) error {
-	expectedType := reflect.TypeOf((*internalhooks.CompleteHookFunc)(nil)).Elem()
-	actualType := m.Type()
-
-	if actualType.NumIn() != expectedType.NumIn() || actualType.NumOut() != expectedType.NumOut() {
-		var fx internalhooks.CompleteHookFunc
-
-		return fmt.Errorf("complete hook must have signature: %s", internalreflect.Signature(fx))
-	}
-
-	for i := range actualType.NumIn() {
-		if actualType.In(i) != expectedType.In(i) {
-			return fmt.Errorf("complete hook parameter %d has wrong type: expected %v, got %v", i, expectedType.In(i), actualType.In(i))
-		}
-	}
-
-	for i := range actualType.NumOut() {
-		if actualType.Out(i) != expectedType.Out(i) {
-			return fmt.Errorf("complete hook return value %d has wrong type: expected %v, got %v", i, expectedType.Out(i), actualType.Out(i))
-		}
-	}
-
-	return nil
-}
-
-// validateCustomFlag validates that a custom flag has proper define and decode mechanisms
-func validateCustomFlag(structValue reflect.Value, fieldName, fieldType string) error {
-	// Get pointer to struct to access methods
-	structPtr := internalreflect.GetStructPtr(structValue)
-	if !structPtr.IsValid() {
-		return fmt.Errorf("cannot get pointer to struct for field '%s'", fieldName)
-	}
-
-	// Check if struct has Define<FieldName> method
-	defineMethodName := fmt.Sprintf("Define%s", fieldName)
-	defineHookFunc := structPtr.MethodByName(defineMethodName)
-
-	// Check if struct has Decode<FieldName> method
-	decodeMethodName := fmt.Sprintf("Decode%s", fieldName)
-	decodeHookFunc := structPtr.MethodByName(decodeMethodName)
-
-	// Case 1: User has defined custom methods
-	if defineHookFunc.IsValid() {
-		// Must have corresponding decode method
-		if !decodeHookFunc.IsValid() {
-			return structclierrors.NewMissingDecodeHookError(fieldName, decodeMethodName)
-		}
-
-		// Validate signatures
-		if err := validateDefineHookSignature(defineHookFunc); err != nil {
-			return structclierrors.NewInvalidDefineHookSignatureError(fieldName, defineMethodName, err)
-		}
-		if err := validateDecodeHookSignature(decodeHookFunc); err != nil {
-			return structclierrors.NewInvalidDecodeHookSignatureError(fieldName, decodeMethodName, err)
-		}
-
-		return nil
-	}
-
-	// Check registries
-	_, inDefineRegistry := internalhooks.DefineHookRegistry[fieldType]
-	_, inDecodeRegistry := internalhooks.DecodeHookRegistry[fieldType]
-
-	// Case 2: Check registry
-	if inDefineRegistry {
-		if !inDecodeRegistry {
-			return fmt.Errorf("internal error: missing decode hook for built-in type %s", fieldType)
-		}
-
-		return nil
-	}
-
-	// Case 3: No define mechanism found
-	return structclierrors.NewMissingDefineHookError(fieldName, defineMethodName)
-}
-
-func validateCompletionHook(structValue reflect.Value, fieldName string) error {
-	structPtr := internalreflect.GetStructPtr(structValue)
-	if !structPtr.IsValid() {
-		return fmt.Errorf("cannot get pointer to struct for field '%s'", fieldName)
-	}
-
-	methodName := fmt.Sprintf("Complete%s", fieldName)
-	completeHookFunc := structPtr.MethodByName(methodName)
-	if !completeHookFunc.IsValid() {
-		return nil
-	}
-
-	if err := validateCompleteHookSignature(completeHookFunc); err != nil {
-		return structclierrors.NewInvalidCompleteHookSignatureError(fieldName, methodName, err)
-	}
-
-	return nil
-}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -2,17 +2,13 @@ package internalvalidation
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 
 	structclierrors "github.com/leodido/structcli/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type validationCustomType string
 
 type invalidShorthandOpts struct {
 	Name string `flagshort:"ab"`
@@ -58,99 +54,6 @@ type presetDuplicateAcrossFieldsOpts struct {
 	B int `flagpreset:"logeverything=4"`
 }
 
-type customMissingDefineOpts struct {
-	Mode validationCustomType `flagcustom:"true"`
-}
-
-type customMissingDecodeOpts struct {
-	Mode validationCustomType `flagcustom:"true"`
-}
-
-func (o *customMissingDecodeOpts) DefineMode(name, short, descr string, _ reflect.StructField, _ reflect.Value) (pflag.Value, string) {
-	return nil, descr
-}
-
-type customInvalidDefineSigOpts struct {
-	Mode validationCustomType `flagcustom:"true"`
-}
-
-func (o *customInvalidDefineSigOpts) DefineMode(_ int, short, descr string, _ reflect.StructField, _ reflect.Value) (pflag.Value, string) {
-	return nil, descr
-}
-
-func (o *customInvalidDefineSigOpts) DecodeMode(input any) (any, error) {
-	return input, nil
-}
-
-type customInvalidDecodeSigOpts struct {
-	Mode validationCustomType `flagcustom:"true"`
-}
-
-func (o *customInvalidDecodeSigOpts) DefineMode(name, short, descr string, _ reflect.StructField, _ reflect.Value) (pflag.Value, string) {
-	return nil, descr
-}
-
-func (o *customInvalidDecodeSigOpts) DecodeMode(_ string) string {
-	return ""
-}
-
-type customValidOpts struct {
-	Mode validationCustomType `flagcustom:"true"`
-}
-
-func (o *customValidOpts) DefineMode(name, short, descr string, _ reflect.StructField, _ reflect.Value) (pflag.Value, string) {
-	return nil, descr
-}
-
-func (o *customValidOpts) DecodeMode(input any) (any, error) {
-	return input, nil
-}
-
-type customConflictingTypeOpts struct {
-	Mode1 validationCustomType `flagcustom:"true"`
-	Mode2 validationCustomType `flagcustom:"true"`
-}
-
-func (o *customConflictingTypeOpts) DefineMode1(name, short, descr string, _ reflect.StructField, _ reflect.Value) (pflag.Value, string) {
-	return nil, descr
-}
-
-func (o *customConflictingTypeOpts) DecodeMode1(input any) (any, error) {
-	return input, nil
-}
-
-func (o *customConflictingTypeOpts) DefineMode2(name, short, descr string, _ reflect.StructField, _ reflect.Value) (pflag.Value, string) {
-	return nil, descr
-}
-
-func (o *customConflictingTypeOpts) DecodeMode2(input any) (any, error) {
-	return input, nil
-}
-
-type invalidCompleteSigOpts struct {
-	Mode string `flag:"mode"`
-}
-
-func (o *invalidCompleteSigOpts) CompleteMode(_ string) []string {
-	return []string{"dev"}
-}
-
-type validCompleteSigOpts struct {
-	Mode string `flag:"mode"`
-}
-
-func (o *validCompleteSigOpts) CompleteMode(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"dev", "prod"}, cobra.ShellCompDirectiveNoFileComp
-}
-
-type ignoredInvalidCompleteSigOpts struct {
-	Hidden string `flag:"hidden" flagignore:"true"`
-}
-
-func (o *ignoredInvalidCompleteSigOpts) CompleteHidden(_ string) []string {
-	return []string{"ignored"}
-}
-
 func TestIsValidBoolTag(t *testing.T) {
 	val, err := IsValidBoolTag("X", "flagenv", "")
 	require.NoError(t, err)
@@ -184,12 +87,6 @@ func TestStructValidationErrors(t *testing.T) {
 		{name: "preset with ignore", opts: &presetWithIgnoreOpts{}, err: structclierrors.ErrInvalidTagUsage},
 		{name: "preset duplicate with flag", opts: &presetDuplicateWithFlagOpts{}, err: structclierrors.ErrDuplicateFlag},
 		{name: "preset duplicate across fields", opts: &presetDuplicateAcrossFieldsOpts{}, err: structclierrors.ErrDuplicateFlag},
-		{name: "missing define hook", opts: &customMissingDefineOpts{}, err: structclierrors.ErrMissingDefineHook},
-		{name: "missing decode hook", opts: &customMissingDecodeOpts{}, err: structclierrors.ErrMissingDecodeHook},
-		{name: "invalid define signature", opts: &customInvalidDefineSigOpts{}, err: structclierrors.ErrInvalidDefineHookSignature},
-		{name: "invalid decode signature", opts: &customInvalidDecodeSigOpts{}, err: structclierrors.ErrInvalidDecodeHookSignature},
-		{name: "invalid completion signature", opts: &invalidCompleteSigOpts{}, err: structclierrors.ErrInvalidCompleteHookSignature},
-		{name: "conflicting custom type", opts: &customConflictingTypeOpts{}, err: structclierrors.ErrConflictingType},
 	}
 
 	for _, tt := range cases {
@@ -201,10 +98,12 @@ func TestStructValidationErrors(t *testing.T) {
 	}
 }
 
+type simpleValidOpts struct {
+	Name string `flag:"name"`
+}
+
 func TestStructValidationSuccess(t *testing.T) {
-	require.NoError(t, Struct(&cobra.Command{Use: "app-1"}, &customValidOpts{}))
-	require.NoError(t, Struct(&cobra.Command{Use: "app-2"}, &validCompleteSigOpts{}))
-	require.NoError(t, Struct(&cobra.Command{Use: "app-3"}, &ignoredInvalidCompleteSigOpts{}))
+	require.NoError(t, Struct(&cobra.Command{Use: "app-1"}, &simpleValidOpts{}))
 }
 
 func TestStructValidationNilInput(t *testing.T) {

--- a/register.go
+++ b/register.go
@@ -28,7 +28,8 @@ type TypeHooks[T any] struct {
 // Panics if T is already registered (duplicate or conflict with a built-in).
 // Panics if Define is nil. Panics if Decode is nil.
 func RegisterType[T any](hooks TypeHooks[T]) {
-	typeName := reflect.TypeFor[T]().String()
+	typ := reflect.TypeFor[T]()
+	typeName := typ.String()
 
 	if hooks.Define == nil {
 		panic(fmt.Sprintf("structcli: RegisterType[%s]: Define hook must not be nil", typeName))
@@ -37,11 +38,11 @@ func RegisterType[T any](hooks TypeHooks[T]) {
 		panic(fmt.Sprintf("structcli: RegisterType[%s]: Decode hook must not be nil", typeName))
 	}
 
-	if _, exists := internalhooks.DefineHookRegistry[typeName]; exists {
+	if _, exists := internalhooks.DefineHookRegistry[typ]; exists {
 		panic(fmt.Sprintf("structcli: RegisterType[%s]: type is already registered", typeName))
 	}
 
-	internalhooks.DefineHookRegistry[typeName] = hooks.Define
+	internalhooks.DefineHookRegistry[typ] = hooks.Define
 
-	internalhooks.RegisterUserDecodeHook(typeName, hooks.Decode)
+	internalhooks.RegisterUserDecodeHook(typ, hooks.Decode)
 }

--- a/register_test.go
+++ b/register_test.go
@@ -13,10 +13,11 @@ import (
 type testCustomType struct{ val string }
 
 func TestRegisterType_Success(t *testing.T) {
+	typ := reflect.TypeFor[testCustomType]()
 	snap := internalhooks.SnapshotDecodeRegistries()
 	defer func() {
 		internalhooks.RestoreDecodeRegistries(snap)
-		delete(internalhooks.DefineHookRegistry, reflect.TypeFor[testCustomType]().String())
+		delete(internalhooks.DefineHookRegistry, typ)
 	}()
 
 	RegisterType(TypeHooks[testCustomType]{
@@ -28,15 +29,13 @@ func TestRegisterType_Success(t *testing.T) {
 		},
 	})
 
-	typeName := reflect.TypeFor[testCustomType]().String()
-
 	// Verify define hook registered
-	defineHook, ok := internalhooks.DefineHookRegistry[typeName]
+	defineHook, ok := internalhooks.DefineHookRegistry[typ]
 	require.True(t, ok, "define hook should be registered")
 	assert.NotNil(t, defineHook)
 
 	// Verify decode hook registered
-	_, ok = internalhooks.DecodeHookRegistry[typeName]
+	_, ok = internalhooks.DecodeHookRegistry[typ]
 	assert.True(t, ok, "decode hook should be registered")
 }
 
@@ -67,10 +66,11 @@ func TestRegisterType_PanicsOnNilDecode(t *testing.T) {
 }
 
 func TestRegisterType_PanicsOnDuplicate(t *testing.T) {
+	typ := reflect.TypeFor[testCustomType]()
 	snap := internalhooks.SnapshotDecodeRegistries()
 	defer func() {
 		internalhooks.RestoreDecodeRegistries(snap)
-		delete(internalhooks.DefineHookRegistry, reflect.TypeFor[testCustomType]().String())
+		delete(internalhooks.DefineHookRegistry, typ)
 	}()
 
 	hooks := TypeHooks[testCustomType]{


### PR DESCRIPTION
## Description

The switchover commit. Wires the new APIs from #156 into the `define.go` field loop and removes all `MethodByName`/`reflect.Value.Call` dispatch from production code.

### Breaking changes

- **`flagcustom:"true"` tag removed** — detected at define time with a migration error pointing to `RegisterType`/`FieldHookProvider`
- **`Define<Field>`/`Decode<Field>`/`Complete<Field>` convention methods removed** — use `FieldHookProvider.FieldHooks()` and `FieldCompleter.CompletionHooks()` instead
- **`StoreDecodeHookFunc` and `StoreCompletionHookFunc` removed** (reflect.Value versions) — replaced by `*Direct` variants in #156
- **6 error types removed**: `MissingDefineHookError`, `MissingDecodeHookError`, `InvalidDefineHookSignatureError`, `InvalidDecodeHookSignatureError`, `InvalidCompleteHookSignatureError`, `ConflictingTypeError`
- **3 error sentinels removed**: `ErrMissingDefineHook`, `ErrMissingDecodeHook`, `ErrConflictingType`

### Hook resolution precedence

1. `FieldHookProvider` — per-field hooks on the options struct
2. `RegisterType` / `RegisterEnum` — per-type hooks in the global registry
3. Built-in registry — `time.Duration`, `zapcore.Level`, `slog.Level`, etc.

### Validation improvements

- Unknown `FieldHookProvider` keys that don't match any struct field produce an error (catches typos)
- Unknown `FieldCompleter` keys that don't match any struct field produce an error
- `FieldHook{Decode: fn}` without `Define` is rejected (was a silent no-op)
- `FieldCompleter` hooks are skipped for `flagenv:"only"` fields (hidden flags have no CLI completion)
- Lint check for `flaghidden+flagenv` now checks `fh.Define != nil`, not just map membership

### Registry key safety

- `DefineHookRegistry` and `DecodeHookRegistry` now use `reflect.Type` keys instead of `reflect.Type.String()` to prevent type name collisions
- Decode hook wrappers (`RegisterUserDecodeHook`, `StringToNamedBytesHookFunc`) match by `reflect.Type` equality instead of string comparison
- `Hex`/`Base64` define+decode hooks registered from `structcli` package init (`bytes.go`) since `internal/hooks` cannot import `structcli` types

### Result

- Zero `MethodByName` in production code (1 comment only)
- Zero `reflect.Value.Call` in production code
- Zero `flagcustom` in any Go file
- Net -1640 lines

## Related Issue(s)

Stacks on #156

## How to test

```
go test ./... -count=1 -race
```