### PR TITLE
refactor!: remove `short` from `DefineHookFunc` signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ type ListenAddress struct {
 
 func init() {
     structcli.RegisterType[ListenAddress](structcli.TypeHooks[ListenAddress]{
-        Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+        Define: func(name, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
             ptr := fv.Addr().Interface().(*ListenAddress)
             *ptr = ListenAddress{Host: "localhost", Port: 8080, raw: "localhost:8080"}
 
@@ -691,7 +691,7 @@ type ServerOptions struct {
 func (o *ServerOptions) FieldHooks() map[string]structcli.FieldHook {
     return map[string]structcli.FieldHook{
         "ListenAddr": {
-            Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+            Define: func(name, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
                 ptr := fv.Addr().Interface().(*string)
                 *ptr = "localhost:8080"
 

--- a/define.go
+++ b/define.go
@@ -445,7 +445,7 @@ func define(c *cobra.Command, o any, startingGroup string, structPath string, ex
 		// Per-field hooks from FieldHookProvider take highest precedence.
 		if fh, ok := fieldHooks[f.Name]; ok && kind != reflect.Struct {
 			if fh.Define != nil {
-				returnedValue, returnedUsage := fh.Define(name, short, descr, f, field)
+				returnedValue, returnedUsage := fh.Define(name, descr, f, field)
 				c.Flags().VarP(returnedValue, name, short, returnedUsage)
 
 				if fh.Decode != nil {

--- a/define_test.go
+++ b/define_test.go
@@ -278,7 +278,7 @@ type gotoCustomHookOptions struct {
 func (o *gotoCustomHookOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"Mode": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = "dev"
 
@@ -448,7 +448,7 @@ type comprehensiveCustomOptions struct {
 func (o *comprehensiveCustomOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"ServerMode": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				enhancedDesc := descr + fmt.Sprintf(" (%s,%s,%s)", string(development), string(staging), string(production))
 				fieldPtr := fieldValue.Addr().Interface().(*serverMode)
 				*fieldPtr = development // Set default
@@ -462,7 +462,7 @@ func (o *comprehensiveCustomOptions) FieldHooks() map[string]FieldHook {
 			},
 		},
 		"SomeConfig": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				enhancedDesc := descr + " (must be .yaml, .yml, or .json)"
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = "" // default
@@ -1399,7 +1399,7 @@ type flagEnvCombinedOptions struct {
 func (o *flagEnvCombinedOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"EnvWithCustom": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = "CUSTOM_DEFAULT"
 
@@ -1410,7 +1410,7 @@ func (o *flagEnvCombinedOptions) FieldHooks() map[string]FieldHook {
 			},
 		},
 		"InvalidEnvValid": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = "INVALID"
 
@@ -1448,7 +1448,7 @@ type validFlagEnvInteractionOptions struct {
 func (o *validFlagEnvInteractionOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"EnvWithCustom": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = "custom"
 
@@ -1717,7 +1717,7 @@ type flagIgnoreCombinedOptions struct {
 func (o *flagIgnoreCombinedOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"IgnoreWithCustom": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = "CUSTOM_DEFAULT"
 
@@ -1755,7 +1755,7 @@ type validFlagIgnoreInteractionOptions struct {
 func (o *validFlagIgnoreInteractionOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"IgnoreWithCustom": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				// This hook should NOT be called if flagignore:"true" is respected.
 				panic("FieldHooks[IgnoreWithCustom].Define should not have been called!")
 			},
@@ -3073,7 +3073,7 @@ func (o *enumCustomDefineHookOptions) Attach(c *cobra.Command) error { return ni
 func (o *enumCustomDefineHookOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"ServerMode": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				enhancedDesc := descr + fmt.Sprintf(" {%s,%s,%s}", string(development), string(staging), string(production))
 				fieldPtr := fieldValue.Addr().Interface().(*serverMode)
 				*fieldPtr = development
@@ -3125,7 +3125,7 @@ func (o enumValuerHookOptions) Attach(c *cobra.Command) error { return nil }
 func (o *enumValuerHookOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"Priority": {
-			Define: func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				ref := fieldValue.Addr().Interface().(*string)
 				// Return a pflag.Value that implements EnumValuer with [alpha, beta, gamma]
 				// but the description says {x,y,z}
@@ -3316,7 +3316,7 @@ type flagCustomWithValidateOptions struct {
 func (o *flagCustomWithValidateOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"Token": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = ""
 
@@ -3480,7 +3480,7 @@ type unknownFieldHookOptions struct {
 func (o *unknownFieldHookOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"Bogus": {
-			Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
 				return values.NewString(fv.Addr().Interface().(*string)), descr
 			},
 			Decode: func(input any) (any, error) { return input, nil },

--- a/examples/customtypes/main.go
+++ b/examples/customtypes/main.go
@@ -77,7 +77,7 @@ func init() {
 	// After this, any struct field of type HostPort works automatically.
 	// RegisterType panics if Define is nil, Decode is nil, or the type was already registered.
 	structcli.RegisterType(structcli.TypeHooks[HostPort]{
-		Define: func(name, short, descr string, _ reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+		Define: func(name, descr string, _ reflect.StructField, fv reflect.Value) (pflag.Value, string) {
 			ref := fv.Addr().Interface().(*HostPort)
 			*ref = HostPort{Host: "localhost", Port: 8080} // default
 
@@ -121,7 +121,7 @@ var validModes = []string{"development", "staging", "production"}
 func (o *ServerOptions) FieldHooks() map[string]structcli.FieldHook {
 	return map[string]structcli.FieldHook{
 		"Mode": {
-			Define: func(name, short, descr string, _ reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, _ reflect.StructField, fv reflect.Value) (pflag.Value, string) {
 				ref := fv.Addr().Interface().(*string)
 				*ref = "development"
 

--- a/flaghidden_test.go
+++ b/flaghidden_test.go
@@ -95,7 +95,7 @@ type hiddenCustomOptions struct {
 func (o *hiddenCustomOptions) FieldHooks() map[string]FieldHook {
 	return map[string]FieldHook{
 		"Mode": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*string)
 				*fieldPtr = "default"
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -2233,7 +2233,7 @@ type customDecodeHookOptions struct {
 func (o *customDecodeHookOptions) FieldHooks() map[string]structcli.FieldHook {
 	return map[string]structcli.FieldHook{
 		"ServerMode": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				enhancedDesc := descr + " (development, staging, production)"
 				fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
 				*fieldPtr = DevMode1
@@ -2273,7 +2273,7 @@ type mixedHooksOptions struct {
 func (m *mixedHooksOptions) FieldHooks() map[string]structcli.FieldHook {
 	return map[string]structcli.FieldHook{
 		"ServerMode": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
 				*fieldPtr = DevMode1
 
@@ -2304,7 +2304,7 @@ type multiCustomOptions struct {
 func (m *multiCustomOptions) FieldHooks() map[string]structcli.FieldHook {
 	return map[string]structcli.FieldHook{
 		"Mode1": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				enhancedDesc := descr + " (first custom mode)"
 				fieldPtr := fieldValue.Addr().Interface().(*ServerMode1)
 				*fieldPtr = DevMode1
@@ -2328,7 +2328,7 @@ func (m *multiCustomOptions) FieldHooks() map[string]structcli.FieldHook {
 			},
 		},
 		"Mode2": {
-			Define: func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+			Define: func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 				enhancedDesc := descr + " (second custom mode)"
 				fieldPtr := fieldValue.Addr().Interface().(*ServerMode2)
 				*fieldPtr = StagingMode2

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -21,8 +21,8 @@ import (
 // that knows how to set the underlying field's value, along with an optional enhanced
 // description for the flag's usage message.
 //
-// The short flag name is not passed here — the caller registers the returned
-// pflag.Value with the appropriate short name via VarP.
+// The short flag name is not passed here.
+// The caller registers the returned pflag.Value with the appropriate short name via VarP.
 type DefineHookFunc func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string)
 
 // DefineHookRegistry keeps track of the built-in flag definition functions.

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -15,14 +15,15 @@ import (
 	"github.com/thediveo/enumflag/v2"
 )
 
-// FIXME: remove short from the signature?
-
 // DefineHookFunc defines how to create a flag for a custom type.
 //
 // It receives flag metadata and struct field information and must return a pflag.Value
 // that knows how to set the underlying field's value, along with an optional enhanced
 // description for the flag's usage message.
-type DefineHookFunc func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string)
+//
+// The short flag name is not passed here — the caller registers the returned
+// pflag.Value with the appropriate short name via VarP.
+type DefineHookFunc func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string)
 
 // DefineHookRegistry keeps track of the built-in flag definition functions.
 // Keyed by reflect.Type for collision-safe lookups.
@@ -51,7 +52,7 @@ var defineHookRegistryByName = map[string]DefineHookFunc{}
 var byteSliceType = reflect.TypeOf([]byte(nil))
 
 func defineByteSliceValueHookFunc(newValue func(val []byte, ref *[]byte) pflag.Value) DefineHookFunc {
-	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Convert(byteSliceType).Interface().([]byte)
 		// The field may be a named type (e.g. structcli.Hex) so Addr().Interface()
 		// would yield *Hex, not *[]byte. Use reflect.NewAt to reinterpret the
@@ -63,11 +64,11 @@ func defineByteSliceValueHookFunc(newValue func(val []byte, ref *[]byte) pflag.V
 }
 
 func defineFlagSetValueHookFunc[T any](register func(fs *pflag.FlagSet, ref *T, name, short string, val T, usage string)) DefineHookFunc {
-	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(T)
 		ref := fieldValue.Addr().Interface().(*T)
 		fs := pflag.NewFlagSet(name, pflag.ContinueOnError)
-		register(fs, ref, name, short, val, descr)
+		register(fs, ref, name, "", val, descr)
 
 		return fs.Lookup(name).Value, descr
 	}
@@ -128,7 +129,7 @@ func DefineBase64BytesHookFunc() DefineHookFunc {
 }
 
 func DefineIPHookFunc() DefineHookFunc {
-	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(net.IP)
 		ref := fieldValue.Addr().Interface().(*net.IP)
 
@@ -137,7 +138,7 @@ func DefineIPHookFunc() DefineHookFunc {
 }
 
 func DefineIPMaskHookFunc() DefineHookFunc {
-	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(net.IPMask)
 		ref := fieldValue.Addr().Interface().(*net.IPMask)
 
@@ -146,7 +147,7 @@ func DefineIPMaskHookFunc() DefineHookFunc {
 }
 
 func DefineIPNetHookFunc() DefineHookFunc {
-	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(net.IPNet)
 		ref := fieldValue.Addr().Interface().(*net.IPNet)
 
@@ -155,7 +156,7 @@ func DefineIPNetHookFunc() DefineHookFunc {
 }
 
 func DefineIPSliceHookFunc() DefineHookFunc {
-	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().([]net.IP)
 		ref := fieldValue.Addr().Interface().(*[]net.IP)
 
@@ -164,7 +165,7 @@ func DefineIPSliceHookFunc() DefineHookFunc {
 }
 
 func DefineTimeDurationHookFunc() DefineHookFunc {
-	return func(name, short, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Interface().(time.Duration)
 		ref := fieldValue.Addr().Interface().(*time.Duration)
 
@@ -194,7 +195,7 @@ func enumHelpText[L ~int | ~int8 | ~int16 | ~int32 | ~int64](levels map[L][]stri
 //
 // It returns an enum flag that implements pflag.Value.
 func DefineSlogLevelHookFunc() DefineHookFunc {
-	return func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		logLevels := map[slog.Level][]string{
 			slog.LevelDebug: {"debug"},
 			slog.LevelInfo:  {"info"},
@@ -214,7 +215,7 @@ func DefineSlogLevelHookFunc() DefineHookFunc {
 // DefineIntEnumHookFunc creates a DefineHookFunc for a registered integer-based enum.
 // It wraps enumflag/v2 and attaches EnumValuer metadata via WrapWithEnumValues.
 func DefineIntEnumHookFunc[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map[E][]string) DefineHookFunc {
-	return func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		fieldPtr := fieldValue.Addr().Interface().(*E)
 		enumFlag := enumflag.New(fieldPtr, structField.Type.String(), values, enumflag.EnumCaseInsensitive)
 		enumValues, enhancedDescr := enumHelpText(values, descr)
@@ -227,7 +228,7 @@ func DefineIntEnumHookFunc[E ~int | ~int8 | ~int16 | ~int32 | ~int64](values map
 // The returned hook creates an enumStringValue that validates on Set() and
 // appends "{val1,val2,...}" to the flag description.
 func DefineStringEnumHookFunc[E ~string](values map[E][]string) DefineHookFunc {
-	return func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
+	return func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		target := fieldValue.Addr().Interface().(*E)
 		ev := structclivalues.NewEnumString(target, values)
 		enhancedDescr := descr + fmt.Sprintf(" {%s}", strings.Join(ev.EnumValues(), ","))
@@ -241,14 +242,14 @@ func DefineStringEnumHookFunc[E ~string](values map[E][]string) DefineHookFunc {
 // registry for types that cannot be referenced by reflect.TypeFor from this package.
 func InferDefineHooks(c *cobra.Command, name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) bool {
 	if defineFunc, ok := DefineHookRegistry[structField.Type]; ok {
-		value, usage := defineFunc(name, short, descr, structField, fieldValue)
+		value, usage := defineFunc(name, descr, structField, fieldValue)
 		c.Flags().VarP(value, name, short, usage)
 
 		return true
 	}
 
 	if defineFunc, ok := defineHookRegistryByName[structField.Type.String()]; ok {
-		value, usage := defineFunc(name, short, descr, structField, fieldValue)
+		value, usage := defineFunc(name, descr, structField, fieldValue)
 		c.Flags().VarP(value, name, short, usage)
 
 		return true

--- a/internal/hooks/define_internal_test.go
+++ b/internal/hooks/define_internal_test.go
@@ -63,7 +63,7 @@ func TestDefineStringEnumHookFunc_CreatesFlag(t *testing.T) {
 	sf := reflect.StructField{Name: "Color", Type: reflect.TypeFor[testColor]()}
 	fv := reflect.ValueOf(&target).Elem()
 
-	pflagVal, usage := hook("color", "c", "pick a color", sf, fv)
+	pflagVal, usage := hook("color", "pick a color", sf, fv)
 
 	require.NotNil(t, pflagVal)
 	assert.Contains(t, usage, "{blue,green,red}")
@@ -87,7 +87,7 @@ func TestDefineStringEnumHookFunc_EnumValues(t *testing.T) {
 	sf := reflect.StructField{Name: "Color", Type: reflect.TypeFor[testColor]()}
 	fv := reflect.ValueOf(&target).Elem()
 
-	pflagVal, _ := hook("color", "", "color", sf, fv)
+	pflagVal, _ := hook("color", "color", sf, fv)
 
 	type enumValuer interface {
 		EnumValues() []string
@@ -118,7 +118,7 @@ func TestDefineIntEnumHookFunc_CreatesFlag(t *testing.T) {
 	sf := reflect.StructField{Name: "Severity", Type: reflect.TypeFor[testSeverity]()}
 	fv := reflect.ValueOf(&target).Elem()
 
-	pflagVal, usage := hook("severity", "", "task severity", sf, fv)
+	pflagVal, usage := hook("severity", "task severity", sf, fv)
 
 	require.NotNil(t, pflagVal)
 	assert.Contains(t, usage, "{low,medium,high}")
@@ -144,7 +144,7 @@ func TestDefineIntEnumHookFunc_EnumValues(t *testing.T) {
 	sf := reflect.StructField{Name: "Severity", Type: reflect.TypeFor[testSeverity]()}
 	fv := reflect.ValueOf(&target).Elem()
 
-	pflagVal, _ := hook("severity", "", "severity", sf, fv)
+	pflagVal, _ := hook("severity", "severity", sf, fv)
 
 	type enumValuerIface interface {
 		EnumValues() []string

--- a/register_test.go
+++ b/register_test.go
@@ -21,7 +21,7 @@ func TestRegisterType_Success(t *testing.T) {
 	}()
 
 	RegisterType(TypeHooks[testCustomType]{
-		Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+		Define: func(name, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
 			return nil, descr
 		},
 		Decode: func(input any) (any, error) {
@@ -56,7 +56,7 @@ func TestRegisterType_PanicsOnNilDecode(t *testing.T) {
 		"structcli: RegisterType[structcli.testCustomType]: Decode hook must not be nil",
 		func() {
 			RegisterType(TypeHooks[testCustomType]{
-				Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+				Define: func(name, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
 					return nil, descr
 				},
 				Decode: nil,
@@ -74,7 +74,7 @@ func TestRegisterType_PanicsOnDuplicate(t *testing.T) {
 	}()
 
 	hooks := TypeHooks[testCustomType]{
-		Define: func(name, short, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
+		Define: func(name, descr string, sf reflect.StructField, fv reflect.Value) (pflag.Value, string) {
 			return nil, descr
 		},
 		Decode: func(input any) (any, error) { return input, nil },


### PR DESCRIPTION
## Description

Remove the `short` parameter from `DefineHookFunc`. It was redundant — callers (`InferDefineHooks`, `define.go` FieldHookProvider path) already have `short` and pass it to `c.Flags().VarP(value, name, short, usage)` when registering the returned `pflag.Value`.

### Before

```go
type DefineHookFunc func(name, short, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string)
```

### After

```go
type DefineHookFunc func(name, descr string, structField reflect.StructField, fieldValue reflect.Value) (pflag.Value, string)
```

### Changes

- `DefineHookFunc` signature: removed `short` parameter
- `defineFlagSetValueHookFunc`: passes empty string for short to internal `pflag.FlagSet` (only the extracted `pflag.Value` matters)
- All 17 built-in hook functions updated
- All test hook functions updated
- README code examples updated
- `examples/customtypes` updated
- Removed the FIXME comment that requested this change

### Breaking change

Any code that implements `DefineHookFunc` (via `RegisterType[T]` or `FieldHookProvider`) needs to remove the `short` parameter from the function signature.

## How to test

```
go test ./... -count=1 -race
cd examples/customtypes && go test -v ./...
```