### PR TITLE
refactor(hooks): remove unnecessary reflect complexity

### DIFF
--- a/internal/hooks/decode.go
+++ b/internal/hooks/decode.go
@@ -286,7 +286,7 @@ func StringToIntSliceHookFunc(sep string) mapstructure.DecodeHookFunc {
 		if f.Kind() != reflect.String {
 			return data, nil
 		}
-		if t != reflect.SliceOf(reflect.TypeOf(int(0))) {
+		if t != reflect.TypeFor[[]int]() {
 			return data, nil
 		}
 

--- a/internal/hooks/define.go
+++ b/internal/hooks/define.go
@@ -52,9 +52,9 @@ func defineByteSliceValueHookFunc(newValue func(val []byte, ref *[]byte) pflag.V
 	return func(name, descr string, _ reflect.StructField, fieldValue reflect.Value) (pflag.Value, string) {
 		val := fieldValue.Convert(byteSliceType).Interface().([]byte)
 		// The field may be a named type (e.g. structcli.Hex) so Addr().Interface()
-		// would yield *Hex, not *[]byte. Use reflect.NewAt to reinterpret the
-		// pointer as *[]byte, which is safe because the underlying type is []byte.
-		ref := reflect.NewAt(byteSliceType, fieldValue.Addr().UnsafePointer()).Interface().(*[]byte)
+		// would yield *Hex, not *[]byte. Cast via unsafe pointer instead, which
+		// is valid because the underlying type is []byte.
+		ref := (*[]byte)(fieldValue.Addr().UnsafePointer())
 
 		return newValue(val, ref), descr
 	}


### PR DESCRIPTION
## Description

Two targeted simplifications that remove unnecessary reflect machinery where the types are known at compile time.

**`internal/hooks/define.go`** — `defineByteSliceValueHookFunc`:
Replace `reflect.NewAt(byteSliceType, ...).Interface().(*[]byte)` with `(*[]byte)(fieldValue.Addr().UnsafePointer())`. The target type is always `*[]byte`, so the reflect round-trip through `NewAt` + type assertion is unnecessary.

**`internal/hooks/decode.go`** — `StringToIntSliceHookFunc`:
Replace `reflect.SliceOf(reflect.TypeOf(int(0)))` with `reflect.TypeFor[[]int]()`. Compile-time type resolution instead of runtime type construction.

Both changes are behavior-preserving. All tests pass, WASM compilation verified.

## How to test

```bash
go test ./internal/hooks/...
GOOS=wasip1 GOARCH=wasm go build ./...
```