### PR TITLE
feat(ci): add WASM build and behavioral parity CI

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,36 @@
+name: wasm
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.0'
+
+      - name: probe wasmtime
+        run: |
+          echo "=== wasmtime ==="
+          which wasmtime && wasmtime --version || echo "wasmtime not found"
+          echo ""
+          echo "=== GOROOT wasm support ==="
+          ls -la "$(go env GOROOT)/lib/wasm/" 2>/dev/null || echo "no lib/wasm"
+          echo ""
+          echo "=== Go version ==="
+          go version
+          echo "GOROOT=$(go env GOROOT)"
+          echo ""
+          echo "=== WASM build smoke test ==="
+          GOOS=wasip1 GOARCH=wasm go build -o /dev/null ./examples/minimal/
+          echo "examples/minimal: WASM build OK"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -35,6 +35,7 @@ jobs:
           GONOSUMDB: github.com/leodido/structcli
           GONOSUMCHECK: github.com/leodido/structcli
         run: |
+          export PATH="$(go env GOROOT)/lib/wasm:$PATH"
           go test ./...
           (cd examples/collections && go test ./...)
           (cd examples/full && go test ./...)
@@ -81,7 +82,7 @@ jobs:
       - name: 'Parity: ${{ matrix.name }} ${{ matrix.args }}'
         run: |
           ./${{ matrix.name }} ${{ matrix.args }} > native.out 2>&1 || true
-          wasmtime ./${{ matrix.name }}.wasm -- ${{ matrix.args }} > wasm.out 2>&1 || true
+          wasmtime run --dir=/ --env PWD="$PWD" --env PATH="$PATH" ./${{ matrix.name }}.wasm -- ${{ matrix.args }} > wasm.out 2>&1 || true
           if [ -n "${{ matrix.filter }}" ]; then
             sed -i '${{ matrix.filter }}' native.out wasm.out
           fi

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  wasm-test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
@@ -42,7 +42,7 @@ jobs:
           (cd examples/loginsvc && go test ./...)
           (cd examples/customtypes && go test ./...)
 
-  wasm-parity:
+  parity:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,27 +10,33 @@ permissions:
   contents: read
 
 jobs:
-  probe:
+  wasm-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out the source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-go@v5
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: '~1.24.0'
+          check-latest: true
 
-      - name: probe wasmtime
+      - name: Set up wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
+        with:
+          version: '29.0.1'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests under WASM
+        env:
+          GOOS: wasip1
+          GOARCH: wasm
+          GONOSUMDB: github.com/leodido/structcli
+          GONOSUMCHECK: github.com/leodido/structcli
         run: |
-          echo "=== wasmtime ==="
-          which wasmtime && wasmtime --version || echo "wasmtime not found"
-          echo ""
-          echo "=== GOROOT wasm support ==="
-          ls -la "$(go env GOROOT)/lib/wasm/" 2>/dev/null || echo "no lib/wasm"
-          echo ""
-          echo "=== Go version ==="
-          go version
-          echo "GOROOT=$(go env GOROOT)"
-          echo ""
-          echo "=== WASM build smoke test ==="
-          GOOS=wasip1 GOARCH=wasm go build -o /dev/null ./examples/minimal/
-          echo "examples/minimal: WASM build OK"
+          go test ./...
+          (cd examples/collections && go test ./...)
+          (cd examples/full && go test ./...)
+          (cd examples/loginsvc && go test ./...)
+          (cd examples/customtypes && go test ./...)

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -82,7 +82,7 @@ jobs:
       - name: 'Parity: ${{ matrix.name }} ${{ matrix.args }}'
         run: |
           ./${{ matrix.name }} ${{ matrix.args }} > native.out 2>&1 || true
-          wasmtime run --dir=/ --env PWD="$PWD" --env PATH="$PATH" ./${{ matrix.name }}.wasm -- ${{ matrix.args }} > wasm.out 2>&1 || true
+          wasmtime run --dir=/ --env PWD="$PWD" --env PATH="$PATH" ./${{ matrix.name }}.wasm ${{ matrix.args }} > wasm.out 2>&1 || true
           if [ -n "${{ matrix.filter }}" ]; then
             sed -i '${{ matrix.filter }}' native.out wasm.out
           fi

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -40,3 +40,53 @@ jobs:
           (cd examples/full && go test ./...)
           (cd examples/loginsvc && go test ./...)
           (cd examples/customtypes && go test ./...)
+
+  wasm-parity:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # examples/minimal: root command with --loglevel and --port flags
+          - dir: examples/minimal
+            name: minimal
+            args: '--help'
+          - dir: examples/minimal
+            name: minimal
+            args: '--port 8080'
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: '~1.24.0'
+          check-latest: true
+
+      - name: Set up wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
+        with:
+          version: '29.0.1'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build native and WASM binaries
+        env:
+          GONOSUMDB: github.com/leodido/structcli
+          GONOSUMCHECK: github.com/leodido/structcli
+        run: |
+          go build -o ${{ matrix.name }} ./${{ matrix.dir }}/
+          GOOS=wasip1 GOARCH=wasm go build -o ${{ matrix.name }}.wasm ./${{ matrix.dir }}/
+
+      - name: 'Parity: ${{ matrix.name }} ${{ matrix.args }}'
+        run: |
+          ./${{ matrix.name }} ${{ matrix.args }} > native.out 2>&1 || true
+          wasmtime ./${{ matrix.name }}.wasm -- ${{ matrix.args }} > wasm.out 2>&1 || true
+          if [ -n "${{ matrix.filter }}" ]; then
+            sed -i '${{ matrix.filter }}' native.out wasm.out
+          fi
+          if ! diff -u native.out wasm.out; then
+            echo "FAIL: output differs for: ${{ matrix.name }} ${{ matrix.args }}"
+            exit 1
+          fi
+          echo "OK: native and WASM output match"


### PR DESCRIPTION
## Description

Add a CI workflow (`.github/workflows/wasm.yml`) that verifies structcli compiles and runs correctly under WASM (`GOOS=wasip1 GOARCH=wasm`).

### Jobs

**`wasm-test`** — Runs the full test suite under WASM via wasmtime. Covers the root module and all four example modules with tests (collections, full, loginsvc, customtypes). Uses Go's built-in `go_wasip1_wasm_exec` script to transparently execute WASM test binaries.

**`wasm-parity`** — Matrix-based behavioral comparison of native vs WASM binaries. Builds each example as both native and WASM, runs with identical arguments, and diffs stdout byte-for-byte. Currently covers `examples/minimal` with `--help` and `--port 8080`. Adding a new example or invocation is a single matrix `include` entry. Supports an optional per-invocation `sed` filter for non-deterministic output normalization.

### Details

- wasmtime v29.0.1 installed via `bytecodealliance/actions/wasmtime/setup` (pinned SHA)
- Action SHAs pinned to match `test.yml` conventions
- `GONOSUMDB`/`GONOSUMCHECK` set for the self-referencing module

### Context

The DCE refactor (#156–#159) removed `MethodByName` and `reflect.Value.Call` to enable WASM/TinyGo compatibility. This workflow prevents regressions.

## How to test

All three WASM jobs (`wasm-test`, `wasm-parity --help`, `wasm-parity --port 8080`) pass in this PR's CI.</p>
